### PR TITLE
App config

### DIFF
--- a/src/assets/icons/ic-checkbox-unselected.svg
+++ b/src/assets/icons/ic-checkbox-unselected.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <rect width="12" height="12" x="6" y="6" fill="none" fill-rule="evenodd" stroke="#767d84" stroke-width="1" rx="3"/>
+    <rect width="12" height="12" x="6" y="6" fill="none" fill-rule="evenodd" stroke="#767d84" stroke-width="1" rx="2"/>
 </svg>

--- a/src/assets/icons/ic-checkbox-unselected.svg
+++ b/src/assets/icons/ic-checkbox-unselected.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <rect width="12" height="12" x="6" y="6" fill="none" fill-rule="evenodd" stroke="#D2D2D2" stroke-width="2" rx="3"/>
+    <rect width="12" height="12" x="6" y="6" fill="none" fill-rule="evenodd" stroke="#767d84" stroke-width="1" rx="3"/>
 </svg>

--- a/src/components/chartRepo/ChartRepo.tsx
+++ b/src/components/chartRepo/ChartRepo.tsx
@@ -7,6 +7,8 @@ import { saveChartProviderConfig, updateChartProviderConfig } from './service'
 import { getChartRepoList } from '../../services/service'
 import { ReactComponent as Add } from '../../assets/icons/ic-add.svg';
 import { ReactComponent as Helm } from '../../assets/icons/ic-helmchart.svg';
+import { DOCUMENTATION } from '../../config';
+
 
 export default function ChartRepo() {
     const [loading, result, error, reload] = useAsync(getChartRepoList)
@@ -19,8 +21,8 @@ export default function ChartRepo() {
     return (
         <section className="global-configuration__component">
             <h2 className="form__title">Chart Repository</h2>
-            <h5 className="form__subtitle">Manage your organization’s chart repositories. &nbsp;
-                </h5>
+            <p className="form__subtitle">Manage your organization’s chart repositories.
+            <span><a rel="noreferrer noopener" target="_blank" className="learn-more__href" href={DOCUMENTATION.GLOBAL_CONFIG_GIT}> Learn more about Git Material</a> </span></p>
             {[{ id: null, default: true, url: "", name: "", active: true, authMode: "ANONYMOUS" }].concat(result && Array.isArray(result.result) ? result.result : []).sort((a, b) => a.name.localeCompare(b.name)).map(chart => <CollapsedList {...chart} key={chart.id || Math.random().toString(36).substr(2, 5)} reload={reload} />)}
         </section>
     );

--- a/src/components/ciConfig/CIConfig.scss
+++ b/src/components/ciConfig/CIConfig.scss
@@ -1,5 +1,5 @@
 .white-card__docker-config {
-    padding: 24px 24px 12px 24px;
+    padding: 20px 24px 12px 24px;
     .form-row {
         margin-bottom: 24px;
     }

--- a/src/components/ciConfig/CIConfig.scss
+++ b/src/components/ciConfig/CIConfig.scss
@@ -59,3 +59,8 @@
         }
     }
 }
+.docker__dropdown{
+    margin: auto;
+    margin-right: 0;
+    margin-top: 0;
+}

--- a/src/components/ciConfig/CIConfig.tsx
+++ b/src/components/ciConfig/CIConfig.tsx
@@ -213,7 +213,6 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                         {dockerfile.error && <label className="form__error">{dockerfile.error}</label>}
                     </div>
                 </div>
-
                 <div onClick={toggleCollapse} className="flex left">
                     <div>
                         <div className="fs-16 fw-6 pb-4">Advanced</div>
@@ -227,7 +226,6 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                 </div>
                 {isCollapsed ? <>
                     {args && args.map((arg, idx) => <KeyValueInput keyLabel={"Key"} valueLabel={"Value"}  {...arg} key={idx} index={idx} onChange={handleArgsChange} onDelete={e => { let argsTemp = [...args]; argsTemp.splice(idx, 1); setArgs(argsTemp) }} valueType="text" />)}
-
                     <div className="add-parameter pointer fs-14 cb-5 mb-20" onClick={e => setArgs(args => [{ k: "", v: '', keyError: '', valueError: '' }, ...args])}>
                         <span className="fa fa-plus mr-8"></span>Add parameter
                     </div> </> : ''}

--- a/src/components/ciConfig/CIConfig.tsx
+++ b/src/components/ciConfig/CIConfig.tsx
@@ -214,9 +214,9 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                     </div>
                 </div>
                 <hr className="mt-0 mb-20"/>
-                <div onClick={toggleCollapse} className="flex left">
+                <div onClick={toggleCollapse} className="flex left cursor">
                     <div>
-                        <div className="fs-16 fw-6 pb-4">Advanced</div>
+                        <div className="fs-16 fw-6 ">Advanced</div>
                         <div className="form-row form-row__add-parameters">
                             <label htmlFor="" className=" fs-14 fw-4 cn-7">Docker build arguments</label>
                         </div>

--- a/src/components/ciConfig/CIConfig.tsx
+++ b/src/components/ciConfig/CIConfig.tsx
@@ -178,7 +178,7 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
             <span><a rel="noreferrer noopener" target="_blank" className="learn-more__href" href={DOCUMENTATION.GLOBAL_CONFIG_DOCKER}> Learn more about Docker Build Config</a> </span></p>
             <div className="white-card white-card__docker-config">
                 <div className="fs-16 fw-6 pb-16">Image store</div>
-                <div className="form-row form-row__docker">
+                <div className="mb-4 form-row__docker">
                     <div className="form__field">
                         <label htmlFor="" className="form__label">Docker registry*</label>
                         <Select onChange={handleOnChange} name="registry" value={registry.value} tabIndex={3}>
@@ -198,7 +198,7 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                     </div>
                 </div>
                 <div className="fs-16 fw-6 pb-16">Checkout Path</div>
-                <div className="form-row form-row__docker">
+                <div className="mb-4 form-row__docker">
                     <div className="form__field">
                         <label className="form__label">Git checkout path*</label>
                         <Select onChange={handleOnChange} name='repository' value={repository.value} tabIndex={1}>
@@ -213,6 +213,7 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                         {dockerfile.error && <label className="form__error">{dockerfile.error}</label>}
                     </div>
                 </div>
+                <hr className="mt-0 mb-20"/>
                 <div onClick={toggleCollapse} className="flex left">
                     <div>
                         <div className="fs-16 fw-6 pb-4">Advanced</div>

--- a/src/components/ciConfig/CIConfig.tsx
+++ b/src/components/ciConfig/CIConfig.tsx
@@ -9,10 +9,8 @@ import { KeyValueInput } from '../configMaps/ConfigMap'
 import { toast } from 'react-toastify';
 import { URLS } from '../../config';
 import { NavLink } from 'react-router-dom';
-import ReactSelect, { components } from 'react-select';
 import { ReactComponent as Dropdown } from '../../assets/icons/appstatus/ic-dropdown.svg';
 import { ReactComponent as Add } from '../../assets/icons/ic-add.svg';
-import { ReactComponent as Check } from '../../assets/icons/ic-check.svg';
 import './CIConfig.scss';
 
 export default function CIConfig({ respondOnSuccess, ...rest }) {
@@ -91,7 +89,8 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                 }
             },
             repository_name: {
-                required: false,
+                required: true,
+                
             }
 
         }, onValidation);
@@ -204,6 +203,7 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                             autoFocus
                             autoComplete={"off"}
                         />
+                        {repository_name.error && <label className="form__error">{repository_name.error}</label>}
                         {!ciConfig && <label className="form__error form__error--info">New repository will be created if not provided</label>}
                     </div>
                 </div>
@@ -248,6 +248,7 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                 {isCollapsed ? <>
                     {args && args.map((arg, idx) => <KeyValueInput keyLabel={"Key"} valueLabel={"Value"}  {...arg} key={idx} index={idx} onChange={handleArgsChange} onDelete={e => { let argsTemp = [...args]; argsTemp.splice(idx, 1); setArgs(argsTemp) }} valueType="text" />)}
                     <div className="add-parameter pointer fs-14 cb-5 mb-20" onClick={e => setArgs(args => [{ k: "", v: '', keyError: '', valueError: '' }, ...args])}>
+
                         <span className="fa fa-plus mr-8"></span>Add parameter
                     </div> </> : ''}
                 <div className="form__buttons mt-12">

--- a/src/components/ciConfig/CIConfig.tsx
+++ b/src/components/ciConfig/CIConfig.tsx
@@ -170,21 +170,7 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
             <p className="form__subtitle">Required to execute CI pipelines for this application.
             <span><a rel="noreferrer noopener" target="_blank" className="learn-more__href" href={DOCUMENTATION.GLOBAL_CONFIG_DOCKER}> Learn more about Docker Build Config</a> </span></p>
             <div className="white-card white-card__docker-config">
-                <div className="form-row form-row__docker">
-                    <div className="form__field">
-                        <label className="form__label">Repository*</label>
-                        <Select onChange={handleOnChange} name='repository' value={repository.value} tabIndex={1}>
-                            <Select.Button>{repository.value || "Select repository"}</Select.Button>
-                            {sourceConfig.material.map(config => <Select.Option key={config.id} value={config.checkoutPath || "./"}>{config.checkoutPath || "./"}</Select.Option>)}
-                        </Select>
-                        {repository.error && <label className="form__error">{repository.error}</label>}
-                    </div>
-                    <div className="form__field">
-                        <label htmlFor="" className="form__label">Docker file path (relative)*</label>
-                        <input tabIndex={2} type="text" className="form__input" placeholder="Dockerfile" name="dockerfile" value={dockerfile.value} onChange={handleOnChange} />
-                        {dockerfile.error && <label className="form__error">{dockerfile.error}</label>}
-                    </div>
-                </div>
+                <div className="fs-16 fw-6 pb-16">Image store</div>
                 <div className="form-row form-row__docker">
                     <div className="form__field">
                         <label htmlFor="" className="form__label">Docker registry*</label>
@@ -204,14 +190,34 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                         {!ciConfig && <label className="form__error form__error--info">New repository will be created if not provided</label>}
                     </div>
                 </div>
-                <div className="form-row form-row__add-parameters">
-                    <label htmlFor="" className="form__label bold">Docker build arguments</label>
-                    <div className="add-parameter bold pointer" onClick={e => setArgs(args => [{ k: "", v: '', keyError: '', valueError: '' }, ...args])}>
-                        <span className="fa fa-plus"></span>Add parameter
+                <div className="fs-16 fw-6 pb-16">Checkout Path</div>
+                <div className="form-row form-row__docker">
+                    <div className="form__field">
+                        <label className="form__label">Git checkout path*</label>
+                        <Select onChange={handleOnChange} name='repository' value={repository.value} tabIndex={1}>
+                            <Select.Button>{repository.value || "Select repository"}</Select.Button>
+                            {sourceConfig.material.map(config => <Select.Option key={config.id} value={config.checkoutPath || "./"}>{config.checkoutPath || "./"}</Select.Option>)}
+                        </Select>
+                        {repository.error && <label className="form__error">{repository.error}</label>}
+                    </div>
+                    <div className="form__field">
+                        <label htmlFor="" className="form__label">Docker file path (relative)*</label>
+                        <input tabIndex={2} type="text" className="form__input" placeholder="Dockerfile" name="dockerfile" value={dockerfile.value} onChange={handleOnChange} />
+                        {dockerfile.error && <label className="form__error">{dockerfile.error}</label>}
                     </div>
                 </div>
+                <label></label>
+                <div className="fs-16 fw-6 pb-4">Advanced</div>
+                <div className="form-row form-row__add-parameters">
+                    <label htmlFor="" className=" fs-14 fw-4 cn-7">Docker build arguments</label>
+                </div>
+
                 {args && args.map((arg, idx) => <KeyValueInput keyLabel={"Key"} valueLabel={"Value"}  {...arg} key={idx} index={idx} onChange={handleArgsChange} onDelete={e => { let argsTemp = [...args]; argsTemp.splice(idx, 1); setArgs(argsTemp) }} valueType="text" />)}
-                <div className="form__buttons">
+
+                <div className="add-parameter pointer fs-14 cb-5 mb-20" onClick={e => setArgs(args => [{ k: "", v: '', keyError: '', valueError: '' }, ...args])}>
+                    <span className="fa fa-plus mr-8"></span>Add parameter
+                    </div>
+                <div className="form__buttons mt-12">
                     <button tabIndex={5} type="button" className={`cta`} onClick={handleOnSubmit}>{loading ? <Progressing /> : 'Save Configuration'}</button>
                 </div>
             </div>

--- a/src/components/ciConfig/CIConfig.tsx
+++ b/src/components/ciConfig/CIConfig.tsx
@@ -193,7 +193,7 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                     </div>
                     <div className="form__field">
                         <label htmlFor="" className="form__label">Docker repository</label>
-                        <input tabIndex={4} type="text" className="form__input" placeholder="Enter repository name" name="repository_name" value={repository_name.value} onChange={handleOnChange} />
+                        <input tabIndex={4} type="text" className="form__input" placeholder="Enter repository name" name="repository_name" value={repository_name.value} onChange={handleOnChange} autoFocus/>
                         {!ciConfig && <label className="form__error form__error--info">New repository will be created if not provided</label>}
                     </div>
                 </div>
@@ -209,7 +209,7 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                     </div>
                     <div className="form__field">
                         <label htmlFor="" className="form__label">Docker file path (relative)*</label>
-                        <input tabIndex={2} type="text" className="form__input" placeholder="Dockerfile" name="dockerfile" value={dockerfile.value} onChange={handleOnChange} />
+                        <input tabIndex={2} type="text" className="form__input" placeholder="Dockerfile" name="dockerfile" value={dockerfile.value} onChange={handleOnChange} autoFocus/>
                         {dockerfile.error && <label className="form__error">{dockerfile.error}</label>}
                     </div>
                 </div>

--- a/src/components/ciConfig/CIConfig.tsx
+++ b/src/components/ciConfig/CIConfig.tsx
@@ -10,6 +10,7 @@ import { toast } from 'react-toastify';
 import { URLS } from '../../config';
 import { NavLink } from 'react-router-dom';
 import ReactSelect, { components } from 'react-select';
+import { ReactComponent as Dropdown } from '../../assets/icons/appstatus/ic-dropdown.svg';
 import { ReactComponent as Add } from '../../assets/icons/ic-add.svg';
 import { ReactComponent as Check } from '../../assets/icons/ic-check.svg';
 import './CIConfig.scss';
@@ -63,7 +64,7 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
     const { state, disable, handleOnChange, handleOnSubmit } = useForm(
         {
             repository: { value: ciConfig && ciConfig.dockerBuildConfig.gitMaterialId ? sourceConfig.material.find(material => material.id === ciConfig.dockerBuildConfig.gitMaterialId).checkoutPath : Array.isArray(sourceConfig.material) && sourceConfig.material.length === 1 ? (sourceConfig.material[0].checkoutPath || "./") : "", error: "" },
-            dockerfile: { value: ciConfig ? ciConfig.dockerBuildConfig.dockerfileRelativePath : "", error: "" },
+            dockerfile: { value: ciConfig ? ciConfig.dockerBuildConfig.dockerfileRelativePath : "Dockerfile", error: "" },
             registry: { value: ciConfig ? ciConfig.dockerRegistry : (Array.isArray(dockerRegistries) ? dockerRegistries.find(reg => reg.isDefault).id || "" : ""), error: "" },
             repository_name: { value: ciConfig ? ciConfig.dockerRepository : "", error: "" },
         },
@@ -213,11 +214,16 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                     </div>
                 </div>
 
-                <div onClick={toggleCollapse}>
-                    <div className="fs-16 fw-6 pb-4">Advanced</div>
-                    <div className="form-row form-row__add-parameters">
-                        <label htmlFor="" className=" fs-14 fw-4 cn-7">Docker build arguments</label>
+                <div onClick={toggleCollapse} className="flex left">
+                    <div>
+                        <div className="fs-16 fw-6 pb-4">Advanced</div>
+                        <div className="form-row form-row__add-parameters">
+                            <label htmlFor="" className=" fs-14 fw-4 cn-7">Docker build arguments</label>
+                        </div>
                     </div>
+                    <span className="docker__dropdown ">
+                        <Dropdown className="icon-dim-32 rotate " style={{ ['--rotateBy' as any]: isCollapsed ? '180deg' : '0deg' }} />
+                    </span>
                 </div>
                 {isCollapsed ? <>
                     {args && args.map((arg, idx) => <KeyValueInput keyLabel={"Key"} valueLabel={"Value"}  {...arg} key={idx} index={idx} onChange={handleArgsChange} onDelete={e => { let argsTemp = [...args]; argsTemp.splice(idx, 1); setArgs(argsTemp) }} valueType="text" />)}

--- a/src/components/ciConfig/CIConfig.tsx
+++ b/src/components/ciConfig/CIConfig.tsx
@@ -59,6 +59,7 @@ export default function CIConfig({ respondOnSuccess, ...rest }) {
 }
 
 function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
+    const [isCollapsed, setIsCollapsed] = useState(false)
     const { state, disable, handleOnChange, handleOnSubmit } = useForm(
         {
             repository: { value: ciConfig && ciConfig.dockerBuildConfig.gitMaterialId ? sourceConfig.material.find(material => material.id === ciConfig.dockerBuildConfig.gitMaterialId).checkoutPath : Array.isArray(sourceConfig.material) && sourceConfig.material.length === 1 ? (sourceConfig.material[0].checkoutPath || "./") : "", error: "" },
@@ -163,6 +164,11 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
             return Array.from(arr);
         })
     }
+
+    function toggleCollapse() {
+        setIsCollapsed(!isCollapsed)
+    }
+
     const { repository, dockerfile, registry, repository_name, key, value } = state
     return (
         <div className="form__app-compose">
@@ -206,17 +212,19 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                         {dockerfile.error && <label className="form__error">{dockerfile.error}</label>}
                     </div>
                 </div>
-                <label></label>
-                <div className="fs-16 fw-6 pb-4">Advanced</div>
-                <div className="form-row form-row__add-parameters">
-                    <label htmlFor="" className=" fs-14 fw-4 cn-7">Docker build arguments</label>
-                </div>
 
-                {args && args.map((arg, idx) => <KeyValueInput keyLabel={"Key"} valueLabel={"Value"}  {...arg} key={idx} index={idx} onChange={handleArgsChange} onDelete={e => { let argsTemp = [...args]; argsTemp.splice(idx, 1); setArgs(argsTemp) }} valueType="text" />)}
-
-                <div className="add-parameter pointer fs-14 cb-5 mb-20" onClick={e => setArgs(args => [{ k: "", v: '', keyError: '', valueError: '' }, ...args])}>
-                    <span className="fa fa-plus mr-8"></span>Add parameter
+                <div onClick={toggleCollapse}>
+                    <div className="fs-16 fw-6 pb-4">Advanced</div>
+                    <div className="form-row form-row__add-parameters">
+                        <label htmlFor="" className=" fs-14 fw-4 cn-7">Docker build arguments</label>
                     </div>
+                </div>
+                {isCollapsed ? <>
+                    {args && args.map((arg, idx) => <KeyValueInput keyLabel={"Key"} valueLabel={"Value"}  {...arg} key={idx} index={idx} onChange={handleArgsChange} onDelete={e => { let argsTemp = [...args]; argsTemp.splice(idx, 1); setArgs(argsTemp) }} valueType="text" />)}
+
+                    <div className="add-parameter pointer fs-14 cb-5 mb-20" onClick={e => setArgs(args => [{ k: "", v: '', keyError: '', valueError: '' }, ...args])}>
+                        <span className="fa fa-plus mr-8"></span>Add parameter
+                    </div> </> : ''}
                 <div className="form__buttons mt-12">
                     <button tabIndex={5} type="button" className={`cta`} onClick={handleOnSubmit}>{loading ? <Progressing /> : 'Save Configuration'}</button>
                 </div>

--- a/src/components/ciConfig/CIConfig.tsx
+++ b/src/components/ciConfig/CIConfig.tsx
@@ -193,7 +193,17 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                     </div>
                     <div className="form__field">
                         <label htmlFor="" className="form__label">Docker repository</label>
-                        <input tabIndex={4} type="text" className="form__input" placeholder="Enter repository name" name="repository_name" value={repository_name.value} onChange={handleOnChange} autoFocus/>
+                        <input
+                            tabIndex={4}
+                            type="text"
+                            className="form__input"
+                            placeholder="Enter repository name"
+                            name="repository_name"
+                            value={repository_name.value}
+                            onChange={handleOnChange}
+                            autoFocus
+                            autoComplete={"off"}
+                        />
                         {!ciConfig && <label className="form__error form__error--info">New repository will be created if not provided</label>}
                     </div>
                 </div>
@@ -209,11 +219,21 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                     </div>
                     <div className="form__field">
                         <label htmlFor="" className="form__label">Docker file path (relative)*</label>
-                        <input tabIndex={2} type="text" className="form__input" placeholder="Dockerfile" name="dockerfile" value={dockerfile.value} onChange={handleOnChange} autoFocus/>
+                        <input
+                            tabIndex={2}
+                            type="text"
+                            className="form__input"
+                            placeholder="Dockerfile"
+                            name="dockerfile"
+                            value={dockerfile.value}
+                            onChange={handleOnChange}
+                            autoFocus
+                            autoComplete={"off"}
+                        />
                         {dockerfile.error && <label className="form__error">{dockerfile.error}</label>}
                     </div>
                 </div>
-                <hr className="mt-0 mb-20"/>
+                <hr className="mt-0 mb-20" />
                 <div onClick={toggleCollapse} className="flex left cursor">
                     <div>
                         <div className="fs-16 fw-6 ">Advanced</div>

--- a/src/components/cluster/Cluster.tsx
+++ b/src/components/cluster/Cluster.tsx
@@ -102,7 +102,7 @@ export default class ClusterList extends Component<ClusterListProps, any> {
         else return <section className="mt-16 mb-16 ml-20 mr-20 global-configuration__component flex-1">
             <h2 className="form__title">Clusters and Environments</h2>
             <h5 className="form__subtitle">Manage your organization’s clusters and environments. &nbsp;
-                <a href={DOCUMENTATION.GLOBAL_CONFIG_CLUSTER} rel="noopener noreferer" target="_blank">Learn more about cluster and environments</a>
+                <a className="learn-more__href" href={DOCUMENTATION.GLOBAL_CONFIG_CLUSTER} rel="noopener noreferer" target="_blank">Learn more about cluster and environments</a>
             </h5>
             {this.state.clusters.map(cluster => <Cluster {...cluster} reload={this.initialise} key={cluster.id || Math.random().toString(36).substr(2, 5)} />)}
         </section>

--- a/src/components/gitOps/GitOpsConfiguration.tsx
+++ b/src/components/gitOps/GitOpsConfiguration.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { ViewType } from '../../config'
+import { ViewType, DOCUMENTATION } from '../../config'
 import { GitOpsState, GitOpsProps, GitOpsConfig } from './gitops.type'
 import { ProtectedInput } from '../globalConfigurations/GlobalConfiguration'
 import { ReactComponent as GitLab } from '../../assets/icons/git/gitlab.svg';
@@ -208,7 +208,8 @@ export default class GitOpsConfiguration extends Component<GitOpsProps, GitOpsSt
         }
         return <section className="mt-16 mb-16 ml-20 mr-20 global-configuration__component flex-1">
             <h2 className="form__title">GitOps</h2>
-            <h5 className="form__subtitle">Devtron uses GitOps configuration to store kubernetes configuration files of applications.</h5>
+            <p className="form__subtitle">Devtron uses GitOps configuration to store kubernetes configuration files of applications.
+            <span><a rel="noreferrer noopener" target="_blank" className="learn-more__href" href={DOCUMENTATION.GLOBAL_CONFIG_GITOPS}> Learn more about GitOps </a> </span></p>
             <form className="bcn-0 bw-1 en-2 br-8 pb-22 pl-20 pr-20">
                 <div className="login__sso-flex">
                     <label className="tertiary-tab__radio">

--- a/src/components/gitProvider/GitProvider.tsx
+++ b/src/components/gitProvider/GitProvider.tsx
@@ -7,6 +7,9 @@ import { toast } from 'react-toastify'
 import Tippy from '@tippyjs/react';
 import { DOCUMENTATION } from '../../config';
 import { GlobalConfigCheckList } from '../checkList/GlobalConfigCheckList';
+import { ReactComponent as GitLab } from '../../assets/icons/git/git.svg'
+import { ReactComponent as GitHub } from '../../assets/icons/git/github.svg'
+import { ReactComponent as BitBucket } from '../../assets/icons/git/bitbucket.svg'
 
 export default function GitProvider({ ...props }) {
     const location = useLocation();
@@ -21,11 +24,11 @@ export default function GitProvider({ ...props }) {
 
     return (<section className="mt-16 mb-16 ml-20 mr-20 global-configuration__component flex-1">
         <h2 className="form__title">Git accounts</h2>
-        <h5 className="form__subtitle">Manage your organization’s git accounts. &nbsp;
+        <div className="form__subtitle">Manage your organization’s git accounts. &nbsp;
             <a className="learn-more__href" href={DOCUMENTATION.GLOBAL_CONFIG_GIT} rel="noopener noreferrer" target="_blank">
                 Learn more about git accounts
             </a>
-        </h5>
+        </div>
         {[{ id: null, name: "", active: true, url: "", authMode: "ANONYMOUS" }].concat(result && Array.isArray(result.result) ? result.result : []).sort((a, b) => a.name.localeCompare(b.name)).map(git => <CollapsedList {...git} key={git.id || Math.random().toString(36).substr(2, 5)} reload={reload} />)}
     </section>
     )
@@ -61,7 +64,11 @@ function CollapsedList({ id, name, active, url, authMode, accessToken = "", user
     return (
         <article className={`collapsed-list collapsed-list--git collapsed-list--${id ? 'update' : 'create'}`}>
             <List onClick={e => toggleCollapse(t => !t)}>
-                <List.Logo>{id ? <div className={`${url.split(".")[0]} list__logo git-logo`}></div> : <div className="add-icon" />}</List.Logo>
+                <List.Logo>{id ? <div className="">
+                    <span className="mr-8">
+                        {url.includes("gitlab") ? <GitLab /> : url.includes("github") ? <GitHub /> : <BitBucket />}
+                    </span></div> :
+                    <div className="add-icon" />}</List.Logo>
                 <div className="flex left">
                     <List.Title title={id && !collapsed ? 'Edit git account' : name || "Add git account"} subtitle={collapsed ? url : null} />
                     {id &&

--- a/src/components/gitProvider/GitProvider.tsx
+++ b/src/components/gitProvider/GitProvider.tsx
@@ -7,7 +7,8 @@ import { toast } from 'react-toastify'
 import Tippy from '@tippyjs/react';
 import { DOCUMENTATION } from '../../config';
 import { GlobalConfigCheckList } from '../checkList/GlobalConfigCheckList';
-import { ReactComponent as GitLab } from '../../assets/icons/git/git.svg'
+import { ReactComponent as GitLab } from '../../assets/icons/git/gitlab.svg'
+import { ReactComponent as Git } from '../../assets/icons/git/git.svg'
 import { ReactComponent as GitHub } from '../../assets/icons/git/github.svg'
 import { ReactComponent as BitBucket } from '../../assets/icons/git/bitbucket.svg'
 
@@ -66,8 +67,11 @@ function CollapsedList({ id, name, active, url, authMode, accessToken = "", user
             <List onClick={e => toggleCollapse(t => !t)}>
                 <List.Logo>{id ? <div className="">
                     <span className="mr-8">
-                        {url.includes("gitlab") ? <GitLab /> : url.includes("github") ? <GitHub /> : <BitBucket />}
-                    </span></div> :
+                        {url.includes("gitlab") ? <GitLab /> : null}
+                        {url.includes("github") ? <GitHub /> : null}
+                        {url.includes("bitbucket") ? <BitBucket /> : null}
+                        {url.includes("gitlab")  || url.includes("github")  ||  url.includes("bitbucket") ? null : <Git/>}
+                        </span></div> :
                     <div className="add-icon" />}</List.Logo>
                 <div className="flex left">
                     <List.Title title={id && !collapsed ? 'Edit git account' : name || "Add git account"} subtitle={collapsed ? url : null} />

--- a/src/components/material/CreateMaterial.tsx
+++ b/src/components/material/CreateMaterial.tsx
@@ -99,6 +99,7 @@ export class CreateMaterial extends Component<CreateMaterialProps, CreateMateria
 
     save(event): void {
         this.setState({
+            isChecked:true,
             isError: {
                 gitProvider: this.props.isGitProviderValid(this.state.material.gitProvider),
                 url: this.props.isGitUrlValid(this.state.material.url),
@@ -107,7 +108,9 @@ export class CreateMaterial extends Component<CreateMaterialProps, CreateMateria
         }, () => {
             if (this.state.isError.url || this.state.isError.gitProvider || this.state.isError.checkoutPath) return;
 
-            this.setState({ isLoading: true });
+            this.setState({ 
+                isLoading: true ,
+            });
             let payload = {
                 appId: this.props.appId,
                 material: [{

--- a/src/components/material/CreateMaterial.tsx
+++ b/src/components/material/CreateMaterial.tsx
@@ -4,6 +4,7 @@ import { toast } from 'react-toastify';
 import { showError } from '../common';
 import { MaterialView } from './MaterialView';
 import { CreateMaterialState } from './material.types';
+
 interface CreateMaterialProps {
     appId: number;
     isMultiGit: boolean;
@@ -26,6 +27,7 @@ export class CreateMaterial extends Component<CreateMaterialProps, CreateMateria
                 active: true,
             },
             isCollapsed: this.props.isMultiGit ? true : false,
+            isChecked: false,
             isLoading: false,
             isError: {
                 gitProvider: undefined,
@@ -40,6 +42,14 @@ export class CreateMaterial extends Component<CreateMaterialProps, CreateMateria
         this.toggleCollapse = this.toggleCollapse.bind(this);
         this.save = this.save.bind(this);
         this.cancel = this.cancel.bind(this);
+        this.handleCheckbox = this.handleCheckbox.bind(this);
+
+    }
+
+    handleCheckbox(event): void {
+        this.setState({
+            isChecked: !this.state.isChecked
+        });
     }
 
     handleProviderChange(selected) {
@@ -138,8 +148,10 @@ export class CreateMaterial extends Component<CreateMaterialProps, CreateMateria
     render() {
         return <MaterialView
             isMultiGit={this.props.isMultiGit}
+            isChecked= {this.state.isChecked}
             material={this.state.material}
             isCollapsed={this.state.isCollapsed}
+            handleCheckbox= {this.handleCheckbox}
             isLoading={this.state.isLoading}
             isError={this.state.isError}
             providers={this.props.providers}
@@ -149,6 +161,7 @@ export class CreateMaterial extends Component<CreateMaterialProps, CreateMateria
             toggleCollapse={this.toggleCollapse}
             save={this.save}
             cancel={this.cancel}
+
         />
     }
 }

--- a/src/components/material/MaterialList.tsx
+++ b/src/components/material/MaterialList.tsx
@@ -107,7 +107,8 @@ class MaterialList extends Component<MaterialListProps, MaterialListState> {
     renderPageHeader() {
         return <>
             <h1 className="form__title form__title--artifacts">Git Materials</h1>
-            <p className="form__subtitle form__subtitle--artifacts">Manage source code repositories for this application. <span><a rel="noreferrer noopener" target="_blank" className="learn-more__href" href={DOCUMENTATION.GLOBAL_CONFIG_GIT}> Learn more about Git Material</a> </span></p>
+            <p className="form__subtitle form__subtitle--artifacts">Manage source code repositories for this application. 
+            <span><a rel="noreferrer noopener" target="_blank" className="learn-more__href" href={DOCUMENTATION.GLOBAL_CONFIG_GIT}> Learn more about Git Material</a> </span></p>
         </>
     }
 

--- a/src/components/material/MaterialList.tsx
+++ b/src/components/material/MaterialList.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { getGitProviderListAuth, getSourceConfig } from '../../services/service';
 import { ErrorScreenManager, Progressing, showError, sortCallback } from '../common';
-import { AppConfigStatus, ViewType } from '../../config';
+import { AppConfigStatus, ViewType,  DOCUMENTATION, } from '../../config';
 import { withRouter } from 'react-router';
 import { CreateMaterial } from './CreateMaterial';
 import { UpdateMaterial } from './UpdateMaterial';
@@ -107,7 +107,7 @@ class MaterialList extends Component<MaterialListProps, MaterialListState> {
     renderPageHeader() {
         return <>
             <h1 className="form__title form__title--artifacts">Git Materials</h1>
-            <p className="form__subtitle form__subtitle--artifacts">Manage source code repositories for this application.</p>
+            <p className="form__subtitle form__subtitle--artifacts">Manage source code repositories for this application. <span><a rel="noreferrer noopener" target="_blank" className="learn-more__href" href={DOCUMENTATION.GLOBAL_CONFIG_GIT}> Learn more about Git Material</a> </span></p>
         </>
     }
 

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -3,20 +3,21 @@ import ReactSelect, { components } from 'react-select';
 import { ReactComponent as Add } from '../../assets/icons/ic-add.svg';
 import { ReactComponent as Check } from '../../assets/icons/ic-check.svg';
 import { ReactComponent as Down } from '../../assets/icons/appstatus/ic-dropdown.svg';
-import { Progressing, Checkbox} from '../common';
+import { Progressing, Checkbox } from '../common';
 import { MaterialViewProps } from './material.types';
 import { NavLink } from 'react-router-dom';
 import { URLS } from '../../config';
 import error from '../../assets/icons/misc/errorInfo.svg';
+import { ReactComponent as GitLab } from '../../assets/icons/git/git.svg'
 
-export class MaterialView extends Component<MaterialViewProps,{}> {
-   
+export class MaterialView extends Component<MaterialViewProps, {}> {
+
 
     renderCollapsedView() {
         if ((this.props.material).id) {
             return <div key={`${(this.props.material).id}`} className="white-card artifact-collapsed" tabIndex={0}
                 onClick={this.props.toggleCollapse}>
-                <span className="git__icon"></span>
+                <span className="git__icon"><GitLab/></span>
                 <div className="">
                     <div className="git__provider">{(this.props.material).name}</div>
                     <p className="git__url">{this.props.material.url}</p>
@@ -33,13 +34,13 @@ export class MaterialView extends Component<MaterialViewProps,{}> {
     renderForm() {
         return <form key={`${(this.props.material).id}`} className="white-card p-20 mb-16">
             <div className="mb-20 cn-9 fs-16 fw-6 white-card__header--form">
-                {(this.props.material).id ? "Edit Material" : "Add Material"}
+                {(this.props.material).id ? "Edit Material" : "Add Git Material"}
                 {(this.props.material).id ? <button type="button" className="transparent collapse-button" tabIndex={0} onClick={this.props.toggleCollapse}>
                     <Down className="collapsed__icon icon-dim-20" style={{ transform: 'rotateX(180deg)' }} />
                 </button> : null}
             </div>
             <div className="form__row form-row__material">
-              <div className="">
+                <div className="">
                     <label className="form__label">Git Account*</label>
                     <ReactSelect className=""
                         tabIndex='1'
@@ -96,7 +97,7 @@ export class MaterialView extends Component<MaterialViewProps,{}> {
                 <div>
                     <label className="form__label">Git Repo URL*</label>
                     <input className="form__input"
-                    name="Git Repo URL*"
+                        name="Git Repo URL*"
                         type="text"
                         placeholder="e.g. https://gitlab.com/abc/xyz.git"
                         value={this.props.material.url}
@@ -111,11 +112,11 @@ export class MaterialView extends Component<MaterialViewProps,{}> {
             </div>
 
             <label className="form__row">
-             <Checkbox
+                <Checkbox
                     isChecked={this.props.isChecked}
                     value={"CHECKED"}
                     tabIndex={3}
-                    onChange={this.props.handleCheckbox} 
+                    onChange={this.props.handleCheckbox}
                     rootClassName="form__label">
                     <span className="">Set Checkout Path(*Required If you’re using multiple Git Materials)</span>
                 </Checkbox>

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -51,6 +51,7 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                         isMulti={false}
                         isClearable={false}
                         options={this.props.providers}
+                        // options={this.props.providers}
                         getOptionLabel={option => `${option.name}`}
                         getOptionValue={option => `${option.id}`}
                         value={this.props.material.gitProvider}
@@ -79,6 +80,12 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                             Option: (props) => {
                                 return <components.Option {...props}>
                                     {props.isSelected ? <Check className="icon-dim-16 vertical-align-middle scb-5 mr-8" /> : <span className="inline-block icon-dim-16 mr-8"></span>}
+                                    {<span className="mr-8">
+                                        {props.data.url.includes("gitlab") ? <GitLab /> : null}
+                                        {props.data.url.includes("github") ? <GitHub /> : null}
+                                        {props.data.url.includes("bitbucket") ? <BitBucket /> : null}
+                                        {props.data.url.includes("gitlab") || props.data.url.includes("github") || props.data.url.includes("bitbucket") ? null : <GitLab />}
+                                    </span>}
                                     {props.label}
                                 </components.Option>
                             },
@@ -91,8 +98,16 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                                     </NavLink>
                                 </components.MenuList>
                             },
+                            Control: (props) => {
+                                return <components.Control {...props}>
+                                    {console.log(props)}
+                                     {props.children}
+                                </components.Control>
+                            }
                         }}
-                        onChange={(selected) => { this.props.handleProviderChange(selected) }} />
+
+                        onChange={(selected) => { this.props.handleProviderChange(selected) }}
+                    />
                     {this.props.isError.gitProvider && <span className="form__error">
                         <img src={error} className="form__icon" />
                         {this.props.isError.gitProvider}

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -51,9 +51,9 @@ export class MaterialView extends Component<MaterialViewProps, MaterialViewState
                     <Down className="collapsed__icon icon-dim-20" style={{ transform: 'rotateX(180deg)' }} />
                 </button> : null}
             </div>
-            <div className="form__row form__row--two-third">
-                <label>
-                    <span className="form__label">Git Account*</span>
+            <div className="form__row form-row__material">
+              <div className="">
+                    <label className="form__label">Git Account*</label>
                     <ReactSelect className=""
                         tabIndex='1'
                         isMulti={false}
@@ -105,11 +105,11 @@ export class MaterialView extends Component<MaterialViewProps, MaterialViewState
                         <img src={error} className="form__icon" />
                         {this.props.isError.gitProvider}
                     </span>}
-                </label>
-
-                <label >
-                    <span className="form__label">Git Repo URL*</span>
+                </div>
+                <div>
+                    <label className="form__label">Git Repo URL*</label>
                     <input className="form__input"
+                    name="Git Repo URL*"
                         type="text"
                         placeholder="e.g. https://gitlab.com/abc/xyz.git"
                         value={this.props.material.url}
@@ -119,7 +119,8 @@ export class MaterialView extends Component<MaterialViewProps, MaterialViewState
                             <img src={error} className="form__icon" />{this.props.isError.url}
                         </>}
                     </span>
-                </label>
+                </div>
+
             </div>
 
             <label className="form__row">

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -9,6 +9,8 @@ import { NavLink } from 'react-router-dom';
 import { URLS } from '../../config';
 import error from '../../assets/icons/misc/errorInfo.svg';
 import { ReactComponent as GitLab } from '../../assets/icons/git/git.svg'
+import { ReactComponent as GitHub } from '../../assets/icons/git/github.svg'
+import { ReactComponent as BitBucket } from '../../assets/icons/git/bitbucket.svg'
 
 export class MaterialView extends Component<MaterialViewProps, {}> {
 
@@ -17,7 +19,9 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
         if ((this.props.material).id) {
             return <div key={`${(this.props.material).id}`} className="white-card artifact-collapsed" tabIndex={0}
                 onClick={this.props.toggleCollapse}>
-                <span className="git__icon"><GitLab/></span>
+                <span className="mr-8">
+                    {this.props.material.url.includes("gitlab") ? <GitLab /> : this.props.material.url.includes("github") ? <GitHub /> : <BitBucket />}
+                </span>
                 <div className="">
                     <div className="git__provider">{(this.props.material).name}</div>
                     <p className="git__url">{this.props.material.url}</p>
@@ -34,7 +38,7 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
     renderForm() {
         return <form key={`${(this.props.material).id}`} className="white-card p-20 mb-16">
             <div className="mb-20 cn-9 fs-16 fw-6 white-card__header--form">
-                {(this.props.material).id ? "Edit Material" : "Add Git Material"}
+                {(this.props.material).id ? "Edit Git Material" : "Add Git Material"}
                 {(this.props.material).id ? <button type="button" className="transparent collapse-button" tabIndex={0} onClick={this.props.toggleCollapse}>
                     <Down className="collapsed__icon icon-dim-20" style={{ transform: 'rotateX(180deg)' }} />
                 </button> : null}
@@ -100,7 +104,7 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                         name="Git Repo URL*"
                         type="text"
                         placeholder="e.g. https://gitlab.com/abc/xyz.git"
-                        value={this.props.material.url}
+                        value={`${this.props.material.url}`}
                         onChange={this.props.handleUrlChange} />
                     <span className="form__error">
                         {this.props.isError.url && <>

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -33,7 +33,7 @@ export class MaterialView extends Component<MaterialViewProps, MaterialViewState
         }
         return <div className="white-card white-card--add-new-item mb-16" onClick={this.props.toggleCollapse}>
             <Add className="icon-dim-24 mr-5 fcb-5 vertical-align-middle" />
-            <span className="artifact__add">Add Material</span>
+            <span className="artifact__add">Add Git Material</span>
         </div>
     }
 
@@ -44,8 +44,8 @@ export class MaterialView extends Component<MaterialViewProps, MaterialViewState
     }
 
     renderForm() {
-        return <form key={`${(this.props.material).id}`} className="white-card p-24 mb-16">
-            <div className="white-card__header white-card__header--form">
+        return <form key={`${(this.props.material).id}`} className="white-card p-20 mb-16">
+            <div className="mb-20 cn-9 fs-16 fw-6 white-card__header--form">
                 {(this.props.material).id ? "Edit Material" : "Add Material"}
                 {(this.props.material).id ? <button type="button" className="transparent collapse-button" tabIndex={0} onClick={this.props.toggleCollapse}>
                     <Down className="collapsed__icon icon-dim-20" style={{ transform: 'rotateX(180deg)' }} />

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -8,7 +8,8 @@ import { MaterialViewProps } from './material.types';
 import { NavLink } from 'react-router-dom';
 import { URLS } from '../../config';
 import error from '../../assets/icons/misc/errorInfo.svg';
-import { ReactComponent as GitLab } from '../../assets/icons/git/git.svg'
+import { ReactComponent as GitLab } from '../../assets/icons/git/gitlab.svg'
+import { ReactComponent as Git } from '../../assets/icons/git/git.svg'
 import { ReactComponent as GitHub } from '../../assets/icons/git/github.svg'
 import { ReactComponent as BitBucket } from '../../assets/icons/git/bitbucket.svg'
 
@@ -20,7 +21,10 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
             return <div key={`${(this.props.material).id}`} className="white-card artifact-collapsed" tabIndex={0}
                 onClick={this.props.toggleCollapse}>
                 <span className="mr-8">
-                    {this.props.material.url.includes("gitlab") ? <GitLab /> : this.props.material.url.includes("github") ? <GitHub /> : <BitBucket />}
+                    {this.props.material.url.includes("gitlab") ? <GitLab /> : null}
+                    {this.props.material.url.includes("github") ? <GitHub /> : null}
+                    {this.props.material.url.includes("bitbuclet") ? <BitBucket /> : null}
+                    {this.props.material.url.includes("gitlab") || this.props.material.url.includes("github") || this.props.material.url.includes("bitbuclet") ? null : <Git />}
                 </span>
                 <div className="">
                     <div className="git__provider">{(this.props.material).name}</div>
@@ -80,12 +84,12 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                             Option: (props) => {
                                 return <components.Option {...props}>
                                     {props.isSelected ? <Check className="icon-dim-16 vertical-align-middle scb-5 mr-8" /> : <span className="inline-block icon-dim-16 mr-8"></span>}
-                                    {<span className="mr-8">
-                                        {props.data.url.includes("gitlab") ? <GitLab /> : null}
-                                        {props.data.url.includes("github") ? <GitHub /> : null}
-                                        {props.data.url.includes("bitbucket") ? <BitBucket /> : null}
-                                        {props.data.url.includes("gitlab") || props.data.url.includes("github") || props.data.url.includes("bitbucket") ? null : <GitLab />}
-                                    </span>}
+
+                                    {props.data.url.includes("gitlab") ? <GitLab className="mr-8 vertical-align-middle icon-dim-20" /> : null}
+                                    {props.data.url.includes("github") ? <GitHub className="mr-8 vertical-align-middle icon-dim-20" /> : null}
+                                    {props.data.url.includes("bitbucket") ? <BitBucket className="mr-8 vertical-align-middle icon-dim-20" /> : null}
+                                    {props.data.url.includes("gitlab") || props.data.url.includes("github") || props.data.url.includes("bitbucket") ? null : <Git className="mr-8 vertical-align-middle icon-dim-20" />}
+
                                     {props.label}
                                 </components.Option>
                             },
@@ -100,8 +104,15 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                             },
                             Control: (props) => {
                                 return <components.Control {...props}>
-                                    {console.log(props)}
-                                     {props.children}
+                                    {console.log(props.hasValue)}
+                                     {/*{(props.hasValue) ? props.options.map((e) => e.url.includes("github")) ?
+                                        <GitHub className="mr-8 vertical-align-middle icon-dim-20" /> : null}
+
+
+                                      {props.getValue().map((e)=>e.url.includes("github")) ? <GitHub className="mr-8 vertical-align-middle icon-dim-20"/> : null}
+                                    {props.getValue().map((e)=>e.url.includes("gitlab")) ? <GitLab className="mr-8 vertical-align-middle icon-dim-20"/> : null}
+                            {props.getValue().map((e)=>e.url.includes("bitbucket")) ? <BitBucket className="mr-8 vertical-align-middle icon-dim-20"/> : null}*/}
+                                    {props.children}
                                 </components.Control>
                             }
                         }}

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -103,18 +103,23 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                                 </components.MenuList>
                             },
                             Control: (props) => {
+                                let value = "";
+                                
+                                if (props.hasValue) {
+                                    value = props.getValue()[0].url;
+                                }
+                                let showGit = value && !value.includes("github") && !value.includes("gitlab") && !value.includes("bitbucket")
                                 return <components.Control {...props}>
-                                    {console.log(props.hasValue)}
-                                     {/*{(props.hasValue) ? props.options.map((e) => e.url.includes("github")) ?
-                                        <GitHub className="mr-8 vertical-align-middle icon-dim-20" /> : null}
 
-
-                                      {props.getValue().map((e)=>e.url.includes("github")) ? <GitHub className="mr-8 vertical-align-middle icon-dim-20"/> : null}
-                                    {props.getValue().map((e)=>e.url.includes("gitlab")) ? <GitLab className="mr-8 vertical-align-middle icon-dim-20"/> : null}
-                            {props.getValue().map((e)=>e.url.includes("bitbucket")) ? <BitBucket className="mr-8 vertical-align-middle icon-dim-20"/> : null}*/}
+                                    {value.includes("github") ? <GitHub className="icon-dim-20 ml-8" /> : null}
+                                    {value.includes("gitlab") ? <GitLab className="icon-dim-20 ml-8"/> : null}
+                                    {value.includes("bitbucket") ? <BitBucket className="icon-dim-20 ml-8"/> : null}
+                                    
+                                    {showGit ?  <Git className="icon-dim-20 ml-8"/> : null }
                                     {props.children}
                                 </components.Control>
-                            }
+                            
+                            },
                         }}
 
                         onChange={(selected) => { this.props.handleProviderChange(selected) }}

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -3,13 +3,21 @@ import ReactSelect, { components } from 'react-select';
 import { ReactComponent as Add } from '../../assets/icons/ic-add.svg';
 import { ReactComponent as Check } from '../../assets/icons/ic-check.svg';
 import { ReactComponent as Down } from '../../assets/icons/appstatus/ic-dropdown.svg';
-import { Progressing } from '../common';
-import { MaterialViewProps } from './material.types';
+import { Progressing, Checkbox } from '../common';
+import { MaterialViewProps, MaterialViewState } from './material.types';
 import { NavLink } from 'react-router-dom';
 import { URLS } from '../../config';
 import error from '../../assets/icons/misc/errorInfo.svg';
 
-export class MaterialView extends Component<MaterialViewProps, {}> {
+export class MaterialView extends Component<MaterialViewProps, MaterialViewState> {
+    constructor(props) {
+        super(props)
+
+        this.state = {
+            isChecked: false,
+        }
+        this.handleCheckbox = this.handleCheckbox.bind(this);
+    }
 
     renderCollapsedView() {
         if ((this.props.material).id) {
@@ -29,6 +37,12 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
         </div>
     }
 
+    handleCheckbox(event): void {
+        this.setState({
+            isChecked: !this.state.isChecked
+        });
+    }
+
     renderForm() {
         return <form key={`${(this.props.material).id}`} className="white-card p-24 mb-16">
             <div className="white-card__header white-card__header--form">
@@ -37,82 +51,91 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                     <Down className="collapsed__icon icon-dim-20" style={{ transform: 'rotateX(180deg)' }} />
                 </button> : null}
             </div>
-            <div className="form__row">
-                <span className="form__label">Select Provider*</span>
-                <ReactSelect className=""
-                    tabIndex='1'
-                    isMulti={false}
-                    isClearable={false}
-                    options={this.props.providers}
-                    getOptionLabel={option => `${option.name}`}
-                    getOptionValue={option => `${option.id}`}
-                    value={this.props.material.gitProvider}
-                    styles={{
-                        valueContainer: (base, state) => ({
-                            ...base,
-                            color: state.selectProps.menuIsOpen ? 'var(--N500)' : base.color,
-                        }),
-                        control: (base, state) => ({
-                            ...base,
-                            border: state.isFocused ? '1px solid #0066CC' : '1px solid #d6dbdf',
-                            boxShadow: 'none',
-                            fontWeight: 'normal',
-                            height: "40px"
-                        }),
-                        option: (base, state) => ({
-                            ...base,
-                            backgroundColor: state.isFocused ? 'var(--N100)' : 'white',
-                            fontWeight: "normal",
-                            color: 'var(--N900)',
-                            padding: '8px 12px',
-                        }),
-                    }}
-                    components={{
-                        IndicatorSeparator: null,
-                        Option: (props) => {
-                            return <components.Option {...props}>
-                                {props.isSelected ? <Check className="icon-dim-16 vertical-align-middle scb-5 mr-8" /> : <span className="inline-block icon-dim-16 mr-8"></span>}
-                                {props.label}
-                            </components.Option>
-                        },
-                        MenuList: (props) => {
-                            return <components.MenuList {...props}>
-                                {props.children}
-                                <NavLink to={`${URLS.GLOBAL_CONFIG_GIT}`} className="react-select__bottom p-10 cb-5 block fw-5 anchor cursor no-decor">
-                                    <Add className="icon-dim-20 mr-5 fcb-5 mr-12 vertical-align-bottom" />
+            <div className="form__row form__row--two-third">
+                <label>
+                    <span className="form__label">Git Account*</span>
+                    <ReactSelect className=""
+                        tabIndex='1'
+                        isMulti={false}
+                        isClearable={false}
+                        options={this.props.providers}
+                        getOptionLabel={option => `${option.name}`}
+                        getOptionValue={option => `${option.id}`}
+                        value={this.props.material.gitProvider}
+                        styles={{
+                            valueContainer: (base, state) => ({
+                                ...base,
+                                color: state.selectProps.menuIsOpen ? 'var(--N500)' : base.color,
+                            }),
+                            control: (base, state) => ({
+                                ...base,
+                                border: state.isFocused ? '1px solid #0066CC' : '1px solid #d6dbdf',
+                                boxShadow: 'none',
+                                fontWeight: 'normal',
+                                height: "40px"
+                            }),
+                            option: (base, state) => ({
+                                ...base,
+                                backgroundColor: state.isFocused ? 'var(--N100)' : 'white',
+                                fontWeight: "normal",
+                                color: 'var(--N900)',
+                                padding: '8px 12px',
+                            }),
+                        }}
+                        components={{
+                            IndicatorSeparator: null,
+                            Option: (props) => {
+                                return <components.Option {...props}>
+                                    {props.isSelected ? <Check className="icon-dim-16 vertical-align-middle scb-5 mr-8" /> : <span className="inline-block icon-dim-16 mr-8"></span>}
+                                    {props.label}
+                                </components.Option>
+                            },
+                            MenuList: (props) => {
+                                return <components.MenuList {...props}>
+                                    {props.children}
+                                    <NavLink to={`${URLS.GLOBAL_CONFIG_GIT}`} className="react-select__bottom p-10 cb-5 block fw-5 anchor cursor no-decor">
+                                        <Add className="icon-dim-20 mr-5 fcb-5 mr-12 vertical-align-bottom" />
                                         Add Git Provider
                                     </NavLink>
-                            </components.MenuList>
-                        },
-                    }}
-                    onChange={(selected) => { this.props.handleProviderChange(selected) }} />
-                {this.props.isError.gitProvider && <span className="form__error">
-                    <img src={error} className="form__icon" />
-                    {this.props.isError.gitProvider}
-                </span>}
+                                </components.MenuList>
+                            },
+                        }}
+                        onChange={(selected) => { this.props.handleProviderChange(selected) }} />
+                    {this.props.isError.gitProvider && <span className="form__error">
+                        <img src={error} className="form__icon" />
+                        {this.props.isError.gitProvider}
+                    </span>}
+                </label>
+
+                <label >
+                    <span className="form__label">Git Repo URL*</span>
+                    <input className="form__input"
+                        type="text"
+                        placeholder="e.g. https://gitlab.com/abc/xyz.git"
+                        value={this.props.material.url}
+                        onChange={this.props.handleUrlChange} />
+                    <span className="form__error">
+                        {this.props.isError.url && <>
+                            <img src={error} className="form__icon" />{this.props.isError.url}
+                        </>}
+                    </span>
+                </label>
             </div>
 
             <label className="form__row">
-                <span className="form__label">Git Repo URL*</span>
-                <input className="form__input"
-                    type="text"
-                    placeholder="e.g. https://gitlab.com/abc/xyz.git"
-                    value={this.props.material.url}
-                    onChange={this.props.handleUrlChange} />
-                <span className="form__error">
-                    {this.props.isError.url && <>
-                        <img src={error} className="form__icon" />{this.props.isError.url}
-                    </>}
-                </span>
-            </label>
-
-            <label className="form__row">
-                <span className="form__label">Checkout Path(*Required If you’re using multiple Git Materials)</span>
-                <input className="form__input"
+                <Checkbox
+                    isChecked={this.state.isChecked}
+                    value={"CHECKED"}
+                    tabIndex={3}
+                    onChange={this.handleCheckbox} 
+                    rootClassName="form__label">
+                    <span className="">Set Checkout Path(*Required If you’re using multiple Git Materials)</span>
+                </Checkbox>
+                {this.state.isChecked ? <input className="form__input"
                     type="text"
                     placeholder="e.g. /abc"
                     value={this.props.material.checkoutPath}
-                    onChange={this.props.handlePathChange} />
+                    onChange={this.props.handlePathChange} /> : ""}
                 <span className="form__error">
                     {this.props.isError.checkoutPath && <> <img src={error} className="form__icon" /> {this.props.isError.checkoutPath}</>}
                 </span>

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -3,21 +3,14 @@ import ReactSelect, { components } from 'react-select';
 import { ReactComponent as Add } from '../../assets/icons/ic-add.svg';
 import { ReactComponent as Check } from '../../assets/icons/ic-check.svg';
 import { ReactComponent as Down } from '../../assets/icons/appstatus/ic-dropdown.svg';
-import { Progressing, Checkbox } from '../common';
-import { MaterialViewProps, MaterialViewState } from './material.types';
+import { Progressing, Checkbox} from '../common';
+import { MaterialViewProps } from './material.types';
 import { NavLink } from 'react-router-dom';
 import { URLS } from '../../config';
 import error from '../../assets/icons/misc/errorInfo.svg';
 
-export class MaterialView extends Component<MaterialViewProps, MaterialViewState> {
-    constructor(props) {
-        super(props)
-
-        this.state = {
-            isChecked: false,
-        }
-        this.handleCheckbox = this.handleCheckbox.bind(this);
-    }
+export class MaterialView extends Component<MaterialViewProps,{}> {
+   
 
     renderCollapsedView() {
         if ((this.props.material).id) {
@@ -35,12 +28,6 @@ export class MaterialView extends Component<MaterialViewProps, MaterialViewState
             <Add className="icon-dim-24 mr-5 fcb-5 vertical-align-middle" />
             <span className="artifact__add">Add Git Material</span>
         </div>
-    }
-
-    handleCheckbox(event): void {
-        this.setState({
-            isChecked: !this.state.isChecked
-        });
     }
 
     renderForm() {
@@ -124,15 +111,15 @@ export class MaterialView extends Component<MaterialViewProps, MaterialViewState
             </div>
 
             <label className="form__row">
-                <Checkbox
-                    isChecked={this.state.isChecked}
+             <Checkbox
+                    isChecked={this.props.isChecked}
                     value={"CHECKED"}
                     tabIndex={3}
-                    onChange={this.handleCheckbox} 
+                    onChange={this.props.handleCheckbox} 
                     rootClassName="form__label">
                     <span className="">Set Checkout Path(*Required If you’re using multiple Git Materials)</span>
                 </Checkbox>
-                {this.state.isChecked ? <input className="form__input"
+                {this.props.isChecked ? <input className="form__input"
                     type="text"
                     placeholder="e.g. /abc"
                     value={this.props.material.checkoutPath}

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -131,6 +131,7 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                 <div>
                     <label className="form__label">Git Repo URL*</label>
                     <input className="form__input"
+                        autoComplete={"off"}
                         autoFocus
                         name="Git Repo URL*"
                         type="text"
@@ -155,12 +156,14 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                     rootClassName="form__label">
                     <span className="">Set Checkout Path(*Required If you’re using multiple Git Materials)</span>
                 </Checkbox>
-                {this.props.isChecked ? <input className="form__input"
-                    autoFocus
-                    type="text"
-                    placeholder="e.g. /abc"
-                    value={this.props.material.checkoutPath}
-                    onChange={this.props.handlePathChange} /> : ""}
+                {this.props.isChecked ?
+                    <input className="form__input"
+                        autoComplete={"off"}
+                        autoFocus
+                        type="text"
+                        placeholder="e.g. /abc"
+                        value={this.props.material.checkoutPath}
+                        onChange={this.props.handlePathChange} /> : ""}
                 <span className="form__error">
                     {this.props.isError.checkoutPath && <> <img src={error} className="form__icon" /> {this.props.isError.checkoutPath}</>}
                 </span>

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -131,6 +131,7 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                 <div>
                     <label className="form__label">Git Repo URL*</label>
                     <input className="form__input"
+                        autoFocus
                         name="Git Repo URL*"
                         type="text"
                         placeholder="e.g. https://gitlab.com/abc/xyz.git"
@@ -155,6 +156,7 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                     <span className="">Set Checkout Path(*Required If you’re using multiple Git Materials)</span>
                 </Checkbox>
                 {this.props.isChecked ? <input className="form__input"
+                    autoFocus
                     type="text"
                     placeholder="e.g. /abc"
                     value={this.props.material.checkoutPath}

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -24,7 +24,7 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                     {this.props.material.url.includes("gitlab") ? <GitLab /> : null}
                     {this.props.material.url.includes("github") ? <GitHub /> : null}
                     {this.props.material.url.includes("bitbucket") ? <BitBucket /> : null}
-                    {this.props.material.url.includes("gitlab") || this.props.material.url.includes("github") || this.props.material.url.includes("bitbuclet") ? null : <Git />}
+                    {this.props.material.url.includes("gitlab") || this.props.material.url.includes("github") || this.props.material.url.includes("bitbucket") ? null : <Git />}
                 </span>
                 <div className="">
                     <div className="git__provider">{(this.props.material).name}</div>

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -55,7 +55,6 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                         isMulti={false}
                         isClearable={false}
                         options={this.props.providers}
-                        // options={this.props.providers}
                         getOptionLabel={option => `${option.name}`}
                         getOptionValue={option => `${option.id}`}
                         value={this.props.material.gitProvider}
@@ -104,7 +103,7 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                             },
                             Control: (props) => {
                                 let value = "";
-                                
+
                                 if (props.hasValue) {
                                     value = props.getValue()[0].url;
                                 }
@@ -112,13 +111,13 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                                 return <components.Control {...props}>
 
                                     {value.includes("github") ? <GitHub className="icon-dim-20 ml-8" /> : null}
-                                    {value.includes("gitlab") ? <GitLab className="icon-dim-20 ml-8"/> : null}
-                                    {value.includes("bitbucket") ? <BitBucket className="icon-dim-20 ml-8"/> : null}
-                                    
-                                    {showGit ?  <Git className="icon-dim-20 ml-8"/> : null }
+                                    {value.includes("gitlab") ? <GitLab className="icon-dim-20 ml-8" /> : null}
+                                    {value.includes("bitbucket") ? <BitBucket className="icon-dim-20 ml-8" /> : null}
+
+                                    {showGit ? <Git className="icon-dim-20 ml-8" /> : null}
                                     {props.children}
                                 </components.Control>
-                            
+
                             },
                         }}
 

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -154,7 +154,7 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                     tabIndex={3}
                     onChange={this.props.handleCheckbox}
                     rootClassName="form__label">
-                    <span className="">Set Checkout Path(*Required If you’re using multiple Git Materials)</span>
+                    <span className="">Set Checkout Path (*Required If you’re using multiple Git Materials)</span>
                 </Checkbox>
                 {this.props.isChecked ?
                     <input className="form__input"

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -23,7 +23,7 @@ export class MaterialView extends Component<MaterialViewProps, {}> {
                 <span className="mr-8">
                     {this.props.material.url.includes("gitlab") ? <GitLab /> : null}
                     {this.props.material.url.includes("github") ? <GitHub /> : null}
-                    {this.props.material.url.includes("bitbuclet") ? <BitBucket /> : null}
+                    {this.props.material.url.includes("bitbucket") ? <BitBucket /> : null}
                     {this.props.material.url.includes("gitlab") || this.props.material.url.includes("github") || this.props.material.url.includes("bitbuclet") ? null : <Git />}
                 </span>
                 <div className="">

--- a/src/components/material/UpdateMaterial.tsx
+++ b/src/components/material/UpdateMaterial.tsx
@@ -125,7 +125,7 @@ export class UpdateMaterial extends Component<UpdateMaterialProps, UpdateMateria
         }, () => {
             if (this.state.isError.url || this.state.isError.gitProvider || this.state.isError.checkoutPath) return;
 
-            this.setState({ isLoading: true });
+            this.setState({ isLoading: true,  isChecked: true });
             let payload = {
                 appId: this.props.appId,
                 material: {

--- a/src/components/material/UpdateMaterial.tsx
+++ b/src/components/material/UpdateMaterial.tsx
@@ -29,6 +29,7 @@ export class UpdateMaterial extends Component<UpdateMaterialProps, UpdateMateria
                 active: this.props.material.active,
             },
             isCollapsed: true,
+            isChecked: false,
             isLoading: false,
             isError: {
                 gitProvider: undefined,
@@ -42,6 +43,8 @@ export class UpdateMaterial extends Component<UpdateMaterialProps, UpdateMateria
         this.toggleCollapse = this.toggleCollapse.bind(this);
         this.save = this.save.bind(this);
         this.cancel = this.cancel.bind(this);
+        this.handleCheckbox = this.handleCheckbox.bind(this);
+
     }
 
     componentDidUpdate(prevProps, prevState) {
@@ -59,6 +62,12 @@ export class UpdateMaterial extends Component<UpdateMaterialProps, UpdateMateria
                 isLoading: false,
             })
         }
+    }
+
+    handleCheckbox(event): void {
+        this.setState({
+            isChecked: !this.state.isChecked
+        });
     }
 
     handleProviderChange(selected) {
@@ -160,9 +169,11 @@ export class UpdateMaterial extends Component<UpdateMaterialProps, UpdateMateria
             material={this.state.material}
             isError={this.state.isError}
             isCollapsed={this.state.isCollapsed}
+            isChecked={ this.state.isCollapsed}
             isLoading={this.state.isLoading}
             isMultiGit={this.props.isMultiGit}
             providers={this.props.providers}
+            handleCheckbox= {this.handleCheckbox}
             handleProviderChange={this.handleProviderChange}
             handleUrlChange={this.handleUrlChange}
             handlePathChange={this.handlePathChange}

--- a/src/components/material/UpdateMaterial.tsx
+++ b/src/components/material/UpdateMaterial.tsx
@@ -29,7 +29,7 @@ export class UpdateMaterial extends Component<UpdateMaterialProps, UpdateMateria
                 active: this.props.material.active,
             },
             isCollapsed: true,
-            isChecked: false,
+            isChecked: true,
             isLoading: false,
             isError: {
                 gitProvider: undefined,
@@ -169,7 +169,7 @@ export class UpdateMaterial extends Component<UpdateMaterialProps, UpdateMateria
             material={this.state.material}
             isError={this.state.isError}
             isCollapsed={this.state.isCollapsed}
-            isChecked={ this.state.isCollapsed}
+            isChecked={ this.state.isChecked}
             isLoading={this.state.isLoading}
             isMultiGit={this.props.isMultiGit}
             providers={this.props.providers}

--- a/src/components/material/material.css
+++ b/src/components/material/material.css
@@ -10,7 +10,7 @@
 .artifact-collapsed {
     display: flex;
     margin-bottom: 12px;
-    padding: 15px 24px;
+    padding: 15px 20px;
     border: solid 1px #d6dbdf;
     align-items: center;
     cursor: pointer;

--- a/src/components/material/material.css
+++ b/src/components/material/material.css
@@ -58,3 +58,12 @@
     border: solid 1px var(--N200);
     background-color: var(--white);
 }
+
+.form-row__material {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    grid-column-gap: 16px;
+   
+      
+    
+}

--- a/src/components/material/material.css
+++ b/src/components/material/material.css
@@ -22,7 +22,7 @@
 }
 
 .git__icon {
-    background-image: url('../../assets/icons/git/git.svg');
+  /*  background-image: url('../../assets/icons/git/git.svg');*/
     margin-right: 10px;
     display: inline-block;
     width: 20px;

--- a/src/components/material/material.types.ts
+++ b/src/components/material/material.types.ts
@@ -61,3 +61,7 @@ export interface MaterialViewProps {
     save: (event) => void;
     cancel: (event) => void;
 }
+
+export interface MaterialViewState{
+    isChecked: boolean
+}

--- a/src/components/material/material.types.ts
+++ b/src/components/material/material.types.ts
@@ -30,6 +30,7 @@ export interface CreateMaterialState {
         active: boolean;
     };
     isCollapsed: boolean;
+    isChecked: boolean;
     isLoading: boolean;
     isError: MaterialError;
 }
@@ -43,25 +44,24 @@ interface MaterialError {
 export interface UpdateMaterialState {
     material: GitMaterialType;
     isCollapsed: boolean;
+    isChecked: boolean;
     isLoading: boolean;
     isError: MaterialError;
 }
 
 export interface MaterialViewProps {
     isMultiGit: boolean;
+    isChecked: boolean;
     material: GitMaterialType;
     isCollapsed: boolean;
     isLoading: boolean;
     isError: MaterialError;
     providers: any[];
     handleProviderChange: (selected) => void;
+    handleCheckbox: (event) => void;
     handleUrlChange: (event) => void;
     handlePathChange: (event) => void;
     toggleCollapse: (event) => void;
     save: (event) => void;
     cancel: (event) => void;
-}
-
-export interface MaterialViewState{
-    isChecked: boolean
 }

--- a/src/components/workflowEditor/workflowEditor.css
+++ b/src/components/workflowEditor/workflowEditor.css
@@ -2,7 +2,7 @@
     min-height: calc(100vh - 128px);
     overflow: visible;
     min-width: 840px;
-    padding: 12px 24px;
+    padding: 24px;
     margin-bottom: 220px;
 }
 

--- a/src/config/constants.tsx
+++ b/src/config/constants.tsx
@@ -176,7 +176,8 @@ export const DOCUMENTATION = {
     APP_CREATE_WORKFLOW: 'https://docs.devtron.ai/creating-application/workflow',
 
     CHART_LIST: 'https://docs.devtron.ai/user-guide/deploy-chart/overview-of-charts',
-
+    
+    GLOBAL_CONFIG_GITOPS: 'https://docs.devtron.ai/user-guide/global-configurations/gitops',
     GLOBAL_CONFIG_GIT: 'https://docs.devtron.ai/user-guide/global-configurations/git-accounts',
     GLOBAL_CONFIG_DOCKER: 'https://docs.devtron.ai/user-guide/global-configurations/docker-registries',
     GLOBAL_CONFIG_CLUSTER: 'https://docs.devtron.ai/user-guide/global-configurations/cluster-and-environments',

--- a/src/css/forms.scss
+++ b/src/css/forms.scss
@@ -153,7 +153,6 @@ p.sentence-case:first-letter {
     background: var(--window-bg);
     display: grid;
     grid-template-columns: 100%;
-    grid-row-gap: 16px;
     border-radius: 4px;
     padding: 16px;
     margin-bottom: 16px;

--- a/src/css/forms.scss
+++ b/src/css/forms.scss
@@ -1,7 +1,7 @@
 .form__app-compose {
     width: 800px;
     margin: 0 auto;
-    padding: 12px 24px;
+    padding: 24px;
     margin-bottom: 64px;
 }
 
@@ -11,7 +11,7 @@
     line-height: 1.4;
     color: var(--N900);
     margin: 0px;
-    margin-bottom: 8px;
+    margin-bottom: 4px;
 }
 
 .form__title--mb-24 {
@@ -22,7 +22,7 @@
     font-size: 12px;
     line-height: 1.67;
     color: var(--N600);
-    margin-bottom: 18px;
+    margin-bottom: 16px;
 }
 
 .form__section {

--- a/src/css/forms.scss
+++ b/src/css/forms.scss
@@ -1,5 +1,5 @@
 .form__app-compose {
-    width: 800px;
+    width: 1012px;
     margin: 0 auto;
     padding: 24px;
     margin-bottom: 64px;

--- a/src/css/forms.scss
+++ b/src/css/forms.scss
@@ -6,7 +6,7 @@
 }
 
 .form__title {
-    font-size: 20px;
+    font-size: 18px;
     font-weight: 400;
     line-height: 1.4;
     color: var(--N900);


### PR DESCRIPTION
# Description

Simplifying Git Material and Docker Build Config in `Applications >App configurations`
1.  Earlier all the fields in `Git Material` and `Docker Build Configuration`  were in the exposed state. It was difficult for the users to get to know about the required fields.
2. Recently we allowed directing the user's attention to a particular field in the form rather than looking at everything.

# Motivation

Please give examples of your use case, e.g. when would you use this.

This will be helpful while creating an application in the `App Configuration` tab. Users will not be required to brainstorm in any non-required field.

# Proposal

How do you think this should be implemented?

1. Exposing only basic Fields in front.
2. Grouped fields with appropriate headers.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Save single Git Material (create)
- [x] Save multiple Git Material (create)
- [x] Save  single Git Material (update)
- [x] Save Edit multiple Git Material (update)
- [x] Save Git Material - Empty State 
- [x] Save Docker Build Configuration 
- [x] Save Docker Build Configuration-Empty State


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).


