### PR TITLE
Added handling of k8sVersion format

### DIFF
--- a/src/components/app/details/appDetails/utils.tsx
+++ b/src/components/app/details/appDetails/utils.tsx
@@ -215,6 +215,7 @@ export function getCalendarValue(startDateStr: string, endDateStr: string): stri
 
 function getK8sVersionArr(k8sVersion: string): number[] {
     let startIndex: number = k8sVersion.indexOf("v");
+    if (startIndex < 0) startIndex = 0;
     let endIndex: number = k8sVersion.indexOf("-");
     if (endIndex < 0) endIndex = k8sVersion.length - 1;
     let versionStr: string = k8sVersion.substring(startIndex + 1, endIndex);

--- a/src/components/app/details/appDetails/utils.tsx
+++ b/src/components/app/details/appDetails/utils.tsx
@@ -215,11 +215,9 @@ export function getCalendarValue(startDateStr: string, endDateStr: string): stri
 
 function getK8sVersionArr(k8sVersion: string): number[] {
     let startIndex: number = k8sVersion.indexOf("v");
-    if (startIndex < 0) startIndex = 0;
     let endIndex: number = k8sVersion.indexOf("-");
-    if (endIndex < 0) endIndex = k8sVersion.length - 1;
+    if (endIndex < 0) endIndex = k8sVersion.length;
     let versionStr: string = k8sVersion.substring(startIndex + 1, endIndex);
-
     let version: string[] = (versionStr).split(".");
     let versionNum: number[] = version.map((item) => Number(item));
     return versionNum;

--- a/src/components/app/details/appDetails/utils.tsx
+++ b/src/components/app/details/appDetails/utils.tsx
@@ -214,13 +214,12 @@ export function getCalendarValue(startDateStr: string, endDateStr: string): stri
 }
 
 function getK8sVersionArr(k8sVersion: string): number[] {
-    let startIndex: number = k8sVersion.indexOf("v");
-    let endIndex: number = k8sVersion.indexOf("-");
-    if (endIndex < 0) endIndex = k8sVersion.length;
-    let versionStr: string = k8sVersion.substring(startIndex + 1, endIndex);
-    let version: string[] = (versionStr).split(".");
-    let versionNum: number[] = version.map((item) => Number(item));
-    return versionNum;
+    let k8sVersionMod = k8sVersion;
+    if (k8sVersionMod.includes("v")) {
+        k8sVersionMod = k8sVersion.split("v")[1];
+    }
+    let version: string[] = k8sVersionMod.split(".");
+    return [Number(version[0]), Number(version[1])];
 }
 
 export function isK8sVersionValid(k8sVersion: string): boolean {

--- a/src/components/app/details/appDetails/utils.tsx
+++ b/src/components/app/details/appDetails/utils.tsx
@@ -213,9 +213,14 @@ export function getCalendarValue(startDateStr: string, endDateStr: string): stri
     return str;
 }
 
-function getK8sVersionArr(k8sVersion): number[] {
-    let version: string[] = (k8sVersion.split("v")[1]).split(".");
-    let versionNum: number[] = version.map(item => Number(item));
+function getK8sVersionArr(k8sVersion: string): number[] {
+    let startIndex: number = k8sVersion.indexOf("v");
+    let endIndex: number = k8sVersion.indexOf("-");
+    if (endIndex < 0) endIndex = k8sVersion.length - 1;
+    let versionStr: string = k8sVersion.substring(startIndex + 1, endIndex);
+
+    let version: string[] = (versionStr).split(".");
+    let versionNum: number[] = version.map((item) => parseInt(item));
     return versionNum;
 }
 
@@ -228,7 +233,7 @@ export function isK8sVersionValid(k8sVersion: string): boolean {
         }, 0)
         if (isNaN(sum)) return false;
     } catch (error) {
-        return false
+        return false;
     }
     return true;
 }

--- a/src/components/app/details/appDetails/utils.tsx
+++ b/src/components/app/details/appDetails/utils.tsx
@@ -220,7 +220,7 @@ function getK8sVersionArr(k8sVersion: string): number[] {
     let versionStr: string = k8sVersion.substring(startIndex + 1, endIndex);
 
     let version: string[] = (versionStr).split(".");
-    let versionNum: number[] = version.map((item) => parseInt(item));
+    let versionNum: number[] = version.map((item) => Number(item));
     return versionNum;
 }
 


### PR DESCRIPTION
# Description

Parsing of k8sVersion="v1.15.12-eks-31566f" was not supported. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Test the grafana url of the following graphs:
App details
- [x] CPU 
- [x] RAM

Graphs Modal
- [x] CPU 
- [x] RAM

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


