### PR TITLE
bug on docker repo

### DIFF
--- a/src/components/ciConfig/CIConfig.tsx
+++ b/src/components/ciConfig/CIConfig.tsx
@@ -89,8 +89,7 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
                 }
             },
             repository_name: {
-                required: true,
-                
+                required: false,
             }
 
         }, onValidation);


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

1. Currently While configuring Docker Build Config (/app/<id>/edit/docker-build-config),  validation prompt that the Docker repository is a required field.
2. fixed: Docker repository field be optional so that a new repo can be created if it is left blank. 

Fixes # (issue)
https://github.com/devtron-labs/devtron/issues/392

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
-  [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x]  Save  =while keeping `Docker Repository` blank


