### PR TITLE
Handling subpath and file permission on configmap, secrets and env overrides for chart version 3.9.0 and below

### DIFF
--- a/src/components/EnvironmentOverride/SecretOverrides.tsx
+++ b/src/components/EnvironmentOverride/SecretOverrides.tsx
@@ -3,7 +3,7 @@ import { deleteSecret, overRideSecret, unlockEnvSecret } from './service'
 import { getEnvironmentSecrets, } from '../../services/service';
 import { useParams } from 'react-router';
 import { ListComponent, Override } from './ConfigMapOverrides'
-import { mapByKey, showError, Pencil, not, ConfirmationDialog, useAsync, Select, RadioGroup, Info, CustomInput, Checkbox, CHECKBOX_VALUE } from '../common'
+import { mapByKey, showError, Pencil, not, ConfirmationDialog, useAsync, Select, RadioGroup, Info, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget } from '../common'
 import { SecretForm } from '../secrets/Secret'
 import { KeyValueInput, useKeyValueYaml } from '../configMaps/ConfigMap'
 import { toast } from 'react-toastify';
@@ -189,6 +189,7 @@ export function OverrideSecretForm({ name, appChartRef, toggleCollapse }) {
     const { yaml, handleYamlChange, error } = useKeyValueYaml(state.duplicate || [], setKeyValueArray, PATTERNS.CONFIG_MAP_AND_SECRET_KEY, `Key must consist of alphanumeric characters, '.', '-' and '_'`)
     const [yamlMode, toggleYamlMode] = useState(true)
     const [isFilePermissionChecked, setIsFilePermissionChecked] = useState(!!filePermission)
+    const isChartVersion309OrBelow = appChartRef && isVersionLessThanOrEqualToTarget(appChartRef.version, [3, 9]);
 
     function setKeyValueArray(arr) {
         tempArr.current = arr
@@ -261,7 +262,7 @@ export function OverrideSecretForm({ name, appChartRef, toggleCollapse }) {
             return
         }
 
-        if (type === 'volume' && isFilePermissionChecked) {
+        if (type === 'volume' && isFilePermissionChecked && !isChartVersion309OrBelow) {
             if (!state.filePermission.value) {
                 dispatch({ type: 'filePermission', value: { value: state.filePermission.value, error: 'This is a required field' } })
                 return
@@ -328,10 +329,10 @@ export function OverrideSecretForm({ name, appChartRef, toggleCollapse }) {
             }
             if (type === 'volume') {
                 payload['mountPath'] = state.mountPath;
-                if (externalType !== "KubernetesSecret") {
+                if (externalType !== "KubernetesSecret" && !isChartVersion309OrBelow) {
                     payload['subPath'] = state.subPath;
                 }
-                if (isFilePermissionChecked) {
+                if (isFilePermissionChecked && !isChartVersion309OrBelow) {
                     payload['filePermission'] = state.filePermission.value.length == 3 ? `0${state.filePermission.value}` : `${state.filePermission.value}`;
                 }
             }
@@ -480,8 +481,8 @@ export function OverrideSecretForm({ name, appChartRef, toggleCollapse }) {
                 </div>}
             {externalType !== "KubernetesSecret" && type === "volume" && <Checkbox isChecked={state.subPath}
                 onClick={(e) => { e.stopPropagation(); }}
-                disabled={!state.duplicate}
-                rootClassName="form__checkbox-label--ignore-cache"
+                disabled={!state.duplicate || isChartVersion309OrBelow}
+                rootClassName=""
                 value={CHECKBOX_VALUE.CHECKED}
                 onChange={(e) => { dispatch({ type: 'subPath', value: !state.subPath }) }}>
                 <span className="mr-5">
@@ -490,27 +491,38 @@ export function OverrideSecretForm({ name, appChartRef, toggleCollapse }) {
                         subPath
                     </a>for volume mount)<br></br>
                     {state.subPath ? <span className="mb-0 cn-5 fs-11">Keys will be used as filename for subpath</span> : null}
+                    {isChartVersion309OrBelow ? <span className="fs-12 fw-5">
+                        <span className="cr-5">Supported for Chart Versions 3.10 and above.</span>
+                        <span className="cn-7 ml-5">Learn more about </span>
+                        <a href="https://docs.devtron.ai/user-guide/creating-application/deployment-template" rel="noreferrer noopener" target="_blank">Deployment Template &gt; Chart Version</a>
+                    </span> : null}
                 </span>
             </Checkbox>}
             {type === "volume" && <div className="mb-16">
                 <Checkbox isChecked={isFilePermissionChecked}
                     onClick={(e) => { e.stopPropagation() }}
-                    disabled={!state.duplicate}
-                    rootClassName="form__checkbox-label--ignore-cache"
+                    disabled={!state.duplicate || isChartVersion309OrBelow}
+                    rootClassName=""
                     value={CHECKBOX_VALUE.CHECKED}
                     onChange={(e) => { setIsFilePermissionChecked(!isFilePermissionChecked) }}>
                     <span className="mr-5"> Set File Permission (same as
                         <a href="https://kubernetes.io/docs/concepts/configuration/secret/#secret-files-permissions" className="ml-5 mr-5 anchor" target="_blank" rel="noopener noreferer">
                             defaultMode
                         </a>
-                     for secrets in kubernetes)</span>
+                     for secrets in kubernetes)<br></br>
+                        {isChartVersion309OrBelow ? <span className="fs-12 fw-5">
+                            <span className="cr-5">Supported for Chart Versions 3.10 and above.</span>
+                            <span className="cn-7 ml-5">Learn more about </span>
+                            <a href="https://docs.devtron.ai/user-guide/creating-application/deployment-template" rel="noreferrer noopener" target="_blank">Deployment Template &gt; Chart Version</a>
+                        </span> : null}
+                    </span>
                 </Checkbox>
             </div>}
             {type === "volume" && isFilePermissionChecked ? <div className="mb-16">
                 <CustomInput value={state.filePermission.value}
                     autoComplete="off"
                     label={""}
-                    disabled={!state.duplicate}
+                    disabled={!state.duplicate || isChartVersion309OrBelow}
                     placeholder={"eg. 0400 or 400"}
                     error={state.filePermission.error}
                     onChange={(e) => { dispatch({ type: 'filePermission', value: { value: e.target.value, error: "" } }) }} />
@@ -615,8 +627,8 @@ export function OverrideSecretForm({ name, appChartRef, toggleCollapse }) {
                 <button className="cta" type="submit" disabled={state.locked}>{state.submitLoading ? <Progressing /> : 'Save'}</button>
             </div>}
         </form>
-            : <SecretForm
-                id={id}
+            : <SecretForm id={id}
+                appChartRef={appChartRef}
                 appId={Number(appId)}
                 name={name}
                 external={external}

--- a/src/components/EnvironmentOverride/SecretOverrides.tsx
+++ b/src/components/EnvironmentOverride/SecretOverrides.tsx
@@ -1,19 +1,20 @@
 import React, { useEffect, useReducer, useRef, useState } from 'react'
 import { deleteSecret, overRideSecret, unlockEnvSecret } from './service'
 import { getEnvironmentSecrets, } from '../../services/service';
-import { useParams } from 'react-router'
+import { useParams } from 'react-router';
 import { ListComponent, Override } from './ConfigMapOverrides'
 import { mapByKey, showError, Pencil, not, ConfirmationDialog, useAsync, Select, RadioGroup, Info, CustomInput, Checkbox, CHECKBOX_VALUE } from '../common'
 import { SecretForm } from '../secrets/Secret'
 import { KeyValueInput, useKeyValueYaml } from '../configMaps/ConfigMap'
-import { toast } from 'react-toastify'
-import { Progressing } from '../common'
+import { toast } from 'react-toastify';
+import { Progressing } from '../common';
 import warningIcon from '../../assets/icons/ic-warning.svg'
 import CodeEditor from '../CodeEditor/CodeEditor'
-import YAML from 'yaml'
+import YAML from 'yaml';
 import { PATTERNS } from '../../config';
 import { KeyValueFileInput } from '../util/KeyValueFileInput';
-import './environmentOverride.scss'
+import { getAppChartRef } from '../../services/service';
+import './environmentOverride.scss';
 
 const sampleJSON = [
     {
@@ -54,11 +55,23 @@ function useSecretContext() {
 export default function SecretOverrides({ parentState, setParentState, ...props }) {
     const { appId, envId } = useParams<{ appId, envId }>()
     const [loading, result, error, reload] = useAsync(() => getEnvironmentSecrets(+appId, +envId), [+appId, +envId])
+    const [appChartRef, setAppChartRef] = useState<{ id: number, version: string }>();
+
+    useEffect(() => {
+        async function callGetAppChartRef() {
+            const { result } = await getAppChartRef(appId);
+            setAppChartRef(result);
+        }
+        callGetAppChartRef();
+    }, [appId])
+
     useEffect(() => {
         if (!loading && result) {
             setParentState('loaded')
         }
     }, [loading])
+
+
     if (loading && !result) return null
     if (error) {
         setParentState('failed')
@@ -75,14 +88,14 @@ export default function SecretOverrides({ parentState, setParentState, ...props 
             <label htmlFor="" className="form__label bold">Secrets</label>
             <SecretContext.Provider value={{ secrets, id, reload }}>
                 {secrets && Array.from(secrets).sort((a, b) => a[0].localeCompare(b[0])).map(([name, { data, defaultData, global, ...rest }]) => {
-                    return <ListComponent key={name || Math.random().toString(36).substr(2, 5)} name={name} type="secret" label={global ? data ? 'modified' : '' : 'env'} />
+                    return <ListComponent key={name || Math.random().toString(36).substr(2, 5)} appChartRef={appChartRef} name={name} type="secret" label={global ? data ? 'modified' : '' : 'env'} />
                 })}
             </SecretContext.Provider>
         </section>
     )
 }
 
-export function OverrideSecretForm({ name, toggleCollapse }) {
+export function OverrideSecretForm({ name, appChartRef, toggleCollapse }) {
     const { secrets, id, reload } = useSecretContext()
     const { data = null, defaultData = null, type = "environment", external = false, mountPath = "", defaultMountPath = "", global: isGlobal = false, externalType = "", defaultPermissionNumber = "", filePermission = "", subPath = false } = secrets.has(name) ? secrets.get(name) : { type: 'environment', mountPath: '', externalType: "" }
     const { appId, envId } = useParams<{ appId, envId }>()

--- a/src/components/app/details/appDetails/utils.tsx
+++ b/src/components/app/details/appDetails/utils.tsx
@@ -5,7 +5,7 @@ import {
     AggregatedNodes,
     PodMetadatum,
 } from '../../types';
-import { mapByKey } from '../../../common';
+import { getVersionArr, isVersionLessThanOrEqualToTarget, mapByKey } from '../../../common';
 import React, { Component } from 'react';
 import { components } from 'react-select';
 import { ReactComponent as Bug } from '../../../../assets/icons/ic-bug.svg';
@@ -213,19 +213,10 @@ export function getCalendarValue(startDateStr: string, endDateStr: string): stri
     return str;
 }
 
-function getK8sVersionArr(k8sVersion: string): number[] {
-    let k8sVersionMod = k8sVersion;
-    if (k8sVersionMod.includes("v")) {
-        k8sVersionMod = k8sVersion.split("v")[1];
-    }
-    let version: string[] = k8sVersionMod.split(".");
-    return [Number(version[0]), Number(version[1])];
-}
-
 export function isK8sVersionValid(k8sVersion: string): boolean {
     if (!k8sVersion) return false;
     try {
-        let versionNum = getK8sVersionArr(k8sVersion);
+        let versionNum = getVersionArr(k8sVersion);
         let sum = versionNum.reduce((sum, item) => {
             return sum += item;
         }, 0)
@@ -239,17 +230,7 @@ export function isK8sVersionValid(k8sVersion: string): boolean {
 export function isK8sVersion115OrBelow(k8sVersion: string): boolean {
     //Comparing with v1.15.xxx
     let target = [1, 15];
-    let versionNum = getK8sVersionArr(k8sVersion);
-    for (let i = 0; i < target.length; i++) {
-        if (versionNum[i] === target[i]) {
-            if (i === target.length - 1) return true;
-            continue
-        }
-        else if (versionNum[i] < target[i]) {
-            return true;
-        }
-    }
-    return false;
+    return isVersionLessThanOrEqualToTarget(k8sVersion, target);
 }
 
 export interface AppInfo {

--- a/src/components/common/helpers/compareVersion.ts
+++ b/src/components/common/helpers/compareVersion.ts
@@ -1,0 +1,24 @@
+
+export function getVersionArr(version: string): number[] {
+    let versionMod = version;
+    if (versionMod.includes("v")) {
+        versionMod = version.split("v")[1];
+    }
+    let versionStr: string[] = versionMod.split(".");
+    return [Number(versionStr[0]), Number(versionStr[1])];
+}
+
+export function isVersionLessThanOrEqualToTarget(version: string, target: number[]): boolean {
+    //Comparing with v1.15.xxx
+    let versionNum = getVersionArr(version);
+    for (let i = 0; i < target.length; i++) {
+        if (versionNum[i] === target[i]) {
+            if (i === target.length - 1) return true;
+            continue
+        }
+        else if (versionNum[i] < target[i]) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -45,3 +45,4 @@ export * from './security/ScanVulnerabilitiesTable';
 export * from './security/ScanDetailsModal';
 export * from './DatePickers/Calender';
 export * from './DatePickers/DayPickerRangeController';
+export * from './helpers/compareVersion';

--- a/src/components/deploymentConfig/DeploymentConfig.tsx
+++ b/src/components/deploymentConfig/DeploymentConfig.tsx
@@ -1,14 +1,15 @@
 import React, { useEffect, useState } from 'react';
-import { getDeploymentTemplate, updateDeploymentTemplate, saveDeploymentTemplate, getChartReferences, toggleAppMetrics as updateAppMetrics } from './service';
+import { getDeploymentTemplate, updateDeploymentTemplate, saveDeploymentTemplate, toggleAppMetrics as updateAppMetrics } from './service';
+import { getChartReferences} from '../../services/service';
 import { Toggle, Progressing, ConfirmationDialog, useJsonYaml } from '../common';
 import { useEffectAfterMount, showError } from '../common/helpers/Helpers'
 import { useParams } from 'react-router'
-import './deploymentConfig.scss';
 import { toast } from 'react-toastify';
 import CodeEditor from '../CodeEditor/CodeEditor'
 import warningIcon from '../../assets/icons/ic-info-filled.svg'
 import ReactSelect from 'react-select';
-import {  DOCUMENTATION } from '../../config';
+import { DOCUMENTATION } from '../../config';
+import './deploymentConfig.scss';
 
 export function OptApplicationMetrics({ currentVersion, minimumSupportedVersion, onChange, opted, focus = false, loading, className = "", disabled = false }) {
     return <div id="opt-metrics" className={`flex column left white-card ${focus ? 'animate-background' : ''} ${className}`}>
@@ -66,12 +67,12 @@ function DeploymentConfigForm({ respondOnSuccess }) {
         // initialise()
     }, [selectedChart])
 
-    const { appId } = useParams()
+    const { appId } = useParams<{ appId }>()
 
     async function saveAppMetrics(appMetricsEnabled) {
         try {
             setAppMetricsLoading(true)
-            const { result } = await updateAppMetrics(+appId, {
+            await updateAppMetrics(+appId, {
                 isAppMetricsEnabled: appMetricsEnabled
             })
             toast.success(`Successfully ${appMetricsEnabled ? 'subscribed' : 'unsubscribed'}.`, { autoClose: null })
@@ -199,8 +200,7 @@ function DeploymentConfigForm({ respondOnSuccess }) {
                         value={template ? JSON.stringify(template, null, 2) : ""}
                         onChange={resp => { setTempFormData(resp) }}
                         mode="yaml"
-                        loading={chartConfigLoading}
-                    >
+                        loading={chartConfigLoading}>
                         <CodeEditor.Header>
                             <CodeEditor.LanguageChanger />
                             <CodeEditor.ValidationError />
@@ -221,7 +221,7 @@ function DeploymentConfigForm({ respondOnSuccess }) {
                     <button type="button" className="cta" onClick={e => save()}>{loading ? <Progressing /> : chartConfig.id ? 'Update' : 'Save'}</button>
                 </ConfirmationDialog.ButtonGroup>
             </ConfirmationDialog>}
-            {chartVersions && selectedChart && appMetricsEnvironmentVariableEnabled && 
+            {chartVersions && selectedChart && appMetricsEnvironmentVariableEnabled &&
                 <OptApplicationMetrics
                     currentVersion={selectedChart?.version}
                     minimumSupportedVersion={"3.7.0"}

--- a/src/components/deploymentConfig/service.tsx
+++ b/src/components/deploymentConfig/service.tsx
@@ -18,11 +18,6 @@ export const saveDeploymentTemplate = (request) => {
     return post(URL, request)
 }
 
-export const getChartReferences = (appId: number) => {
-    const URL = `${Routes.CHART_REFERENCES_MIN}/${appId}`;
-    return get(URL);
-}
-
 export function getConfigmap(appId: number) {
     const URL = `${Routes.APP_CONFIG_MAP_GET}/${appId}`;
     return get(URL).then((response) => {
@@ -53,7 +48,7 @@ export function updateConfigmap(appId: number, request: ConfigMapRequest) {
     })
 }
 
-export function toggleAppMetrics(appId, payload){
+export function toggleAppMetrics(appId, payload) {
     return post(`app/template/metrics/${appId}`, payload)
 }
 

--- a/src/components/secrets/Secret.tsx
+++ b/src/components/secrets/Secret.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react'
 import { Progressing, showError, Select, RadioGroup, not, Info, ToastBody, CustomInput, Checkbox, CHECKBOX_VALUE } from '../common'
 import { useParams } from 'react-router'
 import { updateSecret, deleteSecret, getSecretKeys } from '../secrets/service';
+import { getAppChartRef } from '../../services/service';
 import { overRideSecret, deleteSecret as deleteEnvironmentSecret, unlockEnvSecret } from '../EnvironmentOverride/service'
 import { toast } from 'react-toastify';
 import { KeyValueInput, useKeyValueYaml, validateKeyValuePair } from '../configMaps/ConfigMap'
@@ -40,8 +41,10 @@ let dataHeader = <div>
 const sample = YAML.stringify(sampleJSON);
 
 const Secret = ({ respondOnSuccess, ...props }) => {
+    const [appChartRef, setAppChartRef] = useState<{ id: number, version: string }>();
     const [list, setList] = useState(null)
-    const [loading, setLoading] = useState(true)
+    const [secretLoading, setSecretLoading] = useState(true)
+
     useEffect(() => {
         initialise()
     }, [])
@@ -49,7 +52,8 @@ const Secret = ({ respondOnSuccess, ...props }) => {
 
     async function initialise() {
         try {
-            const { result } = await getSecretList(appId)
+            const appChartRefRes = await getAppChartRef(appId);
+            const { result } = await getSecretList(appId);
             if (Array.isArray(result.configData)) {
                 result.configData = result.configData.map(config => {
                     if (config.data) {
@@ -58,14 +62,14 @@ const Secret = ({ respondOnSuccess, ...props }) => {
                     return config
                 })
             }
-            setList(result)
-            { console.log(result) }
+            setAppChartRef(appChartRefRes.result);
+            setList(result);
         }
         catch (err) {
             showError(err)
         }
         finally {
-            setLoading(false)
+            setSecretLoading(false)
         }
     }
 
@@ -98,24 +102,31 @@ const Secret = ({ respondOnSuccess, ...props }) => {
     function decode(data) {
         return Object.keys(data).map(m => ({ key: m, value: data[m] ? atob(data[m]) : data[m] })).reduce((agg, curr) => { agg[curr.key] = curr.value; return agg }, {})
     }
-    if (loading) return <Progressing pageLoader />
+    if (secretLoading) return <Progressing pageLoader />
     return (
         <div className="form__app-compose">
             <h1 className="form__title form__title--artifacts">Secrets</h1>
             <p className="form__subtitle form__subtitle--artifacts">A Secret is an object that contains sensitive data such as passwords, OAuth tokens, and SSH keys.
             <a className="learn-more__href" rel="noreferer noopener" href={DOCUMENTATION.APP_CREATE_SECRET} target="blank"> Learn more about Secrets</a></p>
-            {list && <CollapsedSecretForm appId={appId} id={list.id || 0} title="Add Secret" update={update} initialise={initialise} />}
-            {list && Array.isArray(list.configData) && list.configData.filter(cs => cs).map((cs, idx) => <CollapsedSecretForm key={cs.name} {...cs} appId={appId} id={list.id} update={update} index={idx} initialise={initialise} />)}
+            <CollapsedSecretForm appId={appId} id={list.id || 0} title="Add Secret" appChartRef={appChartRef} update={update} initialise={initialise} />
+            {list && Array.isArray(list.configData) && list.configData.filter(cs => cs).map((cs, idx) => <CollapsedSecretForm key={cs.name}
+                {...cs}
+                appChartRef={appChartRef}
+                appId={appId} id={list.id}
+                update={update}
+                index={idx}
+                initialise={initialise} />)}
         </div>
     )
 }
 
 
-export function CollapsedSecretForm({ title = "", roleARN = "", secretData = [], mountPath = "", name = "", type = "environment", external = false, data = null, id = null, appId, update = null, index = null, initialise = null, externalType = "", filePermission = "", subPath = false, ...rest }) {
+export function CollapsedSecretForm({ title = "", roleARN = "", appChartRef, secretData = [], mountPath = "", name = "", type = "environment", external = false, data = null, id = null, appId, update = null, index = null, initialise = null, externalType = "", filePermission = "", subPath = false, ...rest }) {
     const [collapsed, toggleCollapse] = useState(true)
     return <section className="mb-12 br-8 bcn-0 bw-1 en-2 pl-20 pr-20 pt-19 pb-19">{collapsed
         ? <ListComponent title={name || title} onClick={e => toggleCollapse(!collapsed)} icon={title ? addIcon : keyIcon} collapsible={!title} className={title ? 'fw-5 cb-5 fs-14' : 'fw-5 cn-9 fs-14'} />
         : <SecretForm name={name}
+            appChartRef={appChartRef}
             secretData={secretData}
             mountPath={mountPath}
             roleARN={roleARN}
@@ -160,6 +171,7 @@ export function ListComponent({ icon = "", title, subtitle = "", onClick, classN
 }
 interface SecretFormProps {
     id: number;
+    appChartRef: { id: number; version: string };
     appId: number;
     roleARN: string;
     name: string;
@@ -188,7 +200,7 @@ export const SecretForm: React.FC<SecretFormProps> = function (props) {
     const [loading, setLoading] = useState(false)
     const [secretMode, toggleSecretMode] = useState(props.isUpdate)
     const [externalType, setExternalType] = useState(props.externalType)
-    const { envId } = useParams<{ envId }>()
+    const { appId, envId } = useParams<{ appId, envId }>()
     const [yamlMode, toggleYamlMode] = useState(true)
     const { yaml, handleYamlChange, error } = useKeyValueYaml(externalValues, setKeyValueArray, PATTERNS.CONFIG_MAP_AND_SECRET_KEY, `Key must consist of alphanumeric characters, '.', '-' and '_'`)
     const { yaml: lockedYaml } = useKeyValueYaml(externalValues.map(({ k, v }) => ({ k, v: Array(8).fill("*").join("") })), setKeyValueArray, PATTERNS.CONFIG_MAP_AND_SECRET_KEY, `Key must consist of alphanumeric characters, '.', '-' and '_'`)
@@ -287,7 +299,6 @@ export const SecretForm: React.FC<SecretFormProps> = function (props) {
                 toast.success('Successfully deleted')
                 props.update(props.index, null)
             }
-
         }
         catch (err) {
             showError(err)
@@ -574,7 +585,7 @@ export const SecretForm: React.FC<SecretFormProps> = function (props) {
                 rootClassName=""
                 value={CHECKBOX_VALUE.CHECKED}
                 onChange={(e) => setIsFilePermissionChecked(!isFilePermissionChecked)}>
-                 <span className="mr-5"> Set File Permission (same as
+                <span className="mr-5"> Set File Permission (same as
                     <a href="https://kubernetes.io/docs/concepts/configuration/secret/#secret-files-permissions" className="ml-5 mr-5 anchor" target="_blank" rel="noopener noreferer">
                         defaultMode
                     </a>

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -271,6 +271,23 @@ export function isGitopsConfigured(): Promise<ResponseType> {
     return get(URL);
 }
 
+export function getChartReferences(appId: number): Promise<ResponseType> {
+    const URL = `${Routes.CHART_REFERENCES_MIN}/${appId}`;
+    return get(URL);
+}
+
+export function getAppChartRef(appId: number): Promise<ResponseType> {
+    return getChartReferences(appId).then((response) => {
+        const { result: { chartRefs, latestAppChartRef } } = response;
+        let selectedChartId = latestAppChartRef;
+        let chart = chartRefs.find(chart => selectedChartId === chart.id);
+        return {
+            code: response.code,
+            status: response.status,
+            result: chart
+        }
+    })
+}
 export function getAppCheckList(): Promise<any> {
     const URL = `${Routes.APP_CHECKLIST}`;
     return get(URL);
@@ -284,4 +301,4 @@ export function getAppCheckList(): Promise<any> {
     //         }
     //     })
     // })
-} 
+}


### PR DESCRIPTION
# Description
Subpath and file permission were not required for chart versions 3.9.0 and below.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
Configmap, Secrets and Environment Overrides have been tested for:

- [x] Payload
- [x] API Response
- [x] UI Elements

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


