### PR TITLE
Typeahead support multiple values; 2 dropdowns on deploy chart changed to typeahead

### DIFF
--- a/src/components/app/ResourceTreeNodes.tsx
+++ b/src/components/app/ResourceTreeNodes.tsx
@@ -711,7 +711,7 @@ const PodPopup: React.FC<{ appName: string, environmentName: string, name: strin
         </span> : ''}
         <span className="flex pod-info__popup-row pod-info__popup-row--red"
             onClick={asyncDeletePod}>
-            <span>Delete {kind}</span>
+            <span>Delete</span>
             <Trash className="icon-dim-20" />
         </span>
     </div>

--- a/src/components/cdPipeline/CDPipeline.tsx
+++ b/src/components/cdPipeline/CDPipeline.tsx
@@ -745,6 +745,7 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
                     <div className="form__label">Deploy to environment</div>
                     <ReactSelect menuPortalTarget={document.getElementById('visible-modal')}
                         closeMenuOnScroll={true}
+                        isDisabled={!!this.props.match.params.cdPipelineId}
                         placeholder="Select Environment"
                         options={this.state.environments}
                         value={selectedEnv}

--- a/src/components/charts/modal/DeployChart.tsx
+++ b/src/components/charts/modal/DeployChart.tsx
@@ -103,8 +103,6 @@ const DeployChart: React.FC<DeployChartProps> = ({
         let projectList = result.map((p) => { return { value: p.id, label: p.name } });
         projectList = projectList.sort((a, b) => sortCallback('label', a, b, true));
         setProjects(projectList);
-        let project = projects.find(p => p.value === teamId);
-        selectProject(project);
     }
 
     const fetchEnvironments = async () => {
@@ -113,8 +111,6 @@ const DeployChart: React.FC<DeployChartProps> = ({
         envList = envList.map((env) => { return { value: env.id, label: env.environment_name, active: env.active } });
         envList = envList.sort((a, b) => sortCallback('label', a, b, true));
         setEnvironments(envList);
-        let environment = envList.find(e => e.value === environmentId);
-        selectEnvironment(environment);
     }
 
     function closeMe(event = null) {
@@ -239,6 +235,20 @@ const DeployChart: React.FC<DeployChartProps> = ({
             })
         }
     }, [chartIdFromDeploymentDetail])
+
+    useEffect(() => {
+        if (environmentId && environments.length) {
+            let environment = environments.find(e => e.value.toString() === environmentId.toString());
+            selectEnvironment(environment);
+        }
+    }, [environmentId, environments])
+
+    useEffect(() => {
+        if (teamId && projects.length) {
+            let project = projects.find(e => e.value.toString() === teamId.toString());
+            selectProject(project);
+        }
+    }, [teamId, projects])
 
     useEffect(() => {
         if (chartValues.id && chartValues.chartVersion) {
@@ -387,7 +397,9 @@ const DeployChart: React.FC<DeployChartProps> = ({
                                     IndicatorSeparator: null,
                                     DropdownIndicator
                                 }}
+                                isDisabled={!!isUpdate}
                                 placeholder="Select Project"
+                                value={selectedProject}
                                 styles={{
                                     ...styles,
                                     ...menuList,
@@ -403,7 +415,9 @@ const DeployChart: React.FC<DeployChartProps> = ({
                                     IndicatorSeparator: null,
                                     DropdownIndicator
                                 }}
+                                isDisabled={!!isUpdate}
                                 placeholder="Select Environment"
+                                value={selectedEnvironment}
                                 styles={{
                                     ...styles,
                                     ...menuList,

--- a/src/components/charts/modal/DeployChart.tsx
+++ b/src/components/charts/modal/DeployChart.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Select, Page, DropdownIcon, Progressing, showError, useJsonYaml, DeleteDialog } from '../../common';
+import { Select, Page, DropdownIcon, Progressing, showError, useJsonYaml, DeleteDialog, sortCallback } from '../../common';
 import { getEnvironmentListMin, getTeamListMin } from '../../../services/service';
 import { toast } from 'react-toastify';
 import { DeployChartProps } from './deployChart.types';
@@ -10,10 +10,12 @@ import { URLS } from '../../../config'
 import { installChart, updateChart, deleteInstalledChart, getChartValuesCategorizedListParsed, getChartValues, getChartVersionsMin, getChartsByKeyword } from '../charts.service'
 import { ChartValuesSelect } from '../util/ChartValueSelect';
 import { getChartValuesURL } from '../charts.helper';
+import { styles, menuList, DropdownIndicator } from '../charts.util';
 import CodeEditor from '../../CodeEditor/CodeEditor'
 import AsyncSelect from 'react-select/async';
 import checkIcon from '../../../assets/icons/appstatus/ic-check.svg'
 import ReactGA from 'react-ga';
+import ReactSelect from 'react-select';
 import './DeployChart.scss';
 
 function mapById(arr) {
@@ -52,14 +54,14 @@ const DeployChart: React.FC<DeployChartProps> = ({
     installedAppVersionId = 0,
     chartValuesFromParent = { id: 0, name: '', chartVersion: '', kind: null, environmentName: "" },
     ...rest }) => {
-    const [teams, setTeams] = useState(new Map())
-    const [environments, setEnvironments] = useState(new Map())
+    const [environments, setEnvironments] = useState([])
+    const [projects, setProjects] = useState([])
     const [loading, setLoading] = useState(false);
     const [selectedVersion, selectVersion] = useState(appStoreVersion)
     const [selectedVersionUpdatePage, setSelectedVersionUpdatePage] = useState(versions.get(selectedVersion))
-    const [selectedTeam, selectTeam] = useState(teamId)
+    const [selectedProject, selectProject] = useState<{ label: string; value: number }>()
     const [chartVersionsData, setChartVersionsData] = useState<{ version: string, id: number }[]>([]);
-    const [selectedEnvironment, selectEnvironment] = useState(environmentId)
+    const [selectedEnvironment, selectEnvironment] = useState<{ label: string; value: number }>(undefined)
     const [appName, setAppName] = useState(originalName)
     const [readmeCollapsed, toggleReadmeCollapsed] = useState(true)
     const [deleting, setDeleting] = useState(false)
@@ -95,20 +97,24 @@ const DeployChart: React.FC<DeployChartProps> = ({
     const [showCodeEditorError, setCodeEditorError] = useState(false);
     const deployChartForm = useRef(null);
     const deployChartEditor = useRef(null);
-    const fetchTeams = async () => {
-        let response = await getTeamListMin()
-        if (response && response.result) {
-            const teams = mapById(response.result)
-            setTeams(teams)
-        }
+
+    const fetchProjects = async () => {
+        let { result } = await getTeamListMin();
+        let projectList = result.map((p) => { return { value: p.id, label: p.name } });
+        projectList = projectList.sort((a, b) => sortCallback('label', a, b, true));
+        setProjects(projectList);
+        let project = projects.find(p => p.value === teamId);
+        selectProject(project);
     }
 
     const fetchEnvironments = async () => {
-        let response = await getEnvironmentListMin()
-        if (response && response.result) {
-            const environments = mapById(response.result)
-            setEnvironments(environments)
-        }
+        let response = await getEnvironmentListMin();
+        let envList = response.result ? response.result : [];
+        envList = envList.map((env) => { return { value: env.id, label: env.environment_name, active: env.active } });
+        envList = envList.sort((a, b) => sortCallback('label', a, b, true));
+        setEnvironments(envList);
+        let environment = envList.find(e => e.value === environmentId);
+        selectEnvironment(environment);
     }
 
     function closeMe(event = null) {
@@ -140,7 +146,7 @@ const DeployChart: React.FC<DeployChartProps> = ({
     }
 
     const deploy = async (e) => {
-        if (!(selectedTeam && selectedEnvironment)) {
+        if (!(selectedProject && selectedEnvironment)) {
             return
         }
         if (!environmentId && !teamId && !appName) {
@@ -171,10 +177,10 @@ const DeployChart: React.FC<DeployChartProps> = ({
             }
             else {
                 let request = {
-                    teamId: selectedTeam,
+                    teamId: selectedProject.value,
                     referenceValueId: chartValues.id,
                     referenceValueKind: chartValues.kind,
-                    environmentId: selectedEnvironment,
+                    environmentId: selectedEnvironment.value,
                     appStoreVersion: selectedVersion,
                     valuesOverride: obj,
                     valuesOverrideYaml: textRef,
@@ -210,8 +216,8 @@ const DeployChart: React.FC<DeployChartProps> = ({
         }
         document.addEventListener("keydown", closeMe);
         if (versions) {
-            fetchTeams()
-            fetchEnvironments()
+            fetchProjects();
+            fetchEnvironments();
         }
         return () => { document.removeEventListener("keydown", closeMe); }
     }, [])
@@ -352,9 +358,7 @@ const DeployChart: React.FC<DeployChartProps> = ({
     }
 
     let isUpdate = environmentId && teamId;
-    let isDisabled = isUpdate ? false : !(selectedEnvironment && selectedTeam && selectedVersion && appName?.length);
-    let teamObj = teams.get(selectedTeam);
-    let envObj = environments.get(selectedEnvironment);
+    let isDisabled = isUpdate ? false : !(selectedEnvironment && selectedProject && selectedVersion && appName?.length);
     let chartVersionObj = versions.get(selectedVersion);
     // fetch chart versions for update route
     useEffect(() => {
@@ -374,21 +378,39 @@ const DeployChart: React.FC<DeployChartProps> = ({
                     <div className="hide-scroll">
                         <label className="form__row form__row--w-100">
                             <span className="form__label">App Name</span>
-                            <input autoComplete="off" tabIndex={1} placeholder="app name" className="form__input" value={appName} autoFocus disabled={!!isUpdate} onChange={e => setAppName(e.target.value)} />
+                            <input autoComplete="off" tabIndex={1} placeholder="App name" className="form__input" value={appName} autoFocus disabled={!!isUpdate} onChange={e => setAppName(e.target.value)} />
                         </label>
                         <label className="form__row form__row--w-100">
                             <span className="form__label">Project</span>
-                            <Select tabIndex={2} rootClassName="select-button--default" disabled={!!isUpdate} onChange={event => selectTeam(event.target.value)} value={selectedTeam}>
-                                <Select.Button>{teamObj ? teamObj.name : 'Select Project'}</Select.Button>
-                                {teams && Array.from(teams).map(([teamId, teamData], idx) => <Select.Option key={teamId} value={teamId}>{teamData.name}</Select.Option>)}
-                            </Select>
+                            <ReactSelect
+                                components={{
+                                    IndicatorSeparator: null,
+                                    DropdownIndicator
+                                }}
+                                placeholder="Select Project"
+                                styles={{
+                                    ...styles,
+                                    ...menuList,
+                                }}
+                                onChange={selectProject}
+                                options={projects}
+                            />
                         </label>
                         <div className="form__row form__row--w-100">
                             <span className="form__label">Environment</span>
-                            <Select tabIndex={3} rootClassName="select-button--default" value={selectedEnvironment} disabled={!!isUpdate} onChange={e => selectEnvironment(e.target.value)}>
-                                <Select.Button>{envObj ? envObj.environment_name : 'Select Environment'}</Select.Button>
-                                {environments && Array.from(environments).map(([envId, envData], idx) => <Select.Option key={envId} value={envId}>{envData.environment_name}</Select.Option>)}
-                            </Select>
+                            <ReactSelect
+                                components={{
+                                    IndicatorSeparator: null,
+                                    DropdownIndicator
+                                }}
+                                placeholder="Select Environment"
+                                styles={{
+                                    ...styles,
+                                    ...menuList,
+                                }}
+                                onChange={selectEnvironment}
+                                options={environments}
+                            />
                         </div>
                         {isUpdate && deprecated &&
                             <div className="info__container--update-chart">

--- a/src/components/common/helpers/util.ts
+++ b/src/components/common/helpers/util.ts
@@ -1,6 +1,12 @@
-export function sortCallback(key: string, a: any, b: any) {
-    if (a[key] < b[key]) { return -1; }
-    if (a[key] > b[key]) { return 1; }
+export function sortCallback(key: string, a: any, b: any, isCaseSensitive?: boolean) {
+    let x = a[key];
+    let y = b[key];
+    if (isCaseSensitive) {
+        x = x.toLowerCase();
+        y = y.toLowerCase();
+    }
+    if (x < y) { return -1; }
+    if (x > y) { return 1; }
     return 0;
 }
 

--- a/src/components/globalConfigurations/GlobalConfiguration.tsx
+++ b/src/components/globalConfigurations/GlobalConfiguration.tsx
@@ -34,7 +34,7 @@ const ConfigRequired = [
 ]
 
 const ConfigOptional = [
-    { name: 'Chart Repositories', href: URLS.GLOBAL_CONFIG_CHART, component: ChartRepo },
+    { name: 'Chart repositories', href: URLS.GLOBAL_CONFIG_CHART, component: ChartRepo },
     { name: 'SSO login services', href: URLS.GLOBAL_CONFIG_LOGIN, component: SSOLogin },
     { name: 'User access', href: URLS.GLOBAL_CONFIG_AUTH, component: UserGroup },
     { name: 'Notifications', href: URLS.GLOBAL_CONFIG_NOTIFIER, component: Notifier },

--- a/src/components/userGroups/User.tsx
+++ b/src/components/userGroups/User.tsx
@@ -305,24 +305,25 @@ export default function UserForm({ id = null, userData = null, index, updateCall
     });
 
     const handleKeyDown = useCallback((event) => {
-        let { emails, inputEmailValue } = emailState
-        inputEmailValue = inputEmailValue.trim()
+        let { emails, inputEmailValue } = emailState;
+        inputEmailValue = inputEmailValue.trim();
         switch (event.key) {
             case 'Enter':
             case 'Tab':
             case ',':
             case ' ': // space
                 if (inputEmailValue) {
+                    let newEmails = inputEmailValue.split(',').map((e) => { e = e.trim(); return createOption(e) });
                     setEmailState({
                         inputEmailValue: '',
-                        emails: [...emails, createOption(inputEmailValue)],
+                        emails: [...emails, ...newEmails],
                         emailError: '',
                     });
                 }
                 if (event.key !== 'Tab') {
                     event.preventDefault();
                 }
-                break
+                break;
         }
     }, [emailState])
 
@@ -384,6 +385,7 @@ export default function UserForm({ id = null, userData = null, index, updateCall
                     <label htmlFor="" className="mb-8">
                         Email addresses*
                     </label>
+                    {console.log(emailState.emails)}
                     <Creatable
                         ref={creatableRef}
                         options={creatableOptions}
@@ -391,15 +393,15 @@ export default function UserForm({ id = null, userData = null, index, updateCall
                         styles={CreatableStyle}
                         autoFocus
                         isMulti
-                        isValidNewOption={() => false}
-                        inputValue={emailState.inputEmailValue}
                         isClearable
-                        onBlur={handleCreatableBlur}
+                        inputValue={emailState.inputEmailValue}
+                        placeholder="Type email and press enter..."
+                        isValidNewOption={() => false}
                         backspaceRemovesValue
+                        value={emailState.emails}
+                        onBlur={handleCreatableBlur}
                         onInputChange={handleInputChange}
                         onKeyDown={handleKeyDown}
-                        placeholder="Type email and press enter..."
-                        value={emailState.emails}
                         onChange={handleEmailChange}
                     />
                     {emailState.emailError && <label className="form__error">{emailState.emailError}</label>}

--- a/src/components/userGroups/UserGroup.tsx
+++ b/src/components/userGroups/UserGroup.tsx
@@ -3,22 +3,22 @@ import { NavLink, Switch, Route, Redirect } from 'react-router-dom'
 import { useRouteMatch } from 'react-router'
 import { useAsync, NavigationArrow, getRandomColor, not, useKeyDown, noop, ConditionalWrap, Progressing, showError, removeItemsFromArray, getRandomString, Option, MultiValueContainer, MultiValueRemove, multiSelectStyles, sortBySelected, mapByKey, useEffectAfterMount } from '../common'
 import { getUserList, getGroupList, getUserId, getGroupId, getUserRole } from './userGroup.service';
-import { ReactComponent as AddIcon } from '../../assets/icons/ic-add.svg';
 import { get } from '../../services/api'
 import { getEnvironmentListMin, getProjectFilteredApps } from '../../services/service'
 import { getChartGroups } from '../charts/charts.service'
 import { ChartGroup } from '../charts/charts.types'
-import { DirectPermissionsRoleFilter, ChartGroupPermissionsFilter, ActionTypes, OptionType } from './userGroups.types'
-import UserForm from './User'
-import GroupForm from './Group';
-import Select, { components } from 'react-select';
+import { DirectPermissionsRoleFilter, ChartGroupPermissionsFilter, ActionTypes, OptionType, CollapsedUserOrGroupProps } from './userGroups.types'
 import { DOCUMENTATION, Routes } from '../../config'
-import { ReactComponent as CloseIcon } from '../../assets/icons/ic-close.svg'
+import { ReactComponent as AddIcon } from '../../assets/icons/ic-add.svg';
+import { ReactComponent as CloseIcon } from '../../assets/icons/ic-close.svg';
+import { ReactComponent as Lock } from '../../assets/icons/ic-locked.svg';
+import Select, { components } from 'react-select';
+import UserForm from './User';
+import GroupForm from './Group';
 import Tippy from '@tippyjs/react';
 import EmptyState from '../EmptyState/EmptyState';
 import EmptyImage from '../../assets/img/empty-applist@2x.png';
 import EmptySearch from '../../assets/img/empty-noresult@2x.png';
-import { ReactComponent as Lock } from '../../assets/icons/ic-locked.svg'
 import './UserGroup.scss';
 
 interface UserGroup {
@@ -270,19 +270,7 @@ const UserGroupList: React.FC<{ type: 'user' | 'group', reloadLists: () => void 
     )
 }
 
-interface Collapsed {
-    index: number;
-    email_id?: string;
-    id?: number;
-    name?: string;
-    description?: string;
-    type: 'user' | 'group';
-    updateCallback: (index: number, payload: any) => void;
-    deleteCallback: (index: number) => void;
-    createCallback: (payload: any) => void;
-}
-
-const CollapsedUserOrGroup: React.FC<Collapsed> = ({ index, email_id = null, id = null, name = null, description = null, type, updateCallback, deleteCallback, createCallback }) => {
+const CollapsedUserOrGroup: React.FC<CollapsedUserOrGroupProps> = ({ index, email_id = null, id = null, name = null, description = null, type, updateCallback, deleteCallback, createCallback }) => {
     const [collapsed, setCollapsed] = useState(true)
     const [dataLoading, data, dataError, reloadData, setData] = useAsync(type === 'group' ? () => getGroupId(id) : () => getUserId(id), [id, type], !collapsed)
 

--- a/src/components/userGroups/userGroups.types.ts
+++ b/src/components/userGroups/userGroups.types.ts
@@ -14,6 +14,17 @@ export enum ActionTypes{
     VIEW = 'view',
     UPDATE = 'update'
 }
+export interface CollapsedUserOrGroupProps {
+    index: number;
+    email_id?: string;
+    id?: number;
+    name?: string;
+    description?: string;
+    type: 'user' | 'group';
+    updateCallback: (index: number, payload: any) => void;
+    deleteCallback: (index: number) => void;
+    createCallback: (payload: any) => void;
+}
 interface RoleFilter{
     entity: EntityTypes.DIRECT | EntityTypes.CHART_GROUP;
     team?: OptionType;


### PR DESCRIPTION
# Description

##### Deploy chart 
- Project and Environment dropdown is now typeahead.
- Option are sorted and are searchable.

##### User access
- Muti-value string is now supported in email address typeahead.

##### Others
- Resource deletion button label changed to `Delete`
- CD Pipeline update environment selection disabled on update

Fixes (https://github.com/devtron-labs/devtron/issues/479)
Fixes (https://github.com/devtron-labs/devtron/issues/485)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Chart Deploy
- [x] Chart Update
- [ ] User Save 
- [ ] User Update

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


