### PR TITLE
[FIX] deprecated charts not visible  in chart group

### DIFF
--- a/src/components/charts/ChartGroupUpdate.tsx
+++ b/src/components/charts/ChartGroupUpdate.tsx
@@ -11,11 +11,11 @@ import CreateChartGroup from './modal/CreateChartGroup'
 import { URLS } from '../../config';
 import { toast } from 'react-toastify'
 import { Prompt } from 'react-router';
-import {ReactComponent as SaveIcon} from '../../assets/icons/ic-save.svg'
+import { ReactComponent as SaveIcon } from '../../assets/icons/ic-save.svg'
 import AppSelector from '../AppSelector'
 
 export default function ChartGroupUpdate({ }) {
-    const { groupId } = useParams<{groupId}>()
+    const { groupId } = useParams<{ groupId }>()
     const [chartDetailsUpdate, setChartDetailsUpdate] = useState(false)
     const { state, getChartVersionsAndValues, configureChart, fetchChartValues, addChart, subtractChart, handleChartValueChange, handleChartVersionChange, chartListing, createChartValues, removeChart, discardValuesYamlChanges, updateChartGroupEntriesFromResponse, updateChartGroupNameAndDescription, reloadState } = useChartGroup(Number(groupId))
     const [loading, setLoading] = useState(false)
@@ -29,7 +29,7 @@ export default function ChartGroupUpdate({ }) {
                 group: 'Chart Groups',
                 ':groupId': {
                     component: <AppSelector
-                        api={()=>getChartGroups().then(res=>({result: res.result.groups}))}
+                        api={() => getChartGroups().then(res => ({ result: res.result.groups }))}
                         primaryKey="groupId"
                         primaryValue='name'
                         matchedKeys={[]}
@@ -95,9 +95,9 @@ export default function ChartGroupUpdate({ }) {
         history.push(url);
     }
 
-    function closeChartGroupModal(props){
-        if(props?.name){
-            updateChartGroupNameAndDescription(props.name, props?.description||"" )
+    function closeChartGroupModal(props) {
+        if (props?.name) {
+            updateChartGroupNameAndDescription(props.name, props?.description || "")
         }
         setChartDetailsUpdate(false)
     }
@@ -108,15 +108,15 @@ export default function ChartGroupUpdate({ }) {
                 <div className="page-header">
                     <div className="flex column left">
                         <div className="flex left">
-                            <BreadCrumb breadcrumbs={breadcrumbs.slice(1,)}/>
+                            <BreadCrumb breadcrumbs={breadcrumbs.slice(1,)} />
                         </div>
                         <div className="flex left page-header__title">
-                            {state.name} 
+                            {state.name}
                             <Pencil className="pointer" onClick={e => setChartDetailsUpdate(true)} />
                         </div>
                     </div>
                     <div className="page-header__cta-container flex right">
-                        <button className="cta cancel mr-16" onClick={handleSave}>{loading ? <Progressing /> : <div className="flex left" style={{width:'100%'}}><SaveIcon className="mr-5"/>Save</div>}</button>
+                        <button className="cta cancel mr-16" onClick={handleSave}>{loading ? <Progressing /> : <div className="flex left" style={{ width: '100%' }}><SaveIcon className="mr-5" />Save</div>}</button>
                         <button className="cta cancel" onClick={redirectToGroupDetail}>Group Detail</button>
                     </div>
                 </div>

--- a/src/components/charts/list/DiscoverCharts.tsx
+++ b/src/components/charts/list/DiscoverCharts.tsx
@@ -253,7 +253,7 @@ function DiscoverChartList() {
     }
 
     function handleViewAllCharts() {
-        history.push(`${url}?${QueryParams.IncludeDeprecated}=0`);
+        history.push(`${url}?${QueryParams.IncludeDeprecated}=1`);
     }
 
     function handleCloseFilter() {

--- a/src/components/charts/list/DiscoverCharts.tsx
+++ b/src/components/charts/list/DiscoverCharts.tsx
@@ -316,15 +316,15 @@ function DiscoverChartList() {
                         handleAppStoreChange={handleAppStoreChange}
                         handleChartRepoChange={handleChartRepoChange}
                         handleDeprecateChange={handleDeprecateChange} />
-                        <span className='empty-height'>
-                            <EmptyState>
-                                <EmptyState.Image><img src={emptyImage} alt="" /></EmptyState.Image>
-                                <EmptyState.Title><h4>No  matching Charts</h4></EmptyState.Title>
-                                <EmptyState.Subtitle>We couldn't find any matching results</EmptyState.Subtitle>
-                                <button type="button" onClick={handleViewAllCharts} className="cta ghosted mb-24">View all charts</button>
-                            </EmptyState>
-                        </span>
-                    </>}
+                            <span className='empty-height'>
+                                <EmptyState>
+                                    <EmptyState.Image><img src={emptyImage} alt="" /></EmptyState.Image>
+                                    <EmptyState.Title><h4>No  matching Charts</h4></EmptyState.Title>
+                                    <EmptyState.Subtitle>We couldn't find any matching results</EmptyState.Subtitle>
+                                    <button type="button" onClick={handleViewAllCharts} className="cta ghosted mb-24">View all charts</button>
+                                </EmptyState>
+                            </span>
+                        </>}
                 </div>
                     : <div className="discover-charts__body-details">
                         {typeof state.configureChartIndex === 'number'

--- a/src/components/charts/list/DiscoverCharts.tsx
+++ b/src/components/charts/list/DiscoverCharts.tsx
@@ -253,7 +253,7 @@ function DiscoverChartList() {
     }
 
     function handleViewAllCharts() {
-        history.push(`${url}?${QueryParams.IncludeDeprecated}=1`);
+        history.push(`${url}?${QueryParams.IncludeDeprecated}=0`);
     }
 
     function handleCloseFilter() {

--- a/src/components/charts/useChartGroup.ts
+++ b/src/components/charts/useChartGroup.ts
@@ -35,7 +35,7 @@ export default function useChartGroup(chartGroupId = null): ChartGroupExports {
     useEffect(() => {
         async function populateCharts() {
             try {
-                const [{ result: chartRepoList }, { result: chartGroup }, { result: availableCharts }, { result: projects }, { result: environments }] = await Promise.all([getChartRepoList(), getChartGroups(), getAvailableCharts(`?includeDeprecated=0`), getTeamList(), getEnvironmentListMin()])
+                const [{ result: chartRepoList }, { result: chartGroup }, { result: availableCharts }, { result: projects }, { result: environments }] = await Promise.all([getChartRepoList(), getChartGroups(), getAvailableCharts(`?includeDeprecated=1`), getTeamList(), getEnvironmentListMin()])
                 let chartRepos = chartRepoList.map((chartRepo) => {
                     return {
                         value: chartRepo.id,


### PR DESCRIPTION
Not Showing deprecated charts In `chart group` section of `Charts`
<img width="1575" alt="Screenshot 2021-06-01 at 12 00 44 PM" src="https://user-images.githubusercontent.com/61836271/120276939-02735b80-c2d1-11eb-9b97-cd5ed3ab4588.png">

Fixes: https://github.com/devtron-labs/dashboard/issues/129

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update




