### PR TITLE
Fix CodeEditor YAML indentation

### DIFF
--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -185,7 +185,7 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
         }
         let final = value
         if (obj) {
-            final = state.mode === 'json' ? JSON.stringify(obj, null, tabSize) : YAML.stringify(obj, { indent: 4 })
+            final = state.mode === 'json' ? JSON.stringify(obj, null, tabSize) : YAML.stringify(obj, { indent: tabSize })
         }
         dispatch({ type: 'setCode', value: final })
     }, [value, noParsing])


### PR DESCRIPTION
# Description

The `CodeEditor` component is hardcoding the indentation for YAML to `4`. This fixes it to use the `tabSize` prop (`tabSize` defaults to `2`).

| Before | After |
| ------- | ----- |
| ![image](https://user-images.githubusercontent.com/17351764/139589539-da459a37-d792-4356-b9e4-d1049c0a72b9.png) | ![image](https://user-images.githubusercontent.com/17351764/139589333-cb81738e-ef64-4051-825d-b3b083af8a1b.png) |
| ![image](https://user-images.githubusercontent.com/17351764/139589565-13f68fcf-9ea3-487b-b76f-999df64f9799.png) | ![image](https://user-images.githubusercontent.com/17351764/139589351-e9d05548-af7b-4eec-9b7f-838baab07326.png) |

Fixes devtron-labs/devtron#119

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] SSO Login Services

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


