### PR TITLE
fix: fixed the chartversion for override

### DIFF
--- a/src/components/EnvironmentOverride/ConfigMapOverrides.tsx
+++ b/src/components/EnvironmentOverride/ConfigMapOverrides.tsx
@@ -6,7 +6,7 @@ import addIcon from '../../assets/icons/ic-add.svg'
 import fileIcon from '../../assets/icons/ic-file.svg'
 import keyIcon from '../../assets/icons/ic-key.svg'
 import arrowTriangle from '../../assets/icons/ic-chevron-down.svg'
-import { showError, Progressing, Info, ConfirmationDialog, Select, RadioGroup, not, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget, isChartRefIdLessThanOrEqualToTarget } from '../common'
+import { showError, Progressing, Info, ConfirmationDialog, Select, RadioGroup, not, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget, isChartRef3090OrBelow } from '../common'
 import { OverrideSecretForm } from './SecretOverrides'
 import { ConfigMapForm, KeyValueInput, useKeyValueYaml } from '../configMaps/ConfigMap'
 import { toast } from 'react-toastify'
@@ -53,6 +53,10 @@ export default function ConfigMapOverrides({ parentState, setParentState, ...pro
                     id: configmapRes.result.id,
                     configData: configmapRes.result.configData || [],
                 })
+                if (!appChartRefRes.result) {
+                  toast.error("Error happened while fetching the results. Please try again");
+                  return;
+                }
                 setAppChartRef(appChartRefRes.result);
             } catch (error) {
                 setParentState('failed');
@@ -196,7 +200,7 @@ const OverrideConfigMapForm: React.FC<ConfigMapProps> = memo(function OverrideCo
     const { yaml, handleYamlChange, error } = useKeyValueYaml(state.duplicate, setKeyValueArray, PATTERNS.CONFIG_MAP_AND_SECRET_KEY, `Key must consist of alphanumeric characters, '.', '-' and '_'`)
     const [yamlMode, toggleYamlMode] = useState(true)
     const [isFilePermissionChecked, setIsFilePermissionChecked] = useState(!!filePermission)
-    const isChartVersion309OrBelow = appChartRef && isVersionLessThanOrEqualToTarget(appChartRef.version, [3, 9]) && isChartRefIdLessThanOrEqualToTarget(appChartRef.id, 10);
+    const isChartVersion309OrBelow = appChartRef && isVersionLessThanOrEqualToTarget(appChartRef.version, [3, 9]) && isChartRef3090OrBelow(appChartRef.id);
 
     function changeEditorMode(e) {
         if (yamlMode) {

--- a/src/components/EnvironmentOverride/ConfigMapOverrides.tsx
+++ b/src/components/EnvironmentOverride/ConfigMapOverrides.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState, useReducer, useRef, memo } from 'react'
 import { overRideConfigMap, deleteConfigMap } from './service'
-import { getEnvironmentConfigs } from '../../services/service';
+import { getAppChartRefForAppAndEnv, getEnvironmentConfigs } from '../../services/service';
 import { useParams } from 'react-router'
 import addIcon from '../../assets/icons/ic-add.svg'
 import fileIcon from '../../assets/icons/ic-file.svg'
 import keyIcon from '../../assets/icons/ic-key.svg'
 import arrowTriangle from '../../assets/icons/ic-chevron-down.svg'
-import { showError, Progressing, Info, ConfirmationDialog, Select, RadioGroup, not, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget } from '../common'
+import { showError, Progressing, Info, ConfirmationDialog, Select, RadioGroup, not, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget, isChartRefIdLessThanOrEqualToTarget } from '../common'
 import { OverrideSecretForm } from './SecretOverrides'
 import { ConfigMapForm, KeyValueInput, useKeyValueYaml } from '../configMaps/ConfigMap'
 import { toast } from 'react-toastify'
@@ -46,7 +46,7 @@ export default function ConfigMapOverrides({ parentState, setParentState, ...pro
         async function initialise() {
             setConfigmapLoading(true);
             try {
-                const appChartRefRes = await getAppChartRef(appId);
+                const appChartRefRes = await getAppChartRefForAppAndEnv(appId, envId);
                 const configmapRes = await getEnvironmentConfigs(appId, envId);
                 setConfigmapList({
                     appId: configmapRes.result.appId,
@@ -196,7 +196,7 @@ const OverrideConfigMapForm: React.FC<ConfigMapProps> = memo(function OverrideCo
     const { yaml, handleYamlChange, error } = useKeyValueYaml(state.duplicate, setKeyValueArray, PATTERNS.CONFIG_MAP_AND_SECRET_KEY, `Key must consist of alphanumeric characters, '.', '-' and '_'`)
     const [yamlMode, toggleYamlMode] = useState(true)
     const [isFilePermissionChecked, setIsFilePermissionChecked] = useState(!!filePermission)
-    const isChartVersion309OrBelow = appChartRef && isVersionLessThanOrEqualToTarget(appChartRef.version, [3, 9]);
+    const isChartVersion309OrBelow = appChartRef && isVersionLessThanOrEqualToTarget(appChartRef.version, [3, 9]) && isChartRefIdLessThanOrEqualToTarget(appChartRef.id, 10);
 
     function changeEditorMode(e) {
         if (yamlMode) {

--- a/src/components/EnvironmentOverride/SecretOverrides.tsx
+++ b/src/components/EnvironmentOverride/SecretOverrides.tsx
@@ -3,7 +3,7 @@ import { deleteSecret, overRideSecret, unlockEnvSecret } from './service'
 import { getEnvironmentSecrets, getAppChartRefForAppAndEnv } from '../../services/service';
 import { useParams } from 'react-router';
 import { ListComponent, Override } from './ConfigMapOverrides'
-import { mapByKey, showError, Pencil, not, ConfirmationDialog, useAsync, Select, RadioGroup, Info, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget } from '../common'
+import { mapByKey, showError, Pencil, not, ConfirmationDialog, useAsync, Select, RadioGroup, Info, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget, isChartRef3090OrBelow } from '../common'
 import { SecretForm } from '../secrets/Secret'
 import { KeyValueInput, useKeyValueYaml } from '../configMaps/ConfigMap'
 import { toast } from 'react-toastify';
@@ -15,7 +15,6 @@ import { PATTERNS } from '../../config';
 import { KeyValueFileInput } from '../util/KeyValueFileInput';
 import { getAppChartRef } from '../../services/service';
 import './environmentOverride.scss';
-import { isChartRefIdLessThanOrEqualToTarget } from '../common/helpers/compareVersion';
 
 const sampleJSON = [
     {
@@ -190,7 +189,7 @@ export function OverrideSecretForm({ name, appChartRef, toggleCollapse }) {
     const { yaml, handleYamlChange, error } = useKeyValueYaml(state.duplicate || [], setKeyValueArray, PATTERNS.CONFIG_MAP_AND_SECRET_KEY, `Key must consist of alphanumeric characters, '.', '-' and '_'`)
     const [yamlMode, toggleYamlMode] = useState(true)
     const [isFilePermissionChecked, setIsFilePermissionChecked] = useState(!!filePermission)
-    const isChartVersion309OrBelow = appChartRef && isVersionLessThanOrEqualToTarget(appChartRef.version, [3, 9]) && isChartRefIdLessThanOrEqualToTarget(appChartRef.id, 10);
+    const isChartVersion309OrBelow = appChartRef && isVersionLessThanOrEqualToTarget(appChartRef.version, [3, 9]) && isChartRef3090OrBelow(appChartRef.id);
 
     function setKeyValueArray(arr) {
         tempArr.current = arr

--- a/src/components/EnvironmentOverride/SecretOverrides.tsx
+++ b/src/components/EnvironmentOverride/SecretOverrides.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useReducer, useRef, useState } from 'react'
 import { deleteSecret, overRideSecret, unlockEnvSecret } from './service'
-import { getEnvironmentSecrets, } from '../../services/service';
+import { getEnvironmentSecrets, getAppChartRefForAppAndEnv } from '../../services/service';
 import { useParams } from 'react-router';
 import { ListComponent, Override } from './ConfigMapOverrides'
 import { mapByKey, showError, Pencil, not, ConfirmationDialog, useAsync, Select, RadioGroup, Info, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget } from '../common'
@@ -15,6 +15,7 @@ import { PATTERNS } from '../../config';
 import { KeyValueFileInput } from '../util/KeyValueFileInput';
 import { getAppChartRef } from '../../services/service';
 import './environmentOverride.scss';
+import { isChartRefIdLessThanOrEqualToTarget } from '../common/helpers/compareVersion';
 
 const sampleJSON = [
     {
@@ -59,7 +60,7 @@ export default function SecretOverrides({ parentState, setParentState, ...props 
 
     useEffect(() => {
         async function callGetAppChartRef() {
-            const { result } = await getAppChartRef(appId);
+            const { result } = await getAppChartRefForAppAndEnv(appId, envId);
             setAppChartRef(result);
         }
         callGetAppChartRef();
@@ -189,7 +190,7 @@ export function OverrideSecretForm({ name, appChartRef, toggleCollapse }) {
     const { yaml, handleYamlChange, error } = useKeyValueYaml(state.duplicate || [], setKeyValueArray, PATTERNS.CONFIG_MAP_AND_SECRET_KEY, `Key must consist of alphanumeric characters, '.', '-' and '_'`)
     const [yamlMode, toggleYamlMode] = useState(true)
     const [isFilePermissionChecked, setIsFilePermissionChecked] = useState(!!filePermission)
-    const isChartVersion309OrBelow = appChartRef && isVersionLessThanOrEqualToTarget(appChartRef.version, [3, 9]);
+    const isChartVersion309OrBelow = appChartRef && isVersionLessThanOrEqualToTarget(appChartRef.version, [3, 9]) && isChartRefIdLessThanOrEqualToTarget(appChartRef.id, 10);
 
     function setKeyValueArray(arr) {
         tempArr.current = arr

--- a/src/components/common/helpers/compareVersion.ts
+++ b/src/components/common/helpers/compareVersion.ts
@@ -25,6 +25,6 @@ export function isVersionLessThanOrEqualToTarget(version: string, target: number
     return false;
 }
 
-export function isChartRefIdLessThanOrEqualToTarget(id: number, target: number): boolean {
-    return id <= target
+export function isChartRef3090OrBelow(id: number): boolean {
+    return id <= 10
 }

--- a/src/components/common/helpers/compareVersion.ts
+++ b/src/components/common/helpers/compareVersion.ts
@@ -24,3 +24,7 @@ export function isVersionLessThanOrEqualToTarget(version: string, target: number
     }
     return false;
 }
+
+export function isChartRefIdLessThanOrEqualToTarget(id: number, target: number): boolean {
+    return id <= target
+}

--- a/src/components/configMaps/ConfigMap.tsx
+++ b/src/components/configMaps/ConfigMap.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'
-import { Progressing, showError, Select, useThrottledEffect, RadioGroup, not, Info, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget } from '../common'
+import { Progressing, showError, Select, useThrottledEffect, RadioGroup, not, Info, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget, isChartRefIdLessThanOrEqualToTarget } from '../common'
 import { useParams } from 'react-router'
 import { updateConfig, deleteConfig } from './service';
 import { getAppChartRef, getConfigMapList } from '../../services/service';
@@ -247,7 +247,7 @@ export function ConfigMapForm({ appChartRef, id, appId, name = "", external, dat
     const [isSubPathChecked, setIsSubPathChecked] = useState(!!subPath)
     const [isFilePermissionChecked, setIsFilePermissionChecked] = useState(!!filePermission)
     const [filePermissionValue, setFilePermissionValue] = useState({ value: filePermission, error: "" });
-    const isChartVersion309OrBelow = appChartRef && isVersionLessThanOrEqualToTarget(appChartRef.version, [3, 9]);
+    const isChartVersion309OrBelow = appChartRef && isVersionLessThanOrEqualToTarget(appChartRef.version, [3, 9]) && isChartRefIdLessThanOrEqualToTarget(appChartRef.id, 10);
 
     function setKeyValueArray(arr) {
         tempArray.current = arr

--- a/src/components/configMaps/ConfigMap.tsx
+++ b/src/components/configMaps/ConfigMap.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'
-import { Progressing, showError, Select, useThrottledEffect, RadioGroup, not, Info, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget, isChartRefIdLessThanOrEqualToTarget } from '../common'
+import { Progressing, showError, Select, useThrottledEffect, RadioGroup, not, Info, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget, isChartRef3090OrBelow } from '../common'
 import { useParams } from 'react-router'
 import { updateConfig, deleteConfig } from './service';
 import { getAppChartRef, getConfigMapList } from '../../services/service';
@@ -247,7 +247,7 @@ export function ConfigMapForm({ appChartRef, id, appId, name = "", external, dat
     const [isSubPathChecked, setIsSubPathChecked] = useState(!!subPath)
     const [isFilePermissionChecked, setIsFilePermissionChecked] = useState(!!filePermission)
     const [filePermissionValue, setFilePermissionValue] = useState({ value: filePermission, error: "" });
-    const isChartVersion309OrBelow = appChartRef && isVersionLessThanOrEqualToTarget(appChartRef.version, [3, 9]) && isChartRefIdLessThanOrEqualToTarget(appChartRef.id, 10);
+    const isChartVersion309OrBelow = appChartRef && isVersionLessThanOrEqualToTarget(appChartRef.version, [3, 9]) && isChartRef3090OrBelow(appChartRef.id);
 
     function setKeyValueArray(arr) {
         tempArray.current = arr

--- a/src/components/secrets/Secret.tsx
+++ b/src/components/secrets/Secret.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'
-import { Progressing, showError, Select, RadioGroup, not, Info, ToastBody, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget, isChartRefIdLessThanOrEqualToTarget } from '../common'
+import { Progressing, showError, Select, RadioGroup, not, Info, ToastBody, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget, isChartRef3090OrBelow } from '../common'
 import { useParams } from 'react-router'
 import { updateSecret, deleteSecret, getSecretKeys } from '../secrets/service';
 import { getAppChartRef } from '../../services/service';
@@ -208,7 +208,7 @@ export const SecretForm: React.FC<SecretFormProps> = function (props) {
     const [isSubPathChecked, setIsSubPathChecked] = useState(!!props.subPath)
     const [isFilePermissionChecked, setIsFilePermissionChecked] = useState(!!props.filePermission)
     const [filePermissionValue, setFilePermissionValue] = useState({ value: props.filePermission, error: "" })
-    const isChartVersion309OrBelow = props.appChartRef && isVersionLessThanOrEqualToTarget(props.appChartRef.version, [3, 9]) && isChartRefIdLessThanOrEqualToTarget(props.appChartRef.id, 10);
+    const isChartVersion309OrBelow = props.appChartRef && isVersionLessThanOrEqualToTarget(props.appChartRef.version, [3, 9]) && isChartRef3090OrBelow(props.appChartRef.id);
 
     let tempSecretData: any[] = props?.secretData || [];
     tempSecretData = tempSecretData.map((s) => {

--- a/src/components/secrets/Secret.tsx
+++ b/src/components/secrets/Secret.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'
-import { Progressing, showError, Select, RadioGroup, not, Info, ToastBody, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget } from '../common'
+import { Progressing, showError, Select, RadioGroup, not, Info, ToastBody, CustomInput, Checkbox, CHECKBOX_VALUE, isVersionLessThanOrEqualToTarget, isChartRefIdLessThanOrEqualToTarget } from '../common'
 import { useParams } from 'react-router'
 import { updateSecret, deleteSecret, getSecretKeys } from '../secrets/service';
 import { getAppChartRef } from '../../services/service';
@@ -208,7 +208,7 @@ export const SecretForm: React.FC<SecretFormProps> = function (props) {
     const [isSubPathChecked, setIsSubPathChecked] = useState(!!props.subPath)
     const [isFilePermissionChecked, setIsFilePermissionChecked] = useState(!!props.filePermission)
     const [filePermissionValue, setFilePermissionValue] = useState({ value: props.filePermission, error: "" })
-    const isChartVersion309OrBelow = props.appChartRef && isVersionLessThanOrEqualToTarget(props.appChartRef.version, [3, 9]);
+    const isChartVersion309OrBelow = props.appChartRef && isVersionLessThanOrEqualToTarget(props.appChartRef.version, [3, 9]) && isChartRefIdLessThanOrEqualToTarget(props.appChartRef.id, 10);
 
     let tempSecretData: any[] = props?.secretData || [];
     tempSecretData = tempSecretData.map((s) => {

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -302,9 +302,9 @@ export function getChartReferencesForAppAndEnv(appId: number, envId: number): Pr
 
 export function getAppChartRefForAppAndEnv(appId: number, envId: number): Promise<ResponseType> {
     return getChartReferencesForAppAndEnv(appId, envId).then((response) => {
-        const { result: { chartRefs, latestEnvChartRef } } = response;
-        let selectedChartId = latestEnvChartRef;
-        let chart = chartRefs.find(chart => selectedChartId === chart.id);
+        const { result: { chartRefs, latestEnvChartRef, latestAppChartRef } } = response;
+        let selectedChartId = latestEnvChartRef || latestAppChartRef;
+        let chart = chartRefs?.find(chart => selectedChartId === chart.id);
         return {
             code: response.code,
             status: response.status,

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -294,6 +294,25 @@ export function getAppChartRef(appId: number): Promise<ResponseType> {
         }
     })
 }
+
+export function getChartReferencesForAppAndEnv(appId: number, envId: number): Promise<ResponseType> {
+    const URL = `${Routes.CHART_REFERENCES_MIN}/${appId}/${envId}`;
+    return get(URL);
+}
+
+export function getAppChartRefForAppAndEnv(appId: number, envId: number): Promise<ResponseType> {
+    return getChartReferencesForAppAndEnv(appId, envId).then((response) => {
+        const { result: { chartRefs, latestEnvChartRef } } = response;
+        let selectedChartId = latestEnvChartRef;
+        let chart = chartRefs.find(chart => selectedChartId === chart.id);
+        return {
+            code: response.code,
+            status: response.status,
+            result: chart
+        }
+    })
+}
+
 export function getAppCheckList(): Promise<any> {
     const URL = `${Routes.APP_CHECKLIST}`;
     return get(URL);


### PR DESCRIPTION
# Description

Chart version comparision inside configmap and secret override happens agains the chart version selected in the global deployment template and not against the chart version selected for this particular environment.

Fixes: devtron-labs/devtron#936

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

    User selects chart version less than 3.9 in global deployment template
    User changes the chart version in the deployment template for a particular environment to a number higher than 3.9
    User tries to use subpath functionality of configmap
    User should be able to use subpath


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


