### PR TITLE
External app support shu1

### DIFF
--- a/src/components/charts/modal/DeployChart.tsx
+++ b/src/components/charts/modal/DeployChart.tsx
@@ -190,8 +190,7 @@ const DeployChart: React.FC<DeployChartProps> = ({
                 };
                 const { result: { environmentId: newEnvironmentId, installedAppId: newInstalledAppId } } = await installChart(payload);
                 toast.success('Deployment initiated');
-                push(`app/${URLS.DEVTRON_CHARTS}/deployments/${newInstalledAppId}/env/${newEnvironmentId}/${URLS.APP_DETAILS}`)
-                // push(`/chart-store/deployments/${newInstalledAppId}/env/${newEnvironmentId}/${URLS.APP_DETAILS}`)
+                push(`${URLS.APP}/${URLS.DEVTRON_CHARTS}/deployments/${newInstalledAppId}/env/${newEnvironmentId}/${URLS.APP_DETAILS}`)
             }
         }
         catch (err) {

--- a/src/components/charts/modal/DeployChart.tsx
+++ b/src/components/charts/modal/DeployChart.tsx
@@ -190,7 +190,8 @@ const DeployChart: React.FC<DeployChartProps> = ({
                 };
                 const { result: { environmentId: newEnvironmentId, installedAppId: newInstalledAppId } } = await installChart(payload);
                 toast.success('Deployment initiated');
-                push(`/chart-store/deployments/${newInstalledAppId}/env/${newEnvironmentId}/${URLS.APP_DETAILS}`)
+                push(`app/${URLS.DEVTRON_CHARTS}/deployments/${newInstalledAppId}/env/${newEnvironmentId}/${URLS.APP_DETAILS}`)
+                // push(`/chart-store/deployments/${newInstalledAppId}/env/${newEnvironmentId}/${URLS.APP_DETAILS}`)
             }
         }
         catch (err) {

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
@@ -233,7 +233,7 @@ function LogsComponent({ selectedTab, isDeleted }) {
         if (selectedTab) {
             selectedTab(NodeDetailTab.LOGS, url);
         }
-    }, []);
+    }, [params.podName]);
 
     useEffect(() => {
         //Values are already set once we reach here
@@ -483,7 +483,7 @@ function LogsComponent({ selectedTab, isDeleted }) {
                                 Connecting
                             </div>
                         )}
-                        {readyState === 1 && <div className="readyState loading-dots cg-5">Connected</div>}
+                        {readyState === 1 && <div className="readyState loading-dots cg-5 pl-20">Connected</div>}
                     </div>
                 </div>
             )}

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Manifest.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Manifest.component.tsx
@@ -213,7 +213,7 @@ function ManifestComponent({ selectedTab, isDeleted }) {
             <MessageUI msg="This resource no longer exists" size={32} />
         </div>
     ) : (
-        <div style={{ minHeight: '600px', background: '#0B0F22', flex: 1 }}>
+        <div style={{ background: '#0B0F22', flex: 1 }}>
             {error && !loading && <MessageUI msg="Manifest not available" size={24} />}
             {!error && (
                 <>

--- a/src/components/v2/values/DeployChart.tsx
+++ b/src/components/v2/values/DeployChart.tsx
@@ -198,9 +198,7 @@ const DeployChart: React.FC<DeployChartProps> = ({
 				};
 				const { result: { environmentId: newEnvironmentId, installedAppId: newInstalledAppId } } = await installChart(payload);
 				toast.success('Deployment initiated');
-                push(`app/${URLS.DEVTRON_CHARTS}/deployments/${newInstalledAppId}/env/${newEnvironmentId}/${URLS.APP_DETAILS}`)
-
-				// push(`/chart-store/deployments/${newInstalledAppId}/env/${newEnvironmentId}`)
+                push(`${URLS.APP}/${URLS.DEVTRON_CHARTS}/deployments/${newInstalledAppId}/env/${newEnvironmentId}/${URLS.APP_DETAILS}`)
 			}
 		}
 		catch (err) {
@@ -306,7 +304,6 @@ const DeployChart: React.FC<DeployChartProps> = ({
 				await deleteInstalledChart(installedAppId)
 			}
 			toast.success('Successfully deleted.')
-			// push(URLS.CHARTS)
 			let url = `${URLS.APP}/${URLS.APP_LIST}/${URLS.APP_LIST_HELM}`;
 			push(url);
 		}

--- a/src/components/v2/values/DeployChart.tsx
+++ b/src/components/v2/values/DeployChart.tsx
@@ -198,7 +198,9 @@ const DeployChart: React.FC<DeployChartProps> = ({
 				};
 				const { result: { environmentId: newEnvironmentId, installedAppId: newInstalledAppId } } = await installChart(payload);
 				toast.success('Deployment initiated');
-				push(`/chart-store/deployments/${newInstalledAppId}/env/${newEnvironmentId}`)
+                push(`app/${URLS.DEVTRON_CHARTS}/deployments/${newInstalledAppId}/env/${newEnvironmentId}/${URLS.APP_DETAILS}`)
+
+				// push(`/chart-store/deployments/${newInstalledAppId}/env/${newEnvironmentId}`)
 			}
 		}
 		catch (err) {
@@ -304,7 +306,9 @@ const DeployChart: React.FC<DeployChartProps> = ({
 				await deleteInstalledChart(installedAppId)
 			}
 			toast.success('Successfully deleted.')
-			push(URLS.CHARTS)
+			// push(URLS.CHARTS)
+			let url = `${URLS.APP}/${URLS.APP_LIST}/${URLS.APP_LIST_HELM}`;
+			push(url);
 		}
 		catch (err) {
 			// if (!force && err.code != 403) {


### PR DESCRIPTION
Bugs reproduced by Shubham:
1. (7) In the case of 2 tabs for different pods, can select only one(In case of logs only). Switching from logs to other elements is applied on another tab.
2. (11) Just after deploying any chart, the app details page comes up with (deployed/ <chart-name>) Redirects to wrong URL (previous URL)
3. (13) After deleting a chart, it should redirect to Helm Apps. Currently redirecting to chart-store
4. (14) Position of "Manifest/Events not available" should be in the center.