### PR TITLE
sorting fix for app list

### DIFF
--- a/src/components/app/list-new/AppList.tsx
+++ b/src/components/app/list-new/AppList.tsx
@@ -345,7 +345,7 @@ export default function AppList() {
             query[key] = qs[key];
         })
         query["orderBy"] = key;
-        query["sortOrder"] = query["sortOrder"] == OrderBy.ASC ? OrderBy.DESC : OrderBy.ASC;
+        query["sortOrder"] = query["sortOrder"] == OrderBy.DESC ? OrderBy.ASC : OrderBy.DESC;
         let queryStr = queryString.stringify(query);
         let url = `${currentTab == AppListConstants.AppTabs.DEVTRON_APPS ? buildDevtronAppListUrl() : buildHelmAppListUrl()}?${queryStr}`;
         history.push(url);


### PR DESCRIPTION
Devtron app list and Helm app list - After page load, if I click on sort icon, then first time it doesn't sort, second time onwards it works (as first time, there is no sortOrder in query param)