### PR TITLE
EA: Internal Tabs - fix for state issue when switching internal tabs

### DIFF
--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetail.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetail.component.tsx
@@ -27,7 +27,7 @@ function NodeDetailComponent() {
     useEffect(() => {
         const _tabs = getNodeDetailTabs(params.nodeType as NodeType);
         setTabs(_tabs);
-    }, []);
+    }, [params.nodeType]);
 
     const handleSelectedTab = (_tabName: string, _url: string) => {
         const isTabFound = AppDetailsStore.markAppDetailsTabActiveByIdentifier(params.podName, params.nodeType);
@@ -65,14 +65,12 @@ function NodeDetailComponent() {
                         tabs.map((tab: string, index: number) => {
                             return (
                                 <div
-                                  
                                     key={index + 'resourceTreeTab'}
                                     className={`${
                                         tab.toLowerCase() === selectedTabName.toLowerCase()
                                             ? 'default-tab-row cb-5'
                                             : 'cn-7'
-                                    } pt-6 pb-6 cursor pl-8 pr-8`
-                               }
+                                    } pt-6 pb-6 cursor pl-8 pr-8`}
                                 >
                                     <NavLink to={`${url}/${tab.toLowerCase()}`} className=" no-decor flex left">
                                         <span


### PR DESCRIPTION
Fix for state issue when switching tabs between deployment & pod and then log analyzer & k8s resources. 

- Case 1: logs & terminal tabs are not visible for Pod when switching from the active Deployment tab
- Case 2: logs & terminal tabs are visible for Deployment when switching from the active Pod tab