### PR TITLE
fix: Some bug fixes

### DIFF
--- a/src/components/v2/appDetails/appDetails.scss
+++ b/src/components/v2/appDetails/appDetails.scss
@@ -75,3 +75,11 @@
 .tab-list__deleted {
     text-decoration: line-through;
 }
+
+/* Start: Container height fixes */
+.resource-node-wrapper .no-pod.no-pod--container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+/* End: Container height fixes */

--- a/src/components/v2/appDetails/appDetails.scss
+++ b/src/components/v2/appDetails/appDetails.scss
@@ -66,6 +66,10 @@
 
 .resource-tree__tab-hover:hover {
     color: #0066cc !important;
+} 
+
+.resource-tree__tab-hover:hover div:not(.cn-9) .resource-tree__tab-hover svg path {
+    fill: #0066cc;
 }
 
 .tab-list__deleted {

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Events.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Events.component.tsx
@@ -59,7 +59,7 @@ function EventsComponent({ selectedTab, isDeleted }) {
                                                     <th
                                                         key={`eh_${idx}`}
                                                         className={
-                                                            'cell-style capitalize ' +
+                                                            'cell-style text-uppercase ' +
                                                             head +
                                                             (idx === 0 && ' pad-left-20')
                                                         }
@@ -101,7 +101,7 @@ function EventsComponent({ selectedTab, isDeleted }) {
                             <MessageUI msg="Events not available" size={24} />
                         )}
 
-                        {loading && <MessageUI msg="fetching events" icon={MsgUIType.LOADING} size={24} />}
+                        {loading && <MessageUI msg="Fetching events" icon={MsgUIType.LOADING} size={24} />}
                     </React.Fragment>
                 )
             )}

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Manifest.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Manifest.component.tsx
@@ -33,7 +33,7 @@ function ManifestComponent({ selectedTab, isDeleted }) {
     const [desiredManifest, setDesiredManifest] = useState('');
     const appDetails = IndexStore.getAppDetails();
     const [loading, setLoading] = useState(true);
-    const [loadingMsg, setLoadingMsg] = useState('');
+    const [loadingMsg, setLoadingMsg] = useState('Fetching manifest');
     const [error, setError] = useState(false);
     const [errorText, setErrorText] = useState('');
     const [isEditmode, setIsEditmode] = useState(false);
@@ -304,13 +304,7 @@ function ManifestComponent({ selectedTab, isDeleted }) {
                                 readOnly={activeTab !== 'Live manifest' || !isEditmode}
                                 onChange={handleEditorValueChange}
                                 loading={loading}
-                                customLoader={
-                                    <MessageUI
-                                        msg={`${loadingMsg || 'Fetching manifest'}`}
-                                        icon={MsgUIType.LOADING}
-                                        size={24}
-                                    />
-                                }
+                                customLoader={<MessageUI msg={loadingMsg} icon={MsgUIType.LOADING} size={24} />}
                                 focus={isEditmode}
                             >
                                 {showInfoText && (

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Manifest.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Manifest.component.tsx
@@ -33,6 +33,7 @@ function ManifestComponent({ selectedTab, isDeleted }) {
     const [desiredManifest, setDesiredManifest] = useState('');
     const appDetails = IndexStore.getAppDetails();
     const [loading, setLoading] = useState(true);
+    const [loadingMsg, setLoadingMsg] = useState('');
     const [error, setError] = useState(false);
     const [errorText, setErrorText] = useState('');
     const [isEditmode, setIsEditmode] = useState(false);
@@ -115,6 +116,8 @@ function ManifestComponent({ selectedTab, isDeleted }) {
 
     const handleApplyChanges = () => {
         setLoading(true);
+        setLoadingMsg('Applying changes');
+
         let manifestString;
         try {
             manifestString = JSON.stringify(YAML.parse(modifiedManifest));
@@ -301,7 +304,13 @@ function ManifestComponent({ selectedTab, isDeleted }) {
                                 readOnly={activeTab !== 'Live manifest' || !isEditmode}
                                 onChange={handleEditorValueChange}
                                 loading={loading}
-                                customLoader={<MessageUI msg="fetching manifest" icon={MsgUIType.LOADING} size={24} />}
+                                customLoader={
+                                    <MessageUI
+                                        msg={`${loadingMsg || 'Fetching manifest'}`}
+                                        icon={MsgUIType.LOADING}
+                                        size={24}
+                                    />
+                                }
                                 focus={isEditmode}
                             >
                                 {showInfoText && (

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -110,7 +110,7 @@ export const Routes = {
     APP_CREATE_ENV_CONFIG_MAP: 'config/environment/cm',
     APP_META_INFO: 'app/meta/info',
     CLUSTER_ENV_MAPPING: 'env',
-    APP_VERSION: '/version',
+    APP_VERSION: 'version',
     HELM_RELEASE_INFO_API: 'application/release-info',
     HELM_RELEASE_DEPLOYMENT_HISTORY_API: 'application/deployment-history',
     HELM_RELEASE_APP_DETAIL_API: 'application/app',


### PR DESCRIPTION
# Description
1. When a user clicks on [apply changes] show loader with the text "Applying changes" instead of "Fetching manifest", some more cases around manifests.
2. K8 resources and log analyzer icon color should be --B500 while hovering over resp. tabs (icon blue on hover)
3. Capitalise events header
4. Height is not covering the full length in No Pod container view
5. Removing extra slash from getVersion API request URL


Fixes - devtron-labs/devtron#1157

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
All tests have been performed manually.

- [x] By updating and applying manifest.
- [x] By hovering over the tabs (active & non-active state) & by using the browser's force state functionality.
- [x] By manually generating a delete event
- [x] By zooming in & out in the view and by manually putting some higher screen resolutions in the browser's responsive mode (responsive/mobile mode simulator)
- [x] By refreshing the page, checking & making sure that there's only one call for /version API. 


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
