### PR TITLE
Feature: Deployment History - fetching YAMLs lazily using new API

### DIFF
--- a/src/components/common/icons/Progressing.tsx
+++ b/src/components/common/icons/Progressing.tsx
@@ -5,12 +5,13 @@ interface ProgressingProps {
     loadingText?: string;
     size?: number;
     fullHeight?: boolean;
+    theme?: 'white' | 'default';
 }
 
-export function Progressing({ pageLoader, size }: ProgressingProps): JSX.Element {
+export function Progressing({ pageLoader, size, theme }: ProgressingProps): JSX.Element {
     const loaderSize = size ? `${size}px` : pageLoader ? '48px' : '20px';
     return (
-        <div className="loader">
+        <div className={`loader ${theme || 'default'}-background`}>
             <div style={{ width: loaderSize, height: loaderSize }}>
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="loader__svg">
                     <g fill="none" fillRule="evenodd" strokeLinecap="round">
@@ -37,7 +38,9 @@ export function Progressing({ pageLoader, size }: ProgressingProps): JSX.Element
 
 export function DetailsProgressing({ loadingText, size = 24, fullHeight = false }: ProgressingProps): JSX.Element {
     return (
-        <div className={`details-loader bcn-0 flex column fs-14 fw-6 ${fullHeight ? 'h-100' : 'details-loader-height'}`}>
+        <div
+            className={`details-loader bcn-0 flex column fs-14 fw-6 ${fullHeight ? 'h-100' : 'details-loader-height'}`}
+        >
             <span style={{ width: `${size}px`, height: `${size}px` }}>
                 <Progressing size={size} />
             </span>

--- a/src/components/external-apps/ExternalAppService.ts
+++ b/src/components/external-apps/ExternalAppService.ts
@@ -12,6 +12,14 @@ export interface HelmAppDeploymentHistoryResponse extends ResponseType {
     result?: HelmAppDeploymentHistory
 }
 
+export interface HelmAppDeploymentDetails {
+    manifest: string;
+    valuesYaml: string;
+}
+export interface HelmAppDeploymentDetailResponse extends ResponseType {
+    result?: HelmAppDeploymentDetails;
+}
+
 export interface HelmAppDetailResponse extends ResponseType {
     result?: HelmAppDetail
 }
@@ -89,6 +97,10 @@ export const getReleaseInfo = (appId: string): Promise<ReleaseInfoResponse> => {
 export const getDeploymentHistory = (appId: string): Promise<HelmAppDeploymentHistoryResponse> => {
     let url = `${Routes.HELM_RELEASE_DEPLOYMENT_HISTORY_API}?appId=${appId}`
     return get(url);
+}
+
+export const getDeploymentDetail = (appId: string, version: number): Promise<HelmAppDeploymentDetailResponse> => {
+    return get(`${Routes.HELM_RELEASE_DEPLOYMENT_DETAIL_API}?appId=${appId}&version=${version}`);
 }
 
 export const getAppDetail = (appId: string): Promise<HelmAppDetailResponse> => {

--- a/src/components/external-apps/ExternalAppService.ts
+++ b/src/components/external-apps/ExternalAppService.ts
@@ -12,12 +12,12 @@ export interface HelmAppDeploymentHistoryResponse extends ResponseType {
     result?: HelmAppDeploymentHistory
 }
 
-export interface HelmAppDeploymentDetails {
-    manifest: string;
-    valuesYaml: string;
+export interface HelmAppDeploymentManifestDetail {
+    manifest?: string;
+    valuesYaml?: string;
 }
-export interface HelmAppDeploymentDetailResponse extends ResponseType {
-    result?: HelmAppDeploymentDetails;
+export interface HelmAppDeploymentManifestDetailResponse extends ResponseType {
+    result?: HelmAppDeploymentManifestDetail;
 }
 
 export interface HelmAppDetailResponse extends ResponseType {
@@ -99,9 +99,12 @@ export const getDeploymentHistory = (appId: string): Promise<HelmAppDeploymentHi
     return get(url);
 }
 
-export const getDeploymentDetail = (appId: string, version: number): Promise<HelmAppDeploymentDetailResponse> => {
+export const getDeploymentManifestDetails = (
+    appId: string,
+    version: number,
+): Promise<HelmAppDeploymentManifestDetailResponse> => {
     return get(`${Routes.HELM_RELEASE_DEPLOYMENT_DETAIL_API}?appId=${appId}&version=${version}`);
-}
+};
 
 export const getAppDetail = (appId: string): Promise<HelmAppDetailResponse> => {
     let url = `${Routes.HELM_RELEASE_APP_DETAIL_API}?appId=${appId}`

--- a/src/components/external-apps/ExternalAppService.ts
+++ b/src/components/external-apps/ExternalAppService.ts
@@ -45,11 +45,10 @@ export interface HelmAppDeploymentHistory {
 }
 
 export interface HelmAppDeploymentDetail {
-    chartMetadata: ChartMetadata,
-    manifest: string,
-    dockerImages: string[],
-    version: number,
-    deployedAt: DeployedAt
+    chartMetadata: ChartMetadata;
+    dockerImages: string[];
+    version: number;
+    deployedAt: DeployedAt;
 }
 
 export interface HelmAppDetail {

--- a/src/components/v2/common/message.ui.tsx
+++ b/src/components/v2/common/message.ui.tsx
@@ -35,7 +35,7 @@ const MessageUI: React.FC<MsgUIProps> = ({
     isShowActionButton,
     actionButtonText,
     onActionButtonClick,
-}) => {
+}: MsgUIProps) => {
     return (
         <div
             className={`text-center ${theme || 'dark'}-background w-100 `}

--- a/src/components/v2/common/message.ui.tsx
+++ b/src/components/v2/common/message.ui.tsx
@@ -12,8 +12,11 @@ export enum MsgUIType {
 export interface MsgUIProps {
     msg: string;
     icon?: MsgUIType;
+    theme?: 'white' | 'dark';
+    iconClassName?: string;
     bodyStyle?: any;
     msgStyle?: any;
+    actionButtonStyle?: any;
     size: number;
     isShowActionButton?: boolean;
     actionButtonText?: string;
@@ -23,8 +26,11 @@ export interface MsgUIProps {
 const MessageUI: React.FC<MsgUIProps> = ({
     msg,
     icon,
+    theme,
+    iconClassName,
     bodyStyle,
     msgStyle,
+    actionButtonStyle,
     size = 24,
     isShowActionButton,
     actionButtonText,
@@ -32,15 +38,15 @@ const MessageUI: React.FC<MsgUIProps> = ({
 }) => {
     return (
         <div
-            className="text-center dark-background w-100 "
-            style={{ ...bodyStyle, paddingTop: '200px', minHeight: '600px', flex: '1' }}
+            className={`text-center ${theme || 'dark'}-background w-100 `}
+            style={{ paddingTop: '200px', minHeight: '600px', flex: '1', ...bodyStyle }}
         >
             <div>
                 {(() => {
                     switch (icon) {
                         case MsgUIType.LOADING:
                             return (
-                                <div className="fcn-0">
+                                <div className={`fcn-0 ${iconClassName || ''}`}>
                                     <Progressing />
                                 </div>
                             );
@@ -52,20 +58,25 @@ const MessageUI: React.FC<MsgUIProps> = ({
                                 />
                             );
                         case MsgUIType.MULTI_CONTAINER:
-                            return <MultipleContainer />;
+                            return <MultipleContainer className={iconClassName || ''} />;
                         default:
-                            return <InfoIcon className="fcn-0" width={size} height={size} />;
+                            return <InfoIcon className={`fcn-0 ${iconClassName || ''}`} width={size} height={size} />;
                     }
                 })()}
             </div>
-            <div className="fs-14" style={{ ...msgStyle, marginTop: '8px', color: 'white' }}>
+            <div className="fs-14" style={{ marginTop: '8px', color: 'white', ...msgStyle }}>
                 {msg}
             </div>
             {isShowActionButton && (
                 <div
                     className="cursor"
                     onClick={onActionButtonClick}
-                    style={{ fontSize: '14px', textDecoration: 'underline', color: 'var(--B300)' }}
+                    style={{
+                        fontSize: '14px',
+                        textDecoration: 'underline',
+                        color: 'var(--B300)',
+                        ...actionButtonStyle,
+                    }}
                 >
                     {actionButtonText}
                 </div>

--- a/src/components/v2/deployment-history/ea/ea-deployment-history.scss
+++ b/src/components/v2/deployment-history/ea/ea-deployment-history.scss
@@ -16,8 +16,8 @@
     grid-template-columns: 30% 70%;
 }
 
-.deployment-tab-list{
-    margin-left : 20px !important;
+.deployment-tab-list {
+    padding-left : 20px !important;
 }
 
 .error-exclamation-icon path {

--- a/src/components/v2/deployment-history/ea/ea-deployment-history.scss
+++ b/src/components/v2/deployment-history/ea/ea-deployment-history.scss
@@ -19,3 +19,7 @@
 .deployment-tab-list{
     margin-left : 20px !important;
 }
+
+.error-exclamation-icon path {
+    fill: #767D84;
+}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -113,6 +113,7 @@ export const Routes = {
     APP_VERSION: 'version',
     HELM_RELEASE_INFO_API: 'application/release-info',
     HELM_RELEASE_DEPLOYMENT_HISTORY_API: 'application/deployment-history',
+    HELM_RELEASE_DEPLOYMENT_DETAIL_API: 'application/deployment-detail',
     HELM_RELEASE_APP_DETAIL_API: 'application/app',
     MANIFEST: 'k8s/resource',
     DESIRED_MANIFEST: 'application/desired-manifest',

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -1691,3 +1691,11 @@ button.anchor {
 .m-auto{
     margin: auto;
 }
+
+.dark-background {
+    background-color: #0b0f22;
+}
+
+.white-background {
+    background-color: #fff;
+}


### PR DESCRIPTION
# Description
Breakdown deployment history API to solve grpc max size error.

- Fetching YAMLs lazily instead of on page load using new API - `application/deployment-detail`.
- Updates in deployment tabs - added `values.yaml` & renamed `Applied YAML` to `Helm generated manifest`.
- Added error handling view containing CTA - 'Retry'.

Fixes # https://github.com/devtron-labs/devtron/issues/1155

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
All tests have been performed manually on the local server.

- [x] No manifest details are fetched on page load
- [x] YAMLs for both `values.yaml` & `Helm generated manifest` are being fetched on click of either tab.
- [x] No multiple API calls are being made while switching between `values.yaml` & `Helm generated manifest` tabs.
- [x] No API call is being made if YAMLs have already been fetched for a particular Deployment version.
- [x] Used network request blocking to block the request to new API & test out Error handling view.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


