### PR TITLE
enhancement: CodeEditor - setting indentation to 2 spaces for YAML

### DIFF
--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -134,8 +134,8 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
         if (
             mode === 'yaml' &&
             editor &&
-            typeof editor.getModal === 'function' &&
-            typeof editor.getModal().updateOptions === 'function'
+            typeof editor.getModel === 'function' &&
+            typeof editor.getModel().updateOptions === 'function'
         ) {
             editor.getModel().updateOptions({ tabSize: 2 });
         }

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -131,6 +131,15 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
     });
 
     function editorDidMount(editor, monaco) {
+        if (
+            mode === 'yaml' &&
+            editor &&
+            typeof editor.getModal === 'function' &&
+            typeof editor.getModal().updateOptions === 'function'
+        ) {
+            editor.getModel().updateOptions({ tabSize: 2 });
+        }
+        
         editorRef.current = editor
         monacoRef.current = monaco
         if (inline) {
@@ -203,7 +212,7 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
         }
         let final = value
         if (obj) {
-            final = state.mode === 'json' ? JSON.stringify(obj, null, tabSize) : YAML.stringify(obj, { indent: 4 })
+            final = state.mode === 'json' ? JSON.stringify(obj, null, tabSize) : YAML.stringify(obj, { indent: 2 })
         }
         dispatch({ type: 'setCode', value: final })
     }, [value, noParsing])

--- a/src/components/EnvironmentOverride/ConfigMapOverrides.tsx
+++ b/src/components/EnvironmentOverride/ConfigMapOverrides.tsx
@@ -234,7 +234,7 @@ const OverrideConfigMapForm: React.FC<ConfigMapProps> = memo(function OverrideCo
     function stringify(value) {
         if (!value) return value
         if (typeof value === 'object') {
-            return YAML.stringify(value, { indent: 4 })
+            return YAML.stringify(value, { indent: 2 })
         }
         if (typeof value === 'string') {
             return value
@@ -432,7 +432,7 @@ const OverrideConfigMapForm: React.FC<ConfigMapProps> = memo(function OverrideCo
                     {yamlMode
                         ? <div className="yaml-container">
                             <CodeEditor
-                                value={state.duplicate ? yaml : YAML.stringify(defaultData, { indent: 4 })}
+                                value={state.duplicate ? yaml : YAML.stringify(defaultData, { indent: 2 })}
                                 mode="yaml"
                                 inline
                                 height={350}
@@ -502,10 +502,10 @@ export function Override({ external, overridden, onClick, loading = false, type 
 export function prettifyData(value) {
     switch (typeof value) {
         case 'object':
-            return YAML.stringify(value, { indent: 4 })
+            return YAML.stringify(value, { indent: 2 })
         case 'string':
             try {
-                return YAML.stringify(JSON.parse(value), { indent: 4 })
+                return YAML.stringify(JSON.parse(value), { indent: 2 })
             }
             catch (err) {
                 return value.toString()

--- a/src/components/EnvironmentOverride/DeploymentTemplateOverride.tsx
+++ b/src/components/EnvironmentOverride/DeploymentTemplateOverride.tsx
@@ -238,11 +238,10 @@ function DeploymentTemplateOverrideForm({ state, handleOverride, dispatch, initi
                 </div>
                 <div className="code-editor-container">
                     <CodeEditor
-                        value={state ? state.duplicate ? YAML.stringify(state.duplicate, { indent: 4 }) : YAML.stringify(state.data.globalConfig, { indent: 4 }) : ""}
+                        value={state ? state.duplicate ? YAML.stringify(state.duplicate, { indent: 2 }) : YAML.stringify(state.data.globalConfig, { indent: 2 }) : ""}
                         onChange={res => setTempValue(res)}
-                        defaultValue={state && state.data && state.duplicate ? YAML.stringify(state.data.globalConfig, { indent: 4 }) : ""}
+                        defaultValue={state && state.data && state.duplicate ? YAML.stringify(state.data.globalConfig, { indent: 2 }) : ""}
                         mode="yaml"
-                        tabSize={4}
                         readOnly={!state.duplicate}
                         loading={chartRefLoading}
                     >

--- a/src/components/cdPipeline/CDPipeline.tsx
+++ b/src/components/cdPipeline/CDPipeline.tsx
@@ -191,7 +191,7 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
                 ...pipelineConfigFromRes.strategies[i],
                 defaultConfig: this.allStrategies[pipelineConfigFromRes.strategies[i].deploymentTemplate],
                 jsonStr: JSON.stringify(pipelineConfigFromRes.strategies[i].config, null, 4),
-                selection: yamlJsParser.stringify(this.allStrategies[pipelineConfigFromRes.strategies[i].config], { indent: 4 }),
+                selection: yamlJsParser.stringify(this.allStrategies[pipelineConfigFromRes.strategies[i].config], { indent: 2 }),
                 isCollapsed: true,
             });
             strategies = strategies.filter(strategy => strategy.deploymentTemplate !== pipelineConfigFromRes.strategies[i].deploymentTemplate)
@@ -286,7 +286,7 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
 
         selection['defaultConfig'] = this.allStrategies[selection.deploymentTemplate];
         selection['jsonStr'] = JSON.stringify(this.allStrategies[selection.deploymentTemplate], null, 4);
-        selection['yamlStr'] = yamlJsParser.stringify(this.allStrategies[selection.deploymentTemplate], { indent: 4 });
+        selection['yamlStr'] = yamlJsParser.stringify(this.allStrategies[selection.deploymentTemplate], { indent: 2 });
         selection['isCollapsed'] = true;
 
         state.strategies = strategies;
@@ -316,7 +316,7 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
         newSelection['isCollapsed'] = true;
         newSelection['default'] = true;
         newSelection['jsonStr'] = JSON.stringify(this.allStrategies[value], null, 4);
-        newSelection['yamlStr'] = yamlJsParser.stringify(this.allStrategies[value], { indent: 4 });
+        newSelection['yamlStr'] = yamlJsParser.stringify(this.allStrategies[value], { indent: 2 });
 
         let { pipelineConfig } = { ...this.state };
         pipelineConfig.strategies.push(newSelection);
@@ -417,7 +417,7 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
             jsonStr = event.target.value;
             try {
                 json = JSON.parse(jsonStr);
-                yamlStr = yamlJsParser.stringify(json, { indent: 4 });
+                yamlStr = yamlJsParser.stringify(json, { indent: 2 });
             } catch (error) { }
         }
         else {

--- a/src/components/common/helpers/Helpers.tsx
+++ b/src/components/common/helpers/Helpers.tsx
@@ -681,7 +681,7 @@ export function useJsonYaml(value, tabSize = 4, language = 'json', shouldRun = f
         }
         if (obj && typeof obj === 'object') {
             setJson(JSON.stringify(obj, null, tabSize));
-            setYaml(YAML.stringify(obj, { indent: tabSize }));
+            setYaml(YAML.stringify(obj, { indent: 2 }));
             setNativeObject(obj);
             setError('');
         } else {

--- a/src/components/configMaps/ConfigMap.tsx
+++ b/src/components/configMaps/ConfigMap.tsx
@@ -576,7 +576,7 @@ export function useKeyValueYaml(keyValueArray, setKeyValueArray, keyPattern, key
             setError("")
             return
         }
-        setYaml(YAML.stringify(keyValueArray.reduce((agg, { k, v }) => ({ ...agg, [k]: v }), {}), { indent: 4 }))
+        setYaml(YAML.stringify(keyValueArray.reduce((agg, { k, v }) => ({ ...agg, [k]: v }), {}), { indent: 2 }))
     }, [keyValueArray])
 
     function handleYamlChange(yamlConfig) {
@@ -593,7 +593,7 @@ export function useKeyValueYaml(keyValueArray, setKeyValueArray, keyPattern, key
             let errorneousKeys = []
             let tempArray = Object.keys(obj).reduce((agg, k) => {
                 if (!k && !obj[k]) return agg
-                let v = obj[k] && ['object', 'number'].includes(typeof obj[k]) ? YAML.stringify(obj[k], { indent: 4 }) : obj[k]
+                let v = obj[k] && ['object', 'number'].includes(typeof obj[k]) ? YAML.stringify(obj[k], { indent: 2 }) : obj[k]
                 let keyErr: string;
                 if (k && keyPattern.test(k)) {
                     keyErr = ''


### PR DESCRIPTION
# Description

Indentation issues in Code editor in EA app detail - add 2 tab sizes/spaces in both read-only & edit mode

Fixes # https://github.com/devtron-labs/devtron/issues/1201

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All changes have been tested manually.

- By loading different views/sections/components and manually checked & confirmed that editors using YAML mode/type are using tab size/space as 2. 
- Different components and their props are mentioned in this doc - [CodeEditor](https://docs.google.com/spreadsheets/d/1b2CrdOE51kGKCJodyxk74BZagSwq_5D4kpZMDLJ8HyM/edit?usp=sharing) 


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


