### PR TITLE
namespace dropdown data issue fix if single cluster for EA_ONLY mode

### DIFF
--- a/src/components/app/list-new/AppList.tsx
+++ b/src/components/app/list-new/AppList.tsx
@@ -75,10 +75,10 @@ export default function AppList() {
             setProjectListRes(initData.projectsRes);
             setEnvironmentListRes(initData.environmentListRes);
             setMasterFilters(initData.filters);
+            setDataStateType(AppListViewType.LIST);
             if(serverMode == SERVER_MODE.EA_ONLY){
                 applyClusterSelectionFilterOnPageLoadIfSingle(initData.filters.clusters, _currentTab);
             }
-            setDataStateType(AppListViewType.LIST);
         }).catch((errors: ServerErrors) => {
             showError(errors);
             setDataStateType(AppListViewType.ERROR);


### PR DESCRIPTION
# Description

For Hyperion mode, If there is only one cluster, then that cluster would be auto selected on app list. For that case namespace filter dropdown is empty. 
