### PR TITLE
[FIX]: Force delete helm bug

### DIFF
--- a/src/components/common/dialogs/DeleteDialog.tsx
+++ b/src/components/common/dialogs/DeleteDialog.tsx
@@ -23,7 +23,7 @@ export const DeleteDialog: React.FC<DeleteDialogProps> & { Description?: React.F
         <ConfirmationDialog.ButtonGroup>
             <div className="flex right">
                 <button type="button" className="cta cancel cta-cd-delete-modal ml-16" onClick={props.closeDelete}>Cancel</button>
-                <button type="button" className="cta delete cta-cd-delete-modal ml-16" onClick={props.delete}>{props.deletePrefix}Delete</button>
+                <button type="button" className="cta delete ml-16" onClick={props.delete}>{props.deletePrefix}Delete</button>
             </div>
         </ConfirmationDialog.ButtonGroup>
     </ConfirmationDialog >

--- a/src/components/v2/appDetails/index.store.ts
+++ b/src/components/v2/appDetails/index.store.ts
@@ -56,7 +56,6 @@ const IndexStore = {
     },
 
     publishAppDetails: (data: AppDetails) => {
-        console.log('setAppDetails', data);
 
         const _nodes = data.resourceTree.nodes || [];
 

--- a/src/components/v2/values/ChartValues.component.tsx
+++ b/src/components/v2/values/ChartValues.component.tsx
@@ -20,7 +20,6 @@ function ValuesComponent() {
     useEffect(() => {
         getChartVersionDetails2(appDetails.appStoreInstalledAppVersionId)
             .then((res) => {
-                console.log('getChartVersionDetails2 result', res.result);
                 setInstalledConfig(res.result);
             })
             .catch((err) => {

--- a/src/components/v2/values/DeployChart.tsx
+++ b/src/components/v2/values/DeployChart.tsx
@@ -307,12 +307,12 @@ const DeployChart: React.FC<DeployChartProps> = ({
 			push(url);
 		}
 		catch (err) {
-			// if (!force && err.code != 403) {
-			//     setForceDeleteDialog(true)
-			//     setForceDeleteDialogData(err)
-			// } else {
-			//     showError(err)
-			// }
+			if (!force && err.code != 403) {
+			    setForceDeleteDialog(true)
+			    setForceDeleteDialogData(err)
+			} else {
+			    showError(err)
+			}
 		}
 		finally {
 			setDeleting(false)


### PR DESCRIPTION
# Description

Force delete modal on helm chart was  disabled
Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Deployed a chart that doesn't exist  or wasn't installed because of timeout , then deleted that 


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas

Fixes: https://github.com/devtron-labs/devtron/issues/1301

