### PR TITLE
Fix - Routing issue fix - Not able to go back to helm-apps from app-details

### DIFF
--- a/src/components/v2/appDetails/k8Resource/nodeType/NodeTree.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeType/NodeTree.component.tsx
@@ -51,7 +51,7 @@ function NodeTreeComponent({
                 handleClickOnNodes(_kind, [parent.toLowerCase()]);
             }
         } else {
-            history.push(url.replace(/\/$/, '') + getRedirectURLExtension(clickedNodes, _treeNodes));
+            history.replace(url.replace(/\/$/, '') + getRedirectURLExtension(clickedNodes, _treeNodes));
         }
     }, [url]);
 


### PR DESCRIPTION


# Description

Currently, the user is not able to navigate back to Helm Apps from AppDetails using the browser's back button. This change fixes this issue by using the `replace` function from history instead of `push`.

Fixes # https://github.com/devtron-labs/devtron/issues/1282

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been performed manually by visiting AppDetails from HelmApps and switching between sub URLs. Then trying to go back to HelmApps using the browser's back button.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


