### PR TITLE
Updated messaging for adding GitOps credentials

### DIFF
--- a/src/components/gitOps/GitOpsConfiguration.tsx
+++ b/src/components/gitOps/GitOpsConfiguration.tsx
@@ -85,7 +85,7 @@ const GitInfoTab: React.FC<{ tab: string, gitLink: string, gitProvider: string, 
         <div className="flex left ">
             <Info className="icon-dim-20" style={{ marginTop: 1 }} />
             <div className="ml-8 fs-13">
-                <span className="fw-6 text-capitalize">Important: </span>Please create a new {gitProvider} {gitProviderGroupAlias} for gitops. Do not use {gitProvider} {gitProviderGroupAlias} containing your source code.
+                <span className="fw-6 text-capitalize">Recommended: </span>Create a new {gitProvider} {gitProviderGroupAlias} for gitops. Avoid using {gitProvider} {gitProviderGroupAlias} containing your source code.
        </div>
         </div>
         <a target="_blank" href={gitLink} className="ml-28 cursor fs-13 onlink">How to create {gitProviderGroupAlias} in {gitProvider} ?</a>


### PR DESCRIPTION
# Description

Updated messaging for adding GitOps credentials. Users can now use their code repository as GitOps repo. A prefix can be added in the GitOps repo created by devtron automatically.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


