### PR TITLE
Empty chart has wrong messaging

### DIFF
--- a/src/components/charts/ChartGroupUpdate.tsx
+++ b/src/components/charts/ChartGroupUpdate.tsx
@@ -210,9 +210,9 @@ export default function ChartGroupUpdate({ }) {
                             <div style={{ height: "calc(100vh - 150px" }}>
                                 <EmptyState>
                                     <EmptyState.Image><img src={emptyImage} alt="" /></EmptyState.Image>
-                                    <EmptyState.Title><h4>No  matching Charts</h4></EmptyState.Title>
+                                    <EmptyState.Title><h4>No matching Charts</h4></EmptyState.Title>
                                     <EmptyState.Subtitle>We couldn't find any matching results</EmptyState.Subtitle>
-                                    <button type="button" onClick={handleViewAllCharts} className="cta ghosted mb-24">View all charts</button>
+                                    <button type="button" onClick={handleViewAllCharts} className="cta ghosted mb-24">View connected chart repositories</button>
                                 </EmptyState>
                             </div></>
                             : <>

--- a/src/components/charts/ChartGroupUpdate.tsx
+++ b/src/components/charts/ChartGroupUpdate.tsx
@@ -208,7 +208,7 @@ export default function ChartGroupUpdate({ }) {
                             />
                              <ChartEmptyState
                                     onClickViewChartButton={handleViewAllCharts}
-                                    heightToDeduct={'150px'}
+                                    heightToDeduct={150}
                             />
                             </>
                             : <>

--- a/src/components/charts/ChartGroupUpdate.tsx
+++ b/src/components/charts/ChartGroupUpdate.tsx
@@ -212,7 +212,7 @@ export default function ChartGroupUpdate({ }) {
                                     <EmptyState.Image><img src={emptyImage} alt="" /></EmptyState.Image>
                                     <EmptyState.Title><h4>No matching Charts</h4></EmptyState.Title>
                                     <EmptyState.Subtitle>We couldn't find any matching results</EmptyState.Subtitle>
-                                    <button type="button" onClick={handleViewAllCharts} className="cta ghosted mb-24">View connected chart repositories</button>
+                                    <button type="button" onClick={handleViewAllCharts} className="cta ghosted mb-24">View all charts</button>
                                 </EmptyState>
                             </div></>
                             : <>

--- a/src/components/charts/ChartGroupUpdate.tsx
+++ b/src/components/charts/ChartGroupUpdate.tsx
@@ -14,9 +14,8 @@ import { Prompt } from 'react-router';
 import { ReactComponent as SaveIcon } from '../../assets/icons/ic-save.svg'
 import AppSelector from '../AppSelector'
 import ChartHeaderFilters from './ChartHeaderFilters'
-import EmptyState from '../EmptyState/EmptyState';
-import emptyImage from '../../assets/img/empty-noresult@2x.png';
 import { QueryParams } from './charts.util';
+import ChartEmptyState from '../common/emptyState/ChartEmptyState'
 
 
 export default function ChartGroupUpdate({ }) {
@@ -207,14 +206,14 @@ export default function ChartGroupUpdate({ }) {
                                 setAppStoreName={setAppStoreName}
                                 handleCloseFilter={handleCloseFilter}
                             />
-                            <div style={{ height: "calc(100vh - 150px" }}>
-                                <EmptyState>
-                                    <EmptyState.Image><img src={emptyImage} alt="" /></EmptyState.Image>
-                                    <EmptyState.Title><h4>No matching charts</h4></EmptyState.Title>
-                                    <EmptyState.Subtitle>We couldn't find any matching results</EmptyState.Subtitle>
-                                    <button type="button" onClick={handleViewAllCharts} className="cta ghosted mb-24">View all charts</button>
-                                </EmptyState>
-                            </div></>
+                             <ChartEmptyState
+                                    title={'No matching charts'}
+                                    subTitle={"We couldn't find any matching results"}
+                                    onClickViewChartButton={handleViewAllCharts}
+                                    buttonText={'View connected chart repositories'} 
+                                    heightToDeduct={'150px'}
+                            />
+                            </>
                             : <>
                                 <ChartHeaderFilters
                                     chartRepoList={state.chartRepos}

--- a/src/components/charts/ChartGroupUpdate.tsx
+++ b/src/components/charts/ChartGroupUpdate.tsx
@@ -210,7 +210,7 @@ export default function ChartGroupUpdate({ }) {
                                     title={'No matching charts'}
                                     subTitle={"We couldn't find any matching results"}
                                     onClickViewChartButton={handleViewAllCharts}
-                                    buttonText={'View connected chart repositories'} 
+                                    buttonText={'View all charts'} 
                                     heightToDeduct={'150px'}
                             />
                             </>

--- a/src/components/charts/ChartGroupUpdate.tsx
+++ b/src/components/charts/ChartGroupUpdate.tsx
@@ -207,10 +207,7 @@ export default function ChartGroupUpdate({ }) {
                                 handleCloseFilter={handleCloseFilter}
                             />
                              <ChartEmptyState
-                                    title={'No matching charts'}
-                                    subTitle={"We couldn't find any matching results"}
                                     onClickViewChartButton={handleViewAllCharts}
-                                    buttonText={'View all charts'} 
                                     heightToDeduct={'150px'}
                             />
                             </>

--- a/src/components/charts/ChartGroupUpdate.tsx
+++ b/src/components/charts/ChartGroupUpdate.tsx
@@ -210,7 +210,7 @@ export default function ChartGroupUpdate({ }) {
                             <div style={{ height: "calc(100vh - 150px" }}>
                                 <EmptyState>
                                     <EmptyState.Image><img src={emptyImage} alt="" /></EmptyState.Image>
-                                    <EmptyState.Title><h4>No matching Charts</h4></EmptyState.Title>
+                                    <EmptyState.Title><h4>No matching charts</h4></EmptyState.Title>
                                     <EmptyState.Subtitle>We couldn't find any matching results</EmptyState.Subtitle>
                                     <button type="button" onClick={handleViewAllCharts} className="cta ghosted mb-24">View all charts</button>
                                 </EmptyState>

--- a/src/components/charts/list/Deployed.tsx
+++ b/src/components/charts/list/Deployed.tsx
@@ -321,7 +321,7 @@ class Deployed extends Component<DeployedChartProps, DeployedChartState> {
                             title={'No matching charts'}
                             subTitle={"We couldn't find any matching results"}
                             onClickViewChartButton={this.handleViewAllCharts}
-                            buttonText={'View connected chart repositories'} 
+                            buttonText={'View all charts'} 
                             heightToDeduct={'160px'}
                             /> 
                 </div>

--- a/src/components/charts/list/Deployed.tsx
+++ b/src/components/charts/list/Deployed.tsx
@@ -319,7 +319,7 @@ class Deployed extends Component<DeployedChartProps, DeployedChartState> {
                     />
                       <ChartEmptyState
                             onClickViewChartButton={this.handleViewAllCharts}
-                            heightToDeduct={'160px'}
+                            heightToDeduct={160}
                             /> 
                 </div>
             }

--- a/src/components/charts/list/Deployed.tsx
+++ b/src/components/charts/list/Deployed.tsx
@@ -13,8 +13,7 @@ import { AllCheckModal } from '../../checkList/AllCheckModal';
 import DeployedChartFilters from './DeployedChartFilters';
 import { showError } from '../../common';
 import { getChartRepoList, getEnvironmentListMin } from '../../../services/service'
-import emptyImage from '../../../assets/img/empty-noresult@2x.png';
-import EmptyState from '../../EmptyState/EmptyState';
+import ChartEmptyState from '../../common/emptyState/ChartEmptyState';
 
 const QueryParams = {
     ChartRepoId: 'chartRepoId',
@@ -318,15 +317,13 @@ class Deployed extends Component<DeployedChartProps, DeployedChartState> {
                         selectedChartRepo={this.state.selectedChartRepo}
                         selectedEnvironment={this.state.selectedEnvironment}
                     />
-                    <span className='empty-height' style={{ height: "calc(100vh - 160px)" }}>
-                        <EmptyState>
-                            <EmptyState.Image><img src={emptyImage} alt="" /></EmptyState.Image>
-                            <EmptyState.Title><h4>No matching charts</h4></EmptyState.Title>
-                            <EmptyState.Subtitle>We couldn't find any matching results</EmptyState.Subtitle>
-                            <button type="button" onClick={this.handleViewAllCharts} className="cta ghosted mb-24">View all charts</button>
-                        </EmptyState>
-                    </span>
-                    { }
+                      <ChartEmptyState
+                            title={'No matching charts'}
+                            subTitle={"We couldn't find any matching results"}
+                            onClickViewChartButton={this.handleViewAllCharts}
+                            buttonText={'View connected chart repositories'} 
+                            heightToDeduct={'160px'}
+                            /> 
                 </div>
             }
         }

--- a/src/components/charts/list/Deployed.tsx
+++ b/src/components/charts/list/Deployed.tsx
@@ -321,7 +321,7 @@ class Deployed extends Component<DeployedChartProps, DeployedChartState> {
                     <span className='empty-height' style={{ height: "calc(100vh - 160px)" }}>
                         <EmptyState>
                             <EmptyState.Image><img src={emptyImage} alt="" /></EmptyState.Image>
-                            <EmptyState.Title><h4>No matching Charts</h4></EmptyState.Title>
+                            <EmptyState.Title><h4>No matching charts</h4></EmptyState.Title>
                             <EmptyState.Subtitle>We couldn't find any matching results</EmptyState.Subtitle>
                             <button type="button" onClick={this.handleViewAllCharts} className="cta ghosted mb-24">View all charts</button>
                         </EmptyState>

--- a/src/components/charts/list/Deployed.tsx
+++ b/src/components/charts/list/Deployed.tsx
@@ -318,10 +318,7 @@ class Deployed extends Component<DeployedChartProps, DeployedChartState> {
                         selectedEnvironment={this.state.selectedEnvironment}
                     />
                       <ChartEmptyState
-                            title={'No matching charts'}
-                            subTitle={"We couldn't find any matching results"}
                             onClickViewChartButton={this.handleViewAllCharts}
-                            buttonText={'View all charts'} 
                             heightToDeduct={'160px'}
                             /> 
                 </div>

--- a/src/components/charts/list/Deployed.tsx
+++ b/src/components/charts/list/Deployed.tsx
@@ -321,7 +321,7 @@ class Deployed extends Component<DeployedChartProps, DeployedChartState> {
                     <span className='empty-height' style={{ height: "calc(100vh - 160px)" }}>
                         <EmptyState>
                             <EmptyState.Image><img src={emptyImage} alt="" /></EmptyState.Image>
-                            <EmptyState.Title><h4>No  matching Charts</h4></EmptyState.Title>
+                            <EmptyState.Title><h4>No matching Charts</h4></EmptyState.Title>
                             <EmptyState.Subtitle>We couldn't find any matching results</EmptyState.Subtitle>
                             <button type="button" onClick={this.handleViewAllCharts} className="cta ghosted mb-24">View all charts</button>
                         </EmptyState>

--- a/src/components/charts/list/DiscoverCharts.tsx
+++ b/src/components/charts/list/DiscoverCharts.tsx
@@ -216,12 +216,12 @@ function DiscoverChartList() {
                 </ConditionalWrap>
 
                 <div className="page-header__cta-container flex">
-                    {
+                    { chartList.length ?
                         serverMode == SERVER_MODE.FULL && state.charts.length === 0 &&
                         <button type="button" className="cta flex"
                                 onClick={(e) => toggleChartGroupModal(!showChartGroupModal)}>
                             <Add className="icon-dim-18 mr-5" />Create Group
-                        </button>
+                        </button> : ''
                     }
                 </div>
 
@@ -241,25 +241,16 @@ function DiscoverChartList() {
                         handleEnvironmentChange={handleEnvironmentChange}
                         handleNameChange={handleNameChange}
                         discardValuesYamlChanges={discardValuesYamlChanges}
-                    /> : <> <ChartListHeader chartRepoList={state.chartRepos}
-                        handleCloseFilter={handleCloseFilter}
-                        setSelectedChartRepo={setSelectedChartRepo}
-                        charts={state.charts}
-                        searchApplied={searchApplied}
-                        appStoreName={appStoreName}
-                        includeDeprecated={includeDeprecated}
-                        selectedChartRepo={selectedChartRepo}
-                        setAppStoreName={setAppStoreName}
-                    />
+                    /> : 
                             <span className='empty-height'>
                                 <EmptyState>
                                     <EmptyState.Image><img src={emptyImage} alt="" /></EmptyState.Image>
                                     <EmptyState.Title><h4>No charts available right now</h4></EmptyState.Title>
                                     <EmptyState.Subtitle>The connected chart repositories are syncing or no charts are available.</EmptyState.Subtitle>
-                                    <button type="button" onClick={handleViewAllCharts} className="cta ghosted mb-24">View all charts</button>
+                                    <button type="button" onClick={handleViewAllCharts} className="cta ghosted mb-24 mt-10">View connected chart repositories</button>
                                 </EmptyState>
                             </span>
-                        </>}
+                        }
                 </div>
                     : <div className="discover-charts__body-details">
                         {typeof state.configureChartIndex === 'number'

--- a/src/components/charts/list/DiscoverCharts.tsx
+++ b/src/components/charts/list/DiscoverCharts.tsx
@@ -241,23 +241,12 @@ function DiscoverChartList() {
                         handleNameChange={handleNameChange}
                         discardValuesYamlChanges={discardValuesYamlChanges}
                     /> : 
-                    <>
-                    <ChartEmptyState
+                     <ChartEmptyState
                             title={'No charts available right now'}
                             subTitle={'The connected chart repositories are syncing or no charts are available.'}
                             onClickViewChartButton={handleViewAllCharts}
-                            buttonText={'View connected chart repositories'} />
-{/*                             
-                            <span className='empty-height'>
-                                <EmptyState>
-                                    <EmptyState.Image><img src={emptyImage} alt="" /></EmptyState.Image>
-                                    <EmptyState.Title><h4></h4></EmptyState.Title>
-                                    <EmptyState.Subtitle></EmptyState.Subtitle>
-                                    <button type="button" className="cta ghosted mb-24 mt-10"></button>
-                                </EmptyState>
-                            </span> */}
-                            </>
-                            
+                            buttonText={'View connected chart repositories'}
+                            />
                         }
                 </div>
                     : <div className="discover-charts__body-details">

--- a/src/components/charts/list/DiscoverCharts.tsx
+++ b/src/components/charts/list/DiscoverCharts.tsx
@@ -190,7 +190,7 @@ function DiscoverChartList() {
     }
 
     function handleViewAllCharts() {
-        history.push(`${url}?${QueryParams.IncludeDeprecated}=1`);
+        history.push(`${match.url.split('/chart-store')[0]}${URLS.GLOBAL_CONFIG_CHART}`);
     }
 
     function handleCloseFilter() {
@@ -254,8 +254,8 @@ function DiscoverChartList() {
                             <span className='empty-height'>
                                 <EmptyState>
                                     <EmptyState.Image><img src={emptyImage} alt="" /></EmptyState.Image>
-                                    <EmptyState.Title><h4>No  matching Charts</h4></EmptyState.Title>
-                                    <EmptyState.Subtitle>We couldn't find any matching results</EmptyState.Subtitle>
+                                    <EmptyState.Title><h4>No charts available right now</h4></EmptyState.Title>
+                                    <EmptyState.Subtitle>The connected chart repositories are syncing or no charts are available.</EmptyState.Subtitle>
                                     <button type="button" onClick={handleViewAllCharts} className="cta ghosted mb-24">View all charts</button>
                                 </EmptyState>
                             </span>

--- a/src/components/charts/list/DiscoverCharts.tsx
+++ b/src/components/charts/list/DiscoverCharts.tsx
@@ -215,12 +215,12 @@ function DiscoverChartList() {
                 </ConditionalWrap>
 
                 <div className="page-header__cta-container flex">
-                    { chartList.length ?
+                    { chartList.length > 0 &&
                         serverMode == SERVER_MODE.FULL && state.charts.length === 0 &&
                         <button type="button" className="cta flex"
                                 onClick={(e) => toggleChartGroupModal(!showChartGroupModal)}>
                             <Add className="icon-dim-18 mr-5" />Create Group
-                        </button> : ''
+                        </button>
                     }
                 </div>
 

--- a/src/components/charts/list/DiscoverCharts.tsx
+++ b/src/components/charts/list/DiscoverCharts.tsx
@@ -21,14 +21,13 @@ import { DOCUMENTATION, URLS, SERVER_MODE } from '../../../config';
 import { Prompt } from 'react-router';
 import { ReactComponent as WarningIcon } from '../../../assets/icons/ic-alert-triangle.svg';
 import Tippy from '@tippyjs/react'
-import emptyImage from '../../../assets/img/empty-noresult@2x.png';
-import EmptyState from '../../EmptyState/EmptyState';
 import { isGitopsConfigured } from '../../../services/service';
 import warn from '../../../assets/icons/ic-warning.svg';
 import empty from '../../../assets/img/ic-empty-chartgroup@2x.jpg'
 import ChartHeaderFilter from '../ChartHeaderFilters';
 import { QueryParams } from '../charts.util';
 import { mainContext } from '../../common/navigation/NavigationRoutes';
+import ChartEmptyState from '../../common/emptyState/ChartEmptyState';
 
 //TODO: move to service
 export function getDeployableChartsFromConfiguredCharts(charts: ChartGroupEntry[]): DeployableCharts[] {
@@ -242,14 +241,23 @@ function DiscoverChartList() {
                         handleNameChange={handleNameChange}
                         discardValuesYamlChanges={discardValuesYamlChanges}
                     /> : 
+                    <>
+                    <ChartEmptyState
+                            title={'No charts available right now'}
+                            subTitle={'The connected chart repositories are syncing or no charts are available.'}
+                            onClickViewChartButton={handleViewAllCharts}
+                            buttonText={'View connected chart repositories'} />
+{/*                             
                             <span className='empty-height'>
                                 <EmptyState>
                                     <EmptyState.Image><img src={emptyImage} alt="" /></EmptyState.Image>
-                                    <EmptyState.Title><h4>No charts available right now</h4></EmptyState.Title>
-                                    <EmptyState.Subtitle>The connected chart repositories are syncing or no charts are available.</EmptyState.Subtitle>
-                                    <button type="button" onClick={handleViewAllCharts} className="cta ghosted mb-24 mt-10">View connected chart repositories</button>
+                                    <EmptyState.Title><h4></h4></EmptyState.Title>
+                                    <EmptyState.Subtitle></EmptyState.Subtitle>
+                                    <button type="button" className="cta ghosted mb-24 mt-10"></button>
                                 </EmptyState>
-                            </span>
+                            </span> */}
+                            </>
+                            
                         }
                 </div>
                     : <div className="discover-charts__body-details">

--- a/src/components/common/emptyState/ChartEmptyState.tsx
+++ b/src/components/common/emptyState/ChartEmptyState.tsx
@@ -3,10 +3,10 @@ import EmptyState from '../../EmptyState/EmptyState';
 import emptyImage from '../../../assets/img/empty-noresult@2x.png';
 
 interface EmptyChartType {
-    title: string;
-    subTitle: string;
+    title?: string;
+    subTitle?: string;
     onClickViewChartButton: () => void;
-    buttonText: string;
+    buttonText?: string;
     heightToDeduct?: string;
 }
 
@@ -18,11 +18,11 @@ function ChartEmptyState({ title, subTitle, onClickViewChartButton, buttonText, 
                     <img src={emptyImage} alt="" />
                 </EmptyState.Image>
                 <EmptyState.Title>
-                    <h4>{title}</h4>
+                    <h4>{title || "No matching charts"}</h4>
                 </EmptyState.Title>
-                <EmptyState.Subtitle>{subTitle}</EmptyState.Subtitle>
+                <EmptyState.Subtitle>{subTitle || "We couldn't find any matching results"}</EmptyState.Subtitle>
                 <button type="button" onClick={onClickViewChartButton} className="cta ghosted mb-24 mt-10">
-                    {buttonText}
+                    {buttonText || "View all charts"}
                 </button>
             </EmptyState>
         </span>

--- a/src/components/common/emptyState/ChartEmptyState.tsx
+++ b/src/components/common/emptyState/ChartEmptyState.tsx
@@ -2,9 +2,17 @@ import React from 'react';
 import EmptyState from '../../EmptyState/EmptyState';
 import emptyImage from '../../../assets/img/empty-noresult@2x.png';
 
-function ChartEmptyState({title, subTitle, onClickViewChartButton, buttonText}) {
+interface EmptyChartType {
+    title: string;
+    subTitle: string;
+    onClickViewChartButton: () => void;
+    buttonText: string;
+    heightToDeduct?: string;
+}
+
+function ChartEmptyState({ title, subTitle, onClickViewChartButton, buttonText, heightToDeduct }: EmptyChartType) {
     return (
-        <span className="empty-height">
+        <span className="empty-height" style={{ height: `calc(100vh - ${heightToDeduct}px)` }}>
             <EmptyState>
                 <EmptyState.Image>
                     <img src={emptyImage} alt="" />
@@ -12,9 +20,7 @@ function ChartEmptyState({title, subTitle, onClickViewChartButton, buttonText}) 
                 <EmptyState.Title>
                     <h4>{title}</h4>
                 </EmptyState.Title>
-                <EmptyState.Subtitle>
-                    {subTitle}
-                </EmptyState.Subtitle>
+                <EmptyState.Subtitle>{subTitle}</EmptyState.Subtitle>
                 <button type="button" onClick={onClickViewChartButton} className="cta ghosted mb-24 mt-10">
                     {buttonText}
                 </button>

--- a/src/components/common/emptyState/ChartEmptyState.tsx
+++ b/src/components/common/emptyState/ChartEmptyState.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import EmptyState from '../../EmptyState/EmptyState';
+import emptyImage from '../../../assets/img/empty-noresult@2x.png';
+
+function ChartEmptyState({title, subTitle, onClickViewChartButton, buttonText}) {
+    return (
+        <span className="empty-height">
+            <EmptyState>
+                <EmptyState.Image>
+                    <img src={emptyImage} alt="" />
+                </EmptyState.Image>
+                <EmptyState.Title>
+                    <h4>{title}</h4>
+                </EmptyState.Title>
+                <EmptyState.Subtitle>
+                    {subTitle}
+                </EmptyState.Subtitle>
+                <button type="button" onClick={onClickViewChartButton} className="cta ghosted mb-24 mt-10">
+                    {buttonText}
+                </button>
+            </EmptyState>
+        </span>
+    );
+}
+
+export default ChartEmptyState;

--- a/src/components/common/emptyState/ChartEmptyState.tsx
+++ b/src/components/common/emptyState/ChartEmptyState.tsx
@@ -7,22 +7,25 @@ interface EmptyChartType {
     subTitle?: string;
     onClickViewChartButton: () => void;
     buttonText?: string;
-    heightToDeduct?: string;
+    heightToDeduct?: number;
 }
 
 function ChartEmptyState({ title, subTitle, onClickViewChartButton, buttonText, heightToDeduct }: EmptyChartType) {
     return (
-        <span className="empty-height" style={{ height: `calc(100vh - ${heightToDeduct}px)` }}>
+        <span
+            className="empty-height"
+            {...(heightToDeduct >= 0 && { style: { height: `calc(100vh - ${heightToDeduct}px)` } })}
+        >
             <EmptyState>
                 <EmptyState.Image>
-                    <img src={emptyImage} alt="" />
+                    <img src={emptyImage} alt="No Result" />
                 </EmptyState.Image>
                 <EmptyState.Title>
-                    <h4>{title || "No matching charts"}</h4>
+                    <h4>{title || 'No matching charts'}</h4>
                 </EmptyState.Title>
                 <EmptyState.Subtitle>{subTitle || "We couldn't find any matching results"}</EmptyState.Subtitle>
                 <button type="button" onClick={onClickViewChartButton} className="cta ghosted mb-24 mt-10">
-                    {buttonText || "View all charts"}
+                    {buttonText || 'View all charts'}
                 </button>
             </EmptyState>
         </span>

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -2,7 +2,7 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 
 module.exports = function (app) {
     app.use("/orchestrator", createProxyMiddleware({
-        target: 'http://54.152.66.206:32080//',
+        target: 'http://demo1.devtron.info:32080/',
         changeOrigin: true,
         logLevel: 'info',
         secure: false,

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -2,7 +2,7 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 
 module.exports = function (app) {
     app.use("/orchestrator", createProxyMiddleware({
-        target: 'http://demo1.devtron.info:32080/',
+        target: 'http://54.210.45.17:32080/',
         changeOrigin: true,
         logLevel: 'info',
         secure: false,

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -2,7 +2,7 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 
 module.exports = function (app) {
     app.use("/orchestrator", createProxyMiddleware({
-        target: 'http://54.210.45.17:32080/',
+        target: 'http://demo1.devtron.info:32080/',
         changeOrigin: true,
         logLevel: 'info',
         secure: false,


### PR DESCRIPTION
# Description

1. Earlier in case, no chart is available,  there was wrong messaging in empty state
<img width="1040" alt="Screenshot 2022-03-04 at 3 32 45 PM" src="https://user-images.githubusercontent.com/61836271/156742569-3b0b4dbd-ca25-4632-b727-a5ab539e7741.png">
2. Currently replaced earlier message with the image given below
<img width="677" alt="Screenshot 2022-03-04 at 3 34 40 PM" src="https://user-images.githubusercontent.com/61836271/156742878-8cd31058-4691-4e2b-a132-b828d05d7831.png">

Fixes https://github.com/devtron-labs/devtron/issues/1307


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested out in new cluster where no chart was available 
- [x] after available charts


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


