### PR TITLE
Warning icon size in charts discover

### DIFF
--- a/src/components/charts/AdvancedConfig.tsx
+++ b/src/components/charts/AdvancedConfig.tsx
@@ -140,7 +140,7 @@ const AdvancedConfig: React.FC<AdvancedConfig> = ({ chart, index, fetchChartValu
                         <input type="text" autoComplete="off" className={`form__input ${appName?.error ? 'form__input--error' : ''}`} value={appName.value} onChange={e => handleNameChange(index, e.target.value)} />
                         {appName?.error &&
                             <span className="form__error flex left">
-                                <WarningIcon className="mr-5" />{appName?.error || ""}
+                                <WarningIcon className="mr-5 icon-dim-16" />{appName?.error || ""}
                                 {appName.suggestedName && <span>. Suggested name: <span className="anchor pointer" onClick={e => handleNameChange(index, appName.suggestedName)}>{appName.suggestedName}</span></span>}
                             </span>}
                     </div>}
@@ -151,7 +151,7 @@ const AdvancedConfig: React.FC<AdvancedConfig> = ({ chart, index, fetchChartValu
                                 <Select.Button rootClassName="select-button--default">{environments.has(environment?.id) ? environments.get(environment.id).environment_name : 'Select Environment'}</Select.Button>
                                 {Array.from(environments.values()).map(env => <Select.Option value={env.id} key={env.id}>{env.environment_name}</Select.Option>)}
                             </Select>
-                            {environment?.error && <span className="form__error flex left "><WarningIcon className="mr-5" />{environment?.error || ""}</span>}
+                            {environment?.error && <span className="form__error flex left"><WarningIcon className="mr-5 icon-dim-16" />{environment?.error || ""}</span>}
                         </div>
                         <div className="flex column half left top">
                             <label htmlFor="" className="form__label">Namespace*</label>

--- a/src/components/charts/ChartGroupAdvanceDeploy.tsx
+++ b/src/components/charts/ChartGroupAdvanceDeploy.tsx
@@ -179,7 +179,7 @@ export default function ChartGroupAdvanceDeploy() {
                                         ))}
                                     </Select>
                                     {project.error && (
-                                        <span className="form__error flex left " style={{display:"flex"}}>
+                                        <span className="form__error flex left">
                                             <WarningIcon className="mr-5 icon-dim-16" />
                                             {project.error}
                                         </span>

--- a/src/components/charts/charts.css
+++ b/src/components/charts/charts.css
@@ -343,3 +343,7 @@
 .chart-group-deployment__delete-app:hover .stroke-color {
     stroke: var(--R500);
 }
+
+.flex {
+    display: flex !important; 
+}

--- a/src/components/charts/charts.css
+++ b/src/components/charts/charts.css
@@ -344,6 +344,6 @@
     stroke: var(--R500);
 }
 
-.flex {
-    display: flex !important; 
+.form__error.flex {
+    display: flex;
 }

--- a/src/components/charts/list/DiscoverCharts.tsx
+++ b/src/components/charts/list/DiscoverCharts.tsx
@@ -322,8 +322,8 @@ function DiscoverChartList() {
                                     ))}
                                 </Select>
                                 {project.error && (
-                                    <span className="form__error flex left ">
-                                        <WarningIcon className="mr-5" />
+                                    <span className="form__error flex left">
+                                        <WarningIcon className="mr-5 icon-dim-16" />
                                         {project.error}
                                     </span>
                                 )}


### PR DESCRIPTION
# Description

In Discover, The size of the error icon is larger than it should be.

Fixes # https://github.com/devtron-labs/devtron/issues/1280

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
All changes have been tested manually.

- [x] By giving wrong input in app name and changing the environment in Advanced options.
- [x] By not choosing any project to obeserve the size of icon.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


