### PR TITLE
Some CSS and code editor changes

### DIFF
--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -112,7 +112,7 @@ interface CodeEditorState {
     height: string;
     noParsing: boolean;
 }
-const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.memo(function Editor({ value, mode = "json", noParsing = false, heightUnit="", defaultValue = "", children, tabSize = 2, lineDecorationsWidth = 0, height = 450, inline = false, shebang = "", minHeight, maxHeight, onChange, readOnly, diffView, theme="", loading, customLoader, focus, validatorSchema ,isKubernetes = true}) {
+const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.memo(function Editor({ value, mode = "json", noParsing = false, heightUnit = "", defaultValue = "", children, tabSize = 2, lineDecorationsWidth = 0, height = 450, inline = false, shebang = "", minHeight, maxHeight, onChange, readOnly, diffView, theme="", loading, customLoader, focus, validatorSchema ,isKubernetes = true}) {
     const editorRef = useRef(null)
     const monacoRef = useRef(null)
     const { width, height: windowHeight } = useWindowSize()
@@ -335,6 +335,7 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
                             editorDidMount={editorDidMount}
                             height={`${state.height}${heightUnit}` || "100%"}
                             width="100%"
+                            
                         />
                     }
                 </>

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -49,7 +49,7 @@ interface CodeEditorInterface {
     tabSize?: number;
     readOnly?: boolean;
     noParsing?: boolean;
-    autoResize?: boolean;
+    heightUnit?: string;
     minHeight?: number;
     maxHeight?: number;
     inline?: boolean;
@@ -112,7 +112,7 @@ interface CodeEditorState {
     height: string;
     noParsing: boolean;
 }
-const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.memo(function Editor({ value, mode = "json", noParsing = false, defaultValue = "", children, tabSize = 2, lineDecorationsWidth = 0, height = 450, inline = false, shebang = "", minHeight, maxHeight, onChange, readOnly, diffView, theme="", loading, customLoader, focus, validatorSchema ,isKubernetes = true}) {
+const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.memo(function Editor({ value, mode = "json", noParsing = false, heightUnit="", defaultValue = "", children, tabSize = 2, lineDecorationsWidth = 0, height = 450, inline = false, shebang = "", minHeight, maxHeight, onChange, readOnly, diffView, theme="", loading, customLoader, focus, validatorSchema ,isKubernetes = true}) {
     const editorRef = useRef(null)
     const monacoRef = useRef(null)
     const { width, height: windowHeight } = useWindowSize()
@@ -322,7 +322,7 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
                             options={options}
                             theme={state.theme.toLowerCase().split(" ").join("-")}
                             editorDidMount={editorDidMount}
-                            height={state.height || "100%"}
+                            height={`${state.height}${heightUnit}` || "100%"}
                             width="100%"
                         />
                         :
@@ -333,7 +333,7 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
                             options={options}
                             onChange={handleOnChange}
                             editorDidMount={editorDidMount}
-                            height={state.height || "100%"}
+                            height={`${state.height}${heightUnit}` || "100%"}
                             width="100%"
                         />
                     }

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -277,7 +277,7 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
                             options={options}
                             theme={state.theme.toLowerCase().split(" ").join("-")}
                             editorDidMount={editorDidMount}
-                            height={height || "100%"}
+                            height={height}
                             width="100%"
                         />
                         :
@@ -288,7 +288,7 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
                             options={options}
                             onChange={handleOnChange}
                             editorDidMount={editorDidMount}
-                            height={ height || "100%"}
+                            height={height}
                             width="100%"
                             
                         />

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -108,15 +108,12 @@ interface CodeEditorState {
     diffMode: boolean;
     theme: 'vs' | 'vs-dark';
     code: string;
-    height: string;
     noParsing: boolean;
 }
 const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.memo(function Editor({ value, mode = "json", noParsing = false, defaultValue = "", children, tabSize = 2, lineDecorationsWidth = 0, height = 450, inline = false, shebang = "", minHeight, maxHeight, onChange, readOnly, diffView, theme="", loading, customLoader, focus, validatorSchema ,isKubernetes = true}) {
     const editorRef = useRef(null)
     const monacoRef = useRef(null)
     const { width, height: windowHeight } = useWindowSize()
-    const numberOnlyRegex = /^[0-9]+$/;
-    const prevHeight = useRef<number>(0)
     const memoisedReducer = useCallback((state: CodeEditorState, action: Action) => {
         switch (action.type) {
             case 'changeLanguage':
@@ -137,7 +134,6 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
         mode,
         theme: theme || 'vs',
         code: value,
-        height: numberOnlyRegex.test(height.toString()) && height.toString() || "450",
         diffMode: diffView,
         noParsing: ['json', 'yaml'].includes(mode) ? noParsing : true
     }
@@ -168,40 +164,7 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
         
         editorRef.current = editor
         monacoRef.current = monaco
-        if (inline) {
-            updateEditorHeight();
-            editor.onDidChangeModelDecorations(() => {
-                updateEditorHeight(); // typing
-                requestAnimationFrame(updateEditorHeight); // folding
-            });
-        }
     }
-
-    const updateEditorHeight = () => {
-        const editorElement = editorRef.current.getDomNode();
-        if (!editorElement) {
-            return;
-        }
-
-        const lineHeight: number = editorRef.current.getOption(monacoRef.current.editor.EditorOption.lineHeight);
-        const lineCount: number = editorRef.current.getModel()?.getLineCount() || 1;
-        const height: number = editorRef.current.getTopForLineNumber(lineCount + 1) + lineHeight;
-
-        if (prevHeight.current !== height) {
-            if (minHeight > height) {
-                prevHeight.current = minHeight
-                dispatch({ type: 'setHeight', value: minHeight });
-            }
-            else if (maxHeight < height) {
-                prevHeight.current = maxHeight
-                dispatch({ type: 'setHeight', value: maxHeight })
-            }
-            else {
-                prevHeight.current = height;
-                dispatch({ type: 'setHeight', value: height })
-            }
-        }
-    };
 
     useEffect(() => {
         if (!validatorSchema) return;
@@ -263,14 +226,6 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
         dispatch({ type: 'setCode', value: final })
     }, [value, noParsing])
 
-
-    useEffect(() => {
-        if (numberOnlyRegex.test(height.toString()) && prevHeight.current !== height) {
-            prevHeight.current = +height;
-            dispatch({ type: 'setHeight', value: height });
-        }
-    }, [height])
-
     useEffect(() => {
       dispatch({ type: 'setDiff', value: diffView })
     }, [diffView])
@@ -322,7 +277,7 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
                             options={options}
                             theme={state.theme.toLowerCase().split(" ").join("-")}
                             editorDidMount={editorDidMount}
-                            height={numberOnlyRegex.test(height.toString()) ?  state.height : height || "100%"}
+                            height={height || "100%"}
                             width="100%"
                         />
                         :
@@ -333,7 +288,7 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
                             options={options}
                             onChange={handleOnChange}
                             editorDidMount={editorDidMount}
-                            height={numberOnlyRegex.test(height.toString()) ?  state.height : height || "100%"}
+                            height={ height || "100%"}
                             width="100%"
                             
                         />

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -49,11 +49,10 @@ interface CodeEditorInterface {
     tabSize?: number;
     readOnly?: boolean;
     noParsing?: boolean;
-    heightUnit?: string;
     minHeight?: number;
     maxHeight?: number;
     inline?: boolean;
-    height?: number;
+    height?: number | string;
     shebang?: string | JSX.Element;
     diffView?: boolean;
     loading?: boolean;
@@ -112,10 +111,11 @@ interface CodeEditorState {
     height: string;
     noParsing: boolean;
 }
-const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.memo(function Editor({ value, mode = "json", noParsing = false, heightUnit = "", defaultValue = "", children, tabSize = 2, lineDecorationsWidth = 0, height = 450, inline = false, shebang = "", minHeight, maxHeight, onChange, readOnly, diffView, theme="", loading, customLoader, focus, validatorSchema ,isKubernetes = true}) {
+const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.memo(function Editor({ value, mode = "json", noParsing = false, defaultValue = "", children, tabSize = 2, lineDecorationsWidth = 0, height = 450, inline = false, shebang = "", minHeight, maxHeight, onChange, readOnly, diffView, theme="", loading, customLoader, focus, validatorSchema ,isKubernetes = true}) {
     const editorRef = useRef(null)
     const monacoRef = useRef(null)
     const { width, height: windowHeight } = useWindowSize()
+    const numberOnlyRegex = /^[0-9]+$/;
     const prevHeight = useRef<number>(0)
     const memoisedReducer = useCallback((state: CodeEditorState, action: Action) => {
         switch (action.type) {
@@ -137,7 +137,7 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
         mode,
         theme: theme || 'vs',
         code: value,
-        height: height.toString(),
+        height: numberOnlyRegex.test(height.toString()) && height.toString() || "450",
         diffMode: diffView,
         noParsing: ['json', 'yaml'].includes(mode) ? noParsing : true
     }
@@ -265,9 +265,9 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
 
 
     useEffect(() => {
-        if (prevHeight.current !== height) {
-            prevHeight.current = height;
-            dispatch({ type: 'setHeight', value: height })
+        if (numberOnlyRegex.test(height.toString()) && prevHeight.current !== height) {
+            prevHeight.current = +height;
+            dispatch({ type: 'setHeight', value: height });
         }
     }, [height])
 
@@ -322,7 +322,7 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
                             options={options}
                             theme={state.theme.toLowerCase().split(" ").join("-")}
                             editorDidMount={editorDidMount}
-                            height={`${state.height}${heightUnit}` || "100%"}
+                            height={numberOnlyRegex.test(height.toString()) ?  state.height : height || "100%"}
                             width="100%"
                         />
                         :
@@ -333,7 +333,7 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
                             options={options}
                             onChange={handleOnChange}
                             editorDidMount={editorDidMount}
-                            height={`${state.height}${heightUnit}` || "100%"}
+                            height={numberOnlyRegex.test(height.toString()) ?  state.height : height || "100%"}
                             width="100%"
                             
                         />

--- a/src/components/EnvironmentOverride/DeploymentTemplateOverride.tsx
+++ b/src/components/EnvironmentOverride/DeploymentTemplateOverride.tsx
@@ -272,7 +272,6 @@ function DeploymentTemplateOverrideForm({ state, handleOverride, dispatch, initi
                     handleClose={e => setReadme(false)}
                     schema={state.data.schema}
                     defaultValue={state && state.data && state.duplicate ? YAML.stringify(state.data.globalConfig, { indent: 2 }) : ""}
-                    height={500}
                     readOnly={!state.duplicate}
                     readme={state.data.readme}
                 />

--- a/src/components/charts/AdvancedConfig.tsx
+++ b/src/components/charts/AdvancedConfig.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react'
-import { Select, showError, mapByKey, Progressing, VisibleModal, useAsync, useKeyDown, Info, Pencil, useSize } from '../common'
+import { Select, showError, mapByKey, Progressing, VisibleModal, useAsync, useKeyDown, Info, Pencil } from '../common'
 import CodeEditor from '../CodeEditor/CodeEditor'
 import { getEnvironmentListMin } from '../../services/service'
 import { ChartGroupEntry, AdvancedConfigHelpers, ChartValuesNativeType, ChartVersionType } from './charts.types'
@@ -274,7 +274,6 @@ export default AdvancedConfig
 
 function ReadmeCharts({ readme, valuesYaml, onChange, handleClose, chart }) {
     const key = useKeyDown()
-    const { target, height, width } = useSize()
     useEffect(() => {
         if (key.join().includes('Escape')) {
             handleClose()
@@ -283,7 +282,7 @@ function ReadmeCharts({ readme, valuesYaml, onChange, handleClose, chart }) {
     return (
         <div className="advanced-config__readme">
             <h3>{chart.chartMetaData.chartName}</h3>
-            <div ref={target} className="readme-config-container">
+            <div className="readme-config-container">
                 <div className="readme-config--header">
                     <h5 className="flex left">Readme.md</h5>
                     <h5 className="flex left">
@@ -301,7 +300,7 @@ function ReadmeCharts({ readme, valuesYaml, onChange, handleClose, chart }) {
                             mode="yaml"
                             noParsing
                             readOnly={!onChange}
-                            height={height}
+                            height={"100%"}
                             onChange={onChange ? valuesYaml => onChange(valuesYaml) : () => { }}
                         />
                     </div>
@@ -318,7 +317,6 @@ function ValuesDiffViewer({ chartName, appName, valuesYaml, selectedChartValue, 
     const [versionId, setVersionId] = useState(selectedChartValue.id);
     const [kind, setKind] = useState(originalKind);
     const [originalValuesYaml, setOriginalValuesYaml] = useState("");
-    const { target, height, width } = useSize();
 
     const { DEFAULT, TEMPLATE, DEPLOYED } = availableChartValues.reduce((agg, { kind, values }) => {
         agg[kind] = values
@@ -388,7 +386,7 @@ function ValuesDiffViewer({ chartName, appName, valuesYaml, selectedChartValue, 
                         <Pencil style={{ marginLeft: 'auto' }} />
                     </h5>
                 </div>
-                <div ref={target} className="readme-config--body" style={{ gridTemplateColumns: '1fr' }}>
+                <div className="readme-config--body" style={{ gridTemplateColumns: '1fr' }}>
                     <CodeEditor
                         defaultValue={originalValuesYaml}
                         value={valuesYaml}
@@ -396,7 +394,7 @@ function ValuesDiffViewer({ chartName, appName, valuesYaml, selectedChartValue, 
                         noParsing
                         loading={loading && !originalValuesYaml}
                         readOnly={!onChange}
-                        height={height}
+                        height={"100%"}
                         diffView
                         onChange={onChange ? valuesYaml => onChange(valuesYaml) : () => { }}
                     >

--- a/src/components/deploymentConfig/DeploymentConfig.tsx
+++ b/src/components/deploymentConfig/DeploymentConfig.tsx
@@ -391,7 +391,6 @@ function DeploymentConfigForm({ respondOnSuccess, isUnSet }) {
                 <VisibleModal className="">
                     <ReadmeConfig
                         value={tempFormData}
-                        height={500}
                         schema={schemas}
                         onChange={(resp) => {
                             setTempFormData(resp);

--- a/src/components/deploymentConfig/ReadmeConfig.tsx
+++ b/src/components/deploymentConfig/ReadmeConfig.tsx
@@ -57,8 +57,7 @@ function ReadmeConfig({ readme, value, handleClose, loading, onChange, schema, r
                     <CodeEditor
                         value={value}
                         defaultValue={defaultValue}
-                        height={100}
-                        heightUnit="%"
+                        height={"calc(100% - 42px)"}
                         readOnly={readOnly}
                         validatorSchema={schema}
                         onChange={setTempForm}

--- a/src/components/deploymentConfig/ReadmeConfig.tsx
+++ b/src/components/deploymentConfig/ReadmeConfig.tsx
@@ -12,14 +12,13 @@ interface Readme {
     value: string;
     handleClose: any;
     loading: boolean;
-    height?: number;
     onChange: any;
     schema?: any;
     readOnly?: boolean;
     defaultValue?: string;
 }
 
-function ReadmeConfig({ readme, value, handleClose, loading, height, onChange, schema, readOnly, defaultValue }:Readme) {
+function ReadmeConfig({ readme, value, handleClose, loading, onChange, schema, readOnly, defaultValue }:Readme) {
     const key = useKeyDown();
     const [tempForm, setTempForm] = useState();
     useEffect(() => {
@@ -54,11 +53,12 @@ function ReadmeConfig({ readme, value, handleClose, loading, height, onChange, s
                         <MarkDown markdown={readme} />
                     </div>
                 </div>
-                <div className="bw-1 br-4 bcn-0">
+                <div className="bw-1 br-4 bcn-0 codeEditor">
                     <CodeEditor
                         value={value}
                         defaultValue={defaultValue}
-                        height={height}
+                        height={100}
+                        heightUnit="%"
                         readOnly={readOnly}
                         validatorSchema={schema}
                         onChange={setTempForm}

--- a/src/components/deploymentConfig/ReadmeConfig.tsx
+++ b/src/components/deploymentConfig/ReadmeConfig.tsx
@@ -53,7 +53,7 @@ function ReadmeConfig({ readme, value, handleClose, loading, onChange, schema, r
                         <MarkDown markdown={readme} />
                     </div>
                 </div>
-                <div className="bw-1 br-4 bcn-0 codeEditor">
+                <div className="bw-1 br-4 bcn-0 code-editor">
                     <CodeEditor
                         value={value}
                         defaultValue={defaultValue}

--- a/src/components/deploymentConfig/deploymentConfig.scss
+++ b/src/components/deploymentConfig/deploymentConfig.scss
@@ -68,10 +68,6 @@
     margin: 50px 50px;
     display: grid;
     grid-row-gap: 12px;
-    // transform: translate(-50%, -50%);
-    // top: 50%;
-    // left: 50%;
-    // position: relative;
     
     .config-editor{
         display: grid;

--- a/src/components/deploymentConfig/deploymentConfig.scss
+++ b/src/components/deploymentConfig/deploymentConfig.scss
@@ -62,20 +62,22 @@
 }
 
 .advanced-config-readme{
-    height: 650px;
+    height: calc(100vh - 100px);
     width: calc(100vw - 100px);
     background: var(--N000);
-   
+    margin: 50px 50px;
     display: grid;
     grid-row-gap: 12px;
-    transform: translate(-50%, -50%);
-    top: 50%;
-    left: 50%;
-    position: relative;
+    // transform: translate(-50%, -50%);
+    // top: 50%;
+    // left: 50%;
+    // position: relative;
     
     .config-editor{
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: 50% 50%;
+        min-height: 0;
+        height: 100%;
     }
 
     .infobar{
@@ -89,13 +91,20 @@
     }
 
     .readme{
-        height: 500px;
+        height: calc(100% - 40px);
         overflow-y: scroll;
+        min-height: 0;
     }
 
     .readmeEditor{
         background: var(--N000);
         border-right: 1px solid #D0D4D9;
-        height: 550px;
+        height:100%;
+        min-height: 0;
+    }
+
+    .codeEditor{
+        min-height: 0;
+        height: calc(100% - 42px);
     }
 }

--- a/src/components/deploymentConfig/deploymentConfig.scss
+++ b/src/components/deploymentConfig/deploymentConfig.scss
@@ -99,7 +99,7 @@
         min-height: 0;
     }
 
-    .codeEditor{
+    .code-editor{
         min-height: 0;
         height: calc(100% - 42px);
     }

--- a/src/components/deploymentConfig/deploymentConfig.scss
+++ b/src/components/deploymentConfig/deploymentConfig.scss
@@ -62,10 +62,10 @@
 }
 
 .advanced-config-readme{
-    height: calc(100vh - 100px);
+    height: calc(100vh - 80px);
     width: calc(100vw - 100px);
     background: var(--N000);
-    margin: 50px 50px;
+    margin: 40px 50px;
     display: grid;
     grid-row-gap: 12px;
     

--- a/src/components/deploymentConfig/deploymentConfig.scss
+++ b/src/components/deploymentConfig/deploymentConfig.scss
@@ -95,12 +95,12 @@
     .readmeEditor{
         background: var(--N000);
         border-right: 1px solid #D0D4D9;
-        height:100%;
+        height: 100%;
         min-height: 0;
     }
 
     .code-editor{
         min-height: 0;
-        height: calc(100% - 42px);
+        height: 100%;
     }
 }

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Manifest.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Manifest.component.tsx
@@ -298,7 +298,7 @@ function ManifestComponent({ selectedTab, isDeleted }) {
                                 defaultValue={activeTab === 'Compare' && desiredManifest}
                                 diffView={activeTab === 'Compare'}
                                 theme="vs-dark--dt"
-                                height={700}
+                                height={"100vh"}
                                 value={activeManifestEditorData}
                                 mode="yaml"
                                 readOnly={activeTab !== 'Live manifest' || !isEditmode}


### PR DESCRIPTION
# Description

Currently, the code editor height in the readme modal is fixed to a numeric value. We need to make the code-editor height dynamic based on available screen size.

Fixes # https://github.com/devtron-labs/devtron/issues/1318

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
All tests have been performed manually.

- [x] By manually changing screen resolution and size.
- [x] Tested on other browser ex. Firefox, chrome etc.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


