### PR TITLE
Enhancements: UX/UI Changes for handling error on chart updation if chart is deployed from terminal

### DIFF
--- a/src/components/chartRepo/ChartRepo.tsx
+++ b/src/components/chartRepo/ChartRepo.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { showError, useForm, useEffectAfterMount, useAsync, Progressing } from '../common'
+import { showError, useForm, useEffectAfterMount, useAsync, Progressing, ToastBody } from '../common'
 import { toast } from 'react-toastify'
 import { List, CustomInput, ProtectedInput } from '../globalConfigurations/GlobalConfiguration'
 import Tippy from '@tippyjs/react';
@@ -216,10 +216,14 @@ function ChartForm({ id = null, name = "", active = false, url = "", authMode = 
 
             if (result && !result?.actualErrMsg) {
                 setValidationStatus(VALIDATION_STATUS.SUCCESS)
-                toast.success('Successfully saved.')
+                toast.success(
+                    <ToastBody
+                        title="Chart repo added."
+                        subtitle="It may take upto 5 mins for the charts to be available in the chart store."
+                    />,
+                );
                 await reload();
-            }
-            else {
+            } else {
                 setValidationStatus(VALIDATION_STATUS.FAILURE)
                 setLoading(false);
                 setValidationError({ errtitle: result?.customErrMsg, errMessage: result.actualErrMsg })

--- a/src/components/chartRepo/ChartRepo.tsx
+++ b/src/components/chartRepo/ChartRepo.tsx
@@ -218,8 +218,8 @@ function ChartForm({ id = null, name = "", active = false, url = "", authMode = 
                 setValidationStatus(VALIDATION_STATUS.SUCCESS)
                 toast.success(
                     <ToastBody
-                        title="Chart repo added."
-                        subtitle="It may take upto 5 mins for the charts to be available in the chart store."
+                        title="Chart repo saved"
+                        subtitle="It may take upto 5 mins for the charts to be listed in the chart store."
                     />,
                 );
                 await reload();

--- a/src/components/charts/modal/DeployChart.scss
+++ b/src/components/charts/modal/DeployChart.scss
@@ -135,13 +135,65 @@
     color: var(--Y700);
 }
 
-.deprecated-text-image {
+.deprecated-text-image,
+.no-helm-chart-linked {
     font-size: 11px;
     margin: 4px 0 0 0;
     line-height: 1.45;
     color: var(--Y700);
-    .deprecated-text {
+
+    .deprecated-text,
+    .no-helm-chart-linked-text {
         margin: 0 0 0 4px;
+    }
+}
+
+.no-helm-chart-linked {
+    color: var(--R500);
+}
+
+.no-helm-chart-linked svg path:nth-child(2) {
+    fill: var(--R500);
+}
+
+.repo-chart-selector {
+    div:first-child {
+        width: 100%;
+    }
+
+    .code-editor__information-info-icon path:nth-child(2) {
+        fill: var(--V500);
+    }
+
+    .refresh-charts {
+        background-color: var(--N100);
+        border: solid 1px var(--N200);
+        border-radius: 4px;
+        margin-left: 8px;
+
+        svg path {
+            fill: var(--N600);
+        }
+
+        &.refreshing {
+            cursor: not-allowed;
+
+            svg {
+                animation-name: refresh;
+                animation-duration: 1s;
+                animation-iteration-count: infinite;
+                animation-timing-function: linear;
+            }
+
+            @keyframes refresh {
+                0% {
+                    transform: rotate(360deg);
+                }
+                100% {
+                    transform: rotate(0deg);
+                }
+            } 
+        }
     }
 }
 

--- a/src/components/charts/modal/DeployChart.scss
+++ b/src/components/charts/modal/DeployChart.scss
@@ -165,6 +165,18 @@
         fill: var(--V500);
     }
 
+    .sticky-information__bottom {
+        background-color: var(--V100);
+        justify-content: flex-start;
+        padding: 10px 12px;
+        margin: 8px 8px;
+        border-radius: 4px;
+
+        a {
+            color: var(--B500);
+        }
+    }
+
     .refetch-charts {
         background-color: var(--N100);
         border: solid 1px var(--N200);
@@ -192,7 +204,7 @@
                 100% {
                     transform: rotate(0deg);
                 }
-            } 
+            }
         }
     }
 }

--- a/src/components/charts/modal/DeployChart.scss
+++ b/src/components/charts/modal/DeployChart.scss
@@ -165,7 +165,7 @@
         fill: var(--V500);
     }
 
-    .refresh-charts {
+    .refetch-charts {
         background-color: var(--N100);
         border: solid 1px var(--N200);
         border-radius: 4px;
@@ -175,17 +175,17 @@
             fill: var(--N600);
         }
 
-        &.refreshing {
+        &.refetching {
             cursor: not-allowed;
 
             svg {
-                animation-name: refresh;
+                animation-name: refetch;
                 animation-duration: 1s;
                 animation-iteration-count: infinite;
                 animation-timing-function: linear;
             }
 
-            @keyframes refresh {
+            @keyframes refetch {
                 0% {
                     transform: rotate(360deg);
                 }

--- a/src/components/charts/modal/DeployChart.scss
+++ b/src/components/charts/modal/DeployChart.scss
@@ -255,3 +255,7 @@
 .update_deploy-chart-container_header {
     grid-template-rows: 60px 1fr 64px;
 }
+
+.no-readme-icon path:nth-child(2) {
+    fill: var(--N500);
+}

--- a/src/components/charts/util/ChartValueSelect.tsx
+++ b/src/components/charts/util/ChartValueSelect.tsx
@@ -37,16 +37,22 @@ export class ChartValuesSelect extends Component<ChartValuesSelectProps> {
         </div>
     }
 
+    getChartValueLabel(selectedChartValue: ChartValuesType): string {
+        return selectedChartValue
+            ? `${selectedChartValue.name}${
+                  this.props.hideVersionFromLabel || !selectedChartValue.chartVersion
+                      ? ''
+                      : ` (${selectedChartValue.chartVersion})`
+              }`
+            : 'Select Chart Value';
+    }
+
     render() {
         let chartValuesList = this.props.chartValuesList;
         let chartValues = getChartValuesFiltered(this.props.chartValuesList);
         let selectedChartValue = chartValuesList.find(chartValue => this.props.chartValues.id === chartValue.id && chartValue.kind === this.props.chartValues.kind);
-        let label = "Select Chart Value";
-        if (selectedChartValue) {
-            label = `${selectedChartValue.name}${
-                this.props.hideVersionFromLabel ? '' : ` (${selectedChartValue.chartVersion})`
-            }`;
-        }
+        const label = this.getChartValueLabel(selectedChartValue);
+
         return <>
             <Select tabIndex={this.props.tabIndex || 0}
                 rootClassName="select-button--default"
@@ -77,7 +83,9 @@ export class ChartValuesSelect extends Component<ChartValuesSelectProps> {
                     {chartValues.existingChartValues.length ? chartValues.existingChartValues.map((chartValue) => {
                         return <Select.Option key={chartValue.id} value={chartValue}>
                                           {`${chartValue.name}${
-                                              this.props.hideVersionFromLabel ? '' : ` (${chartValue.chartVersion})`
+                                              this.props.hideVersionFromLabel || !chartValue.chartVersion
+                                                  ? ''
+                                                  : ` (${chartValue.chartVersion})`
                                           }`}
                     </Select.Option>
                     }) : this.renderNoResultsOption()}

--- a/src/components/charts/util/ChartValueSelect.tsx
+++ b/src/components/charts/util/ChartValueSelect.tsx
@@ -37,21 +37,17 @@ export class ChartValuesSelect extends Component<ChartValuesSelectProps> {
         </div>
     }
 
-    getChartValueLabel(selectedChartValue: ChartValuesType): string {
-        return selectedChartValue
-            ? `${selectedChartValue.name}${
-                  this.props.hideVersionFromLabel || !selectedChartValue.chartVersion
-                      ? ''
-                      : ` (${selectedChartValue.chartVersion})`
-              }`
-            : 'Select Chart Value';
+    getChartValueLabel(chartName: string, version: string): string {
+        return `${chartName}${this.props.hideVersionFromLabel || !version ? '' : ` (${version})`}`;
     }
 
     render() {
         let chartValuesList = this.props.chartValuesList;
         let chartValues = getChartValuesFiltered(this.props.chartValuesList);
         let selectedChartValue = chartValuesList.find(chartValue => this.props.chartValues.id === chartValue.id && chartValue.kind === this.props.chartValues.kind);
-        const label = this.getChartValueLabel(selectedChartValue);
+        const label = selectedChartValue
+            ? this.getChartValueLabel(selectedChartValue.name, selectedChartValue.chartVersion)
+            : 'Select Chart Value';
 
         return <>
             <Select tabIndex={this.props.tabIndex || 0}
@@ -82,11 +78,7 @@ export class ChartValuesSelect extends Component<ChartValuesSelectProps> {
                 <Select.OptGroup label="EXISTING" key={"EXISTING"}>
                     {chartValues.existingChartValues.length ? chartValues.existingChartValues.map((chartValue) => {
                         return <Select.Option key={chartValue.id} value={chartValue}>
-                                          {`${chartValue.name}${
-                                              this.props.hideVersionFromLabel || !chartValue.chartVersion
-                                                  ? ''
-                                                  : ` (${chartValue.chartVersion})`
-                                          }`}
+                                          {this.getChartValueLabel(chartValue.name, chartValue.chartVersion)}
                     </Select.Option>
                     }) : this.renderNoResultsOption()}
                 </Select.OptGroup>

--- a/src/components/charts/util/ChartValueSelect.tsx
+++ b/src/components/charts/util/ChartValueSelect.tsx
@@ -10,6 +10,7 @@ export interface ChartValuesSelectProps {
     tabIndex?: number;
     chartValues: ChartValuesType;
     chartValuesList: ChartValuesType[];
+    hideVersionFromLabel?: boolean;
 }
 
 export class ChartValuesSelect extends Component<ChartValuesSelectProps> {
@@ -42,7 +43,9 @@ export class ChartValuesSelect extends Component<ChartValuesSelectProps> {
         let selectedChartValue = chartValuesList.find(chartValue => this.props.chartValues.id === chartValue.id && chartValue.kind === this.props.chartValues.kind);
         let label = "Select Chart Value";
         if (selectedChartValue) {
-            label = `${selectedChartValue.name} (${selectedChartValue.chartVersion})`
+            label = `${selectedChartValue.name}${
+                this.props.hideVersionFromLabel ? '' : ` (${selectedChartValue.chartVersion})`
+            }`;
         }
         return <>
             <Select tabIndex={this.props.tabIndex || 0}
@@ -73,7 +76,9 @@ export class ChartValuesSelect extends Component<ChartValuesSelectProps> {
                 <Select.OptGroup label="EXISTING" key={"EXISTING"}>
                     {chartValues.existingChartValues.length ? chartValues.existingChartValues.map((chartValue) => {
                         return <Select.Option key={chartValue.id} value={chartValue}>
-                            {chartValue.name} ({chartValue.chartVersion})
+                                          {`${chartValue.name}${
+                                              this.props.hideVersionFromLabel ? '' : ` (${chartValue.chartVersion})`
+                                          }`}
                     </Select.Option>
                     }) : this.renderNoResultsOption()}
                 </Select.OptGroup>

--- a/src/components/common/dialogs/DeleteDialog.tsx
+++ b/src/components/common/dialogs/DeleteDialog.tsx
@@ -23,7 +23,7 @@ export const DeleteDialog: React.FC<DeleteDialogProps> & { Description?: React.F
         <ConfirmationDialog.ButtonGroup>
             <div className="flex right">
                 <button type="button" className="cta cancel cta-cd-delete-modal ml-16" onClick={props.closeDelete}>Cancel</button>
-                <button type="button" className="cta delete ml-16" onClick={props.delete}>{props.deletePrefix}Delete</button>
+                <button type="button" className="cta delete cta-cd-delete-modal ml-16" onClick={props.delete}>{props.deletePrefix}Delete</button>
             </div>
         </ConfirmationDialog.ButtonGroup>
     </ConfirmationDialog >

--- a/src/components/external-apps/ExternalAppService.ts
+++ b/src/components/external-apps/ExternalAppService.ts
@@ -109,6 +109,14 @@ export interface UpdateApplicationRequest {
     valuesYaml: string
 }
 
+export interface LinkToChartStoreRequest {
+    appId: string;
+    valuesYaml: string;
+    appStoreApplicationVersionId: number;
+    referenceValueId: number;
+    referenceValueKind: string;
+}
+
 export const getReleaseInfo = (appId: string): Promise<ReleaseInfoResponse> => {
     let url = `${Routes.HELM_RELEASE_INFO_API}?appId=${appId}`
     return get(url);
@@ -137,6 +145,9 @@ export const deleteApplicationRelease = (appId: string): Promise<UninstallReleas
 }
 
 export const updateApplicationRelease = (requestPayload: UpdateApplicationRequest): Promise<UpdateReleaseResponse> => {
-    let url = `${Routes.HELM_RELEASE_APP_UPDATE_API}`
-    return put(url, requestPayload);
-}
+    return put(Routes.HELM_RELEASE_APP_UPDATE_API, requestPayload);
+};
+
+export const linkToChartStore = (request: LinkToChartStoreRequest): Promise<UpdateReleaseResponse> => {
+    return put(Routes.HELM_LINK_TO_CHART_STORE_API, request);
+};

--- a/src/components/v2/common/message.ui.tsx
+++ b/src/components/v2/common/message.ui.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
 import { ReactComponent as InfoIcon } from '../assets/icons/ic-info-outline-gray.svg';
 import { ReactComponent as MultipleContainer } from '../assets/icons/ic-select-container.svg';
+import { ReactComponent as ErrorIcon } from '../../../assets/icons/ic-error-exclamation.svg';
 import { Pod as PodIcon, Progressing } from '../../common';
 
 export enum MsgUIType {
     LOADING = 'loading',
     POD = 'pod',
     MULTI_CONTAINER = 'multi_container',
+    ERROR = 'error',
 }
 
 export interface MsgUIProps {
     msg: string;
     icon?: MsgUIType;
-    theme?: 'white' | 'dark';
+    theme?: 'white' | 'dark' | 'light-gray';
     iconClassName?: string;
     bodyStyle?: any;
     msgStyle?: any;
@@ -59,6 +61,8 @@ const MessageUI: React.FC<MsgUIProps> = ({
                             );
                         case MsgUIType.MULTI_CONTAINER:
                             return <MultipleContainer className={iconClassName || ''} />;
+                        case MsgUIType.ERROR:
+                            return <ErrorIcon className={iconClassName || ''} width={size} height={size} />;
                         default:
                             return <InfoIcon className={`fcn-0 ${iconClassName || ''}`} width={size} height={size} />;
                     }

--- a/src/components/v2/values/DeployChart.tsx
+++ b/src/components/v2/values/DeployChart.tsx
@@ -1,594 +1,496 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Select, Page, DropdownIcon, Progressing, showError, useJsonYaml, DeleteDialog, sortCallback } from '../../common';
+import { Progressing, showError, useJsonYaml, sortCallback } from '../../common';
 import { getEnvironmentListMin, getTeamListMin } from '../../../services/service';
 import { toast } from 'react-toastify';
-import { ReactComponent as AlertTriangle } from '../../../assets/icons/ic-alert-triangle.svg';
-import { useHistory, useParams, useRouteMatch, } from 'react-router'
-import { URLS } from '../../../config'
-import CodeEditor from '../../CodeEditor/CodeEditor'
-import AsyncSelect from 'react-select/async';
-import checkIcon from '../../../assets/icons/appstatus/ic-check.svg'
-import ReactGA from 'react-ga';
+import { useHistory, useParams, useRouteMatch } from 'react-router';
+import { URLS } from '../../../config';
 import ReactSelect from 'react-select';
 import '../../charts/modal/DeployChart.scss';
 import { ServerErrors } from '../../../modals/commonTypes';
 import ForceDeleteDialog from '../../common/dialogs/ForceDeleteDialog';
 import { getChartValuesURL } from '../../charts/charts.helper';
 import { menuList } from '../../charts/charts.util';
-import { MarkDown } from '../../charts/discoverChartDetail/DiscoverChartDetails';
 import { DeployChartProps } from '../../charts/modal/deployChart.types';
-import { ChartValuesSelect } from '../../charts/util/ChartValueSelect';
 import { DropdownIndicator, styles } from '../common/ReactSelect.utils';
-import ReadmeColumn  from './common/ReadmeColumn.component';
-import { getChartValuesCategorizedListParsed, updateChart, installChart, getChartValues, deleteInstalledChart, getChartVersionsMin, getChartsByKeyword } from '../../charts/charts.service';
+import {
+    getChartValuesCategorizedListParsed,
+    updateChart,
+    installChart,
+    getChartValues,
+    deleteInstalledChart,
+} from '../../charts/charts.service';
+import {
+    ChartDeprecated,
+    ChartEnvironmentSelector,
+    ChartRepoSelector,
+    ChartVersionValuesSelector,
+    ActiveReadmeColumn,
+    DeleteChartDialog,
+    ChartValuesEditor,
+} from './common/ChartValuesSelectors';
+import { fetchChartVersionsData, getChartValuesList } from './common/chartValues.api';
 
 function mapById(arr) {
-	if (!Array.isArray(arr)) {
-		throw 'parameter is not an array'
-	}
-	return arr.reduce((agg, curr) => agg.set(curr.id || curr.Id, curr), new Map())
+    if (!Array.isArray(arr)) {
+        throw 'parameter is not an array';
+    }
+    return arr.reduce((agg, curr) => agg.set(curr.id || curr.Id, curr), new Map());
 }
 
-interface chartRepoOtions {
-	appStoreApplicationVersionId: number,
-	chartRepoName: string,
-	chartId: number,
-	chartName: string,
-	version: string,
-	deprecated: boolean,
+export interface ChartRepoOtions {
+    appStoreApplicationVersionId: number;
+    chartRepoName: string;
+    chartId: number;
+    chartName: string;
+    version: string;
+    deprecated: boolean;
 }
 
 const DeployChart: React.FC<DeployChartProps> = ({
-	installedAppId,
-	installedAppVersion,
-	appStoreVersion,
-	appName: originalName,
-	versions,
-	valuesYaml = JSON.stringify({}),
-	rawValues = "",
-	environmentId = null,
-	teamId = null,
-	onHide,
-	chartName = "",
-	name = "",
-	readme = "",
-	deprecated = false,
-	appStoreId = 0,
-	chartIdFromDeploymentDetail = 0,
-	installedAppVersionId = 0,
-	chartValuesFromParent = { id: 0, name: '', chartVersion: '', kind: null, environmentName: "" },
-	...rest }) => {
-	const [environments, setEnvironments] = useState([])
-	const [projects, setProjects] = useState([])
-	const [loading, setLoading] = useState(false);
-	const [selectedVersion, selectVersion] = useState(appStoreVersion)
-	const [selectedVersionUpdatePage, setSelectedVersionUpdatePage] = useState(versions.get(selectedVersion))
-	const [selectedProject, selectProject] = useState<{ label: string; value: number }>()
-	const [chartVersionsData, setChartVersionsData] = useState<{ version: string, id: number }[]>([]);
-	const [selectedEnvironment, selectEnvironment] = useState<{ label: string; value: number }>(undefined)
-	const [appName, setAppName] = useState(originalName)
-	const [readmeCollapsed, toggleReadmeCollapsed] = useState(true)
-	const [deleting, setDeleting] = useState(false)
-	const [confirmation, toggleConfirmation] = useState(false)
-	const [showForceDeleteDialog, setForceDeleteDialog] = useState(false)
-	const [forceDeleteDialogMessage, setForceDeleteErrorMessage] = useState("")
-	const [forceDeleteDialogTitle, setForceDeleteErroTitle] = useState("")
-	const [textRef, setTextRef] = useState(rawValues)
-	const [repoChartAPIMade, setRepoChartAPIMade] = useState(false);
-	const [repoChartOptions, setRepoChartOptions] = useState<chartRepoOtions[] | null>([
-		{
-			appStoreApplicationVersionId: appStoreVersion,
-			chartRepoName: chartName,
-			chartId: appStoreId,
-			chartName: name,
-			version: versions.get(selectedVersion).version,
-			deprecated: deprecated,
-		}
-	]);
-	const [repoChartValue, setRepoChartValue] = useState<chartRepoOtions>(
-		{
-			appStoreApplicationVersionId: appStoreVersion,
-			chartRepoName: chartName,
-			chartId: appStoreId,
-			chartName: name,
-			version: versions.get(selectedVersion).version,
-			deprecated: deprecated,
-		},
-	);
-	const [obj, json, yaml, error] = useJsonYaml(textRef, 4, 'yaml', true)
-	const [chartValuesList, setChartValuesList] = useState([])
-	const initialChartValuesFromParent = chartValuesFromParent;
-	const [chartValues, setChartValues] = useState(chartValuesFromParent);
-	const { push } = useHistory()
-	const { chartId, envId } = useParams<{ chartId, envId }>()
-	const [showCodeEditorError, setCodeEditorError] = useState(false);
-	const deployChartForm = useRef(null);
-	const deployChartEditor = useRef(null);
-	const history = useHistory()
-	const {url} = useRouteMatch()
+    installedAppId,
+    installedAppVersion,
+    appStoreVersion,
+    appName: originalName,
+    versions,
+    valuesYaml = JSON.stringify({}),
+    rawValues = '',
+    environmentId = null,
+    teamId = null,
+    onHide,
+    chartName = '',
+    name = '',
+    readme = '',
+    deprecated = false,
+    appStoreId = 0,
+    chartIdFromDeploymentDetail = 0,
+    installedAppVersionId = 0,
+    chartValuesFromParent = { id: 0, name: '', chartVersion: '', kind: null, environmentName: '' },
+    ...rest
+}: DeployChartProps) => {
+    const [environments, setEnvironments] = useState([]);
+    const [projects, setProjects] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [selectedVersion, selectVersion] = useState(appStoreVersion);
+    const [selectedVersionUpdatePage, setSelectedVersionUpdatePage] = useState(versions.get(selectedVersion));
+    const [selectedProject, selectProject] = useState<{ label: string; value: number }>();
+    const [chartVersionsData, setChartVersionsData] = useState<{ version: string; id: number }[]>([]);
+    const [selectedEnvironment, selectEnvironment] = useState<{ label: string; value: number }>(undefined);
+    const [appName, setAppName] = useState(originalName);
+    const [readmeCollapsed, toggleReadmeCollapsed] = useState(true);
+    const [deleting, setDeleting] = useState(false);
+    const [confirmation, toggleConfirmation] = useState(false);
+    const [showForceDeleteDialog, setForceDeleteDialog] = useState(false);
+    const [forceDeleteDialogMessage, setForceDeleteErrorMessage] = useState('');
+    const [forceDeleteDialogTitle, setForceDeleteErroTitle] = useState('');
+    const [textRef, setTextRef] = useState(rawValues);
+    const [repoChartValue, setRepoChartValue] = useState<ChartRepoOtions>({
+        appStoreApplicationVersionId: appStoreVersion,
+        chartRepoName: chartName,
+        chartId: appStoreId,
+        chartName: name,
+        version: versions.get(selectedVersion).version,
+        deprecated: deprecated,
+    });
+    const [obj, json, yaml, error] = useJsonYaml(textRef, 4, 'yaml', true);
+    const [chartValuesList, setChartValuesList] = useState([]);
+    const initialChartValuesFromParent = chartValuesFromParent;
+    const [chartValues, setChartValues] = useState(chartValuesFromParent);
+    const { push } = useHistory();
+    const { chartId, envId } = useParams<{ chartId; envId }>();
+    const [showCodeEditorError, setCodeEditorError] = useState(false);
+    const deployChartForm = useRef(null);
+    const deployChartEditor = useRef(null);
+    const history = useHistory();
+    const { url } = useRouteMatch();
 
-	const fetchProjects = async () => {
-		let { result } = await getTeamListMin();
-		let projectList = result.map((p) => { return { value: p.id, label: p.name } });
-		projectList = projectList.sort((a, b) => sortCallback('label', a, b, true));
-		setProjects(projectList);
-	}
+    const fetchProjects = async () => {
+        let { result } = await getTeamListMin();
+        let projectList = result.map((p) => {
+            return { value: p.id, label: p.name };
+        });
+        projectList = projectList.sort((a, b) => sortCallback('label', a, b, true));
+        setProjects(projectList);
+    };
 
-	const fetchEnvironments = async () => {
-		let response = await getEnvironmentListMin();
-		let envList = response.result ? response.result : [];
-		envList = envList.map((env) => { return { value: env.id, label: env.environment_name, active: env.active } });
-		envList = envList.sort((a, b) => sortCallback('label', a, b, true));
-		setEnvironments(envList);
-	}
+    const fetchEnvironments = async () => {
+        let response = await getEnvironmentListMin();
+        let envList = response.result ? response.result : [];
+        envList = envList.map((env) => {
+            return { value: env.id, label: env.environment_name, active: env.active };
+        });
+        envList = envList.sort((a, b) => sortCallback('label', a, b, true));
+        setEnvironments(envList);
+    };
 
-	function closeMe(event = null) {
-		if (event.keyCode === 27 && typeof onHide === 'function') {
-			onHide(false);
-		}
-	}
+    function closeMe(event = null) {
+        if (event.keyCode === 27 && typeof onHide === 'function') {
+            onHide(false);
+        }
+    }
 
-	async function getChartValuesList(id: number, installedAppVersionId = null) {
-		setLoading(true)
-		try {
-			const { result } = await getChartValuesCategorizedListParsed(id, installedAppVersionId);
-			setChartValuesList(result);
-			if (installedAppVersionId) {
-				setChartValues({
-					id: initialChartValuesFromParent.id,
-					kind: "EXISTING",
-				})
-			}
-		}
-		catch (err) { }
-		finally {
-			setLoading(false)
-		}
-	}
+    function hasChartChanged(): boolean {
+        return appStoreId !== repoChartValue.chartId;
+    }
 
-	function hasChartChanged(): boolean {
-		return appStoreId !== repoChartValue.chartId;
-	}
+    const deploy = async (e) => {
+        if (!(selectedProject && selectedEnvironment)) {
+            return;
+        }
+        if (!environmentId && !teamId && !appName) {
+            toast.warn('App name should not be empty and spaces are not allowed.');
+            return;
+        }
+        if (!obj) {
+            toast.error(error);
+            return;
+        }
+        try {
+            setLoading(true);
+            if (installedAppVersion) {
+                let payload = {
+                    // if chart has changed send 0
+                    id: hasChartChanged() ? 0 : installedAppVersion,
+                    referenceValueId: chartValues.id,
+                    referenceValueKind: chartValues.kind,
+                    // valuesOverride: obj,
+                    valuesOverrideYaml: textRef,
+                    installedAppId: installedAppId,
+                    appStoreVersion: selectedVersionUpdatePage.id,
+                };
+                await updateChart(payload);
+                toast.success('Deployment initiated');
+                setLoading(false);
+                let _url = `${url.split('/').slice(0, -1).join('/')}/${URLS.APP_DETAILS}?refetchData=true`;
+                history.push(_url);
+                onHide(true);
+            } else {
+                let payload = {
+                    teamId: selectedProject.value,
+                    referenceValueId: chartValues.id,
+                    referenceValueKind: chartValues.kind,
+                    environmentId: selectedEnvironment.value,
+                    appStoreVersion: selectedVersion,
+                    valuesOverride: obj,
+                    valuesOverrideYaml: textRef,
+                    appName,
+                };
+                const {
+                    result: { environmentId: newEnvironmentId, installedAppId: newInstalledAppId },
+                } = await installChart(payload);
+                toast.success('Deployment initiated');
+                push(
+                    `${URLS.APP}/${URLS.DEVTRON_CHARTS}/deployments/${newInstalledAppId}/env/${newEnvironmentId}/${URLS.APP_DETAILS}?refetchData=true`,
+                );
+            }
+        } catch (err) {
+            // if (Array.isArray(err.errors)) {
+            //     err.errors.map(({ userMessage }, idx) => toast.error(userMessage, { autoClose: false }))
+            // }
+            setLoading(false);
+        }
+    };
+    useEffect(() => {
+        // scroll to the editor view with animation for only update-chart
+        // subtracting - 100 from offset top because of floating header's tab
+        if (envId) {
+            setTimeout(() => {
+                deployChartForm.current?.scrollTo({
+                    top: deployChartEditor.current.offsetTop - 100,
+                    behavior: 'smooth',
+                });
+            }, 1000);
+        }
+    }, []);
 
-	const deploy = async (e) => {
-		if (!(selectedProject && selectedEnvironment)) {
-			return
-		}
-		if (!environmentId && !teamId && !appName) {
-			toast.warn('App name should not be empty and spaces are not allowed.')
-			return
-		}
-		if (!obj) {
-			toast.error(error)
-			return
-		}
-		try {
-			setLoading(true)
-			if (installedAppVersion) {
-				let payload = {
-					// if chart has changed send 0
-					id: hasChartChanged() ? 0 : installedAppVersion,
-					referenceValueId: chartValues.id,
-					referenceValueKind: chartValues.kind,
-					// valuesOverride: obj,
-					valuesOverrideYaml: textRef,
-					installedAppId: installedAppId,
-					appStoreVersion: selectedVersionUpdatePage.id,
-				}
-				await updateChart(payload)
-				toast.success('Deployment initiated')
-				setLoading(false)
-				let _url = `${url.split('/').slice(0, -1).join('/')}/${URLS.APP_DETAILS}?refetchData=true`;
-				history.push(_url);
-				onHide(true)
-			}
+    useEffect(() => {
+        if (chartId) {
+            getChartValuesList(chartId, setChartValuesList, setChartValues, setLoading);
+        }
+        document.addEventListener('keydown', closeMe);
+        if (versions) {
+            fetchProjects();
+            fetchEnvironments();
+        }
+        return () => {
+            document.removeEventListener('keydown', closeMe);
+        };
+    }, []);
 
-			else {
-				let payload = {
-					teamId: selectedProject.value,
-					referenceValueId: chartValues.id,
-					referenceValueKind: chartValues.kind,
-					environmentId: selectedEnvironment.value,
-					appStoreVersion: selectedVersion,
-					valuesOverride: obj,
-					valuesOverrideYaml: textRef,
-					appName,
-				};
-				const { result: { environmentId: newEnvironmentId, installedAppId: newInstalledAppId } } = await installChart(payload);
-				toast.success('Deployment initiated');
-                push(`${URLS.APP}/${URLS.DEVTRON_CHARTS}/deployments/${newInstalledAppId}/env/${newEnvironmentId}/${URLS.APP_DETAILS}?refetchData=true`)
-			}
-		}
-		catch (err) {
-			// if (Array.isArray(err.errors)) {
-			//     err.errors.map(({ userMessage }, idx) => toast.error(userMessage, { autoClose: false }))
-			// }
-			setLoading(false)
-		}
-	}
-	useEffect(() => {
-		// scroll to the editor view with animation for only update-chart
-		// subtracting - 100 from offset top because of floating header's tab 
-		if (envId) {
-			setTimeout(() => {
-				deployChartForm.current?.scrollTo({
-					top: deployChartEditor.current.offsetTop - 100,
-					behavior: 'smooth',
-				});
-			}, 1000);
-		}
-	}, []);
+    useEffect(() => {
+        let cv = versions.get(selectedVersion);
+        if (chartValues && cv && cv.version !== chartValues.chartVersion) {
+            setCodeEditorError(true);
+        } else setCodeEditorError(false);
+    }, [selectedVersion]);
 
-	useEffect(() => {
-		if (chartId) {
-			getChartValuesList(chartId);
-		}
-		document.addEventListener("keydown", closeMe);
-		if (versions) {
-			fetchProjects();
-			fetchEnvironments();
-		}
-		return () => { document.removeEventListener("keydown", closeMe); }
-	}, [])
+    useEffect(() => {
+        if (chartIdFromDeploymentDetail) {
+            if (chartIdFromDeploymentDetail)
+                getChartValuesCategorizedListParsed(chartIdFromDeploymentDetail)
+                    .then((response) => {
+                        setChartValuesList(response.result);
+                    })
+                    .catch((error) => {
+                        showError(error);
+                    });
+        }
+    }, [chartIdFromDeploymentDetail]);
 
-	useEffect(() => {
-		let cv = versions.get(selectedVersion);
-		if (chartValues && cv && cv.version !== chartValues.chartVersion) {
-			setCodeEditorError(true);
-		}
-		else setCodeEditorError(false);
-	}, [selectedVersion])
+    useEffect(() => {
+        if (environmentId && environments.length) {
+            let environment = environments.find((e) => e.value.toString() === environmentId.toString());
+            selectEnvironment(environment);
+        }
+    }, [environmentId, environments]);
 
-	useEffect(() => {
-		if (chartIdFromDeploymentDetail) {
-			if (chartIdFromDeploymentDetail) getChartValuesCategorizedListParsed(chartIdFromDeploymentDetail).then((response) => {
-				setChartValuesList(response.result);
-			}).catch((error) => {
-				showError(error);
-			})
-		}
-	}, [chartIdFromDeploymentDetail])
+    useEffect(() => {
+        if (teamId && projects.length) {
+            let project = projects.find((e) => e.value.toString() === teamId.toString());
+            selectProject(project);
+        }
+    }, [teamId, projects]);
 
-	useEffect(() => {
-		if (environmentId && environments.length) {
-			let environment = environments.find(e => e.value.toString() === environmentId.toString());
-			selectEnvironment(environment);
-		}
-	}, [environmentId, environments])
+    useEffect(() => {
+        if (chartValues.id && chartValues.chartVersion) {
+            getChartValues(chartValues.id, chartValues.kind)
+                .then((response) => {
+                    let values = response.result.values || '';
+                    setTextRef(values);
+                    let cv = versions.get(selectedVersion);
+                    if (chartValues && cv && cv.version !== chartValues.chartVersion) {
+                        setCodeEditorError(true);
+                    } else setCodeEditorError(false);
+                })
+                .catch((error) => {
+                    showError(error);
+                });
+        }
+    }, [chartValues]);
 
-	useEffect(() => {
-		if (teamId && projects.length) {
-			let project = projects.find(e => e.value.toString() === teamId.toString());
-			selectProject(project);
-		}
-	}, [teamId, projects])
+    useEffect(() => {
+        if (chartValuesFromParent.id) {
+            setChartValues(chartValuesFromParent);
+        }
+    }, [chartValuesFromParent]);
 
-	useEffect(() => {
-		if (chartValues.id && chartValues.chartVersion) {
-			getChartValues(chartValues.id, chartValues.kind).then((response) => {
-				let values = response.result.values || "";
-				setTextRef(values);
-				let cv = versions.get(selectedVersion);
-				if (chartValues && cv && cv.version !== chartValues.chartVersion) {
-					setCodeEditorError(true);
-				}
-				else setCodeEditorError(false);
-			}).catch((error) => {
-				showError(error);
-			})
-		}
-	}, [chartValues])
+    function setForceDeleteDialogData(serverError) {
+        if (serverError instanceof ServerErrors && Array.isArray(serverError.errors)) {
+            serverError.errors.map(({ userMessage, internalMessage }) => {
+                setForceDeleteErroTitle(userMessage);
+                setForceDeleteErrorMessage(internalMessage);
+            });
+        }
+    }
 
-	useEffect(() => {
-		if (chartValuesFromParent.id) {
-			setChartValues(chartValuesFromParent);
-		}
-	}, [chartValuesFromParent])
+    async function handleDelete(force) {
+        setDeleting(true);
+        try {
+            if (force === true) {
+                await deleteInstalledChart(installedAppId, force);
+            } else {
+                await deleteInstalledChart(installedAppId);
+            }
+            toast.success('Successfully deleted.');
+            let url = `${URLS.APP}/${URLS.APP_LIST}/${URLS.APP_LIST_HELM}`;
+            push(url);
+        } catch (err) {
+            if (!force && err.code != 403) {
+                setForceDeleteDialog(true);
+                setForceDeleteDialogData(err);
+            } else {
+                showError(err);
+            }
+        } finally {
+            setDeleting(false);
+        }
+    }
 
-	function setForceDeleteDialogData(serverError) {
-		if (serverError instanceof ServerErrors && Array.isArray(serverError.errors)) {
-			serverError.errors.map(({ userMessage, internalMessage }) => {
-				setForceDeleteErroTitle(userMessage)
-				setForceDeleteErrorMessage(internalMessage);
-			});
-		}
-	}
+    async function redirectToChartValues() {
+        let id = chartId || chartIdFromDeploymentDetail;
+        let url = getChartValuesURL(id);
+        push(url);
+    }
 
-	async function handleDelete(force) {
-		setDeleting(true)
-		try {
-			if (force === true) {
-				await deleteInstalledChart(installedAppId, force)
-			} else {
-				await deleteInstalledChart(installedAppId)
-			}
-			toast.success('Successfully deleted.')
-			let url = `${URLS.APP}/${URLS.APP_LIST}/${URLS.APP_LIST_HELM}`;
-			push(url);
-		}
-		catch (err) {
-			if (!force && err.code != 403) {
-			    setForceDeleteDialog(true)
-			    setForceDeleteDialogData(err)
-			} else {
-			    showError(err)
-			}
-		}
-		finally {
-			setDeleting(false)
-		}
-	}
+    function handleRepoChartValueChange(event) {
+        setRepoChartValue(event);
+        fetchChartVersionsData(
+            event.chartId,
+            true,
+            false,
+            setSelectedVersionUpdatePage,
+            setChartVersionsData,
+            setLoading,
+        );
+        getChartValuesList(
+            event.chartId,
+            setChartValuesList,
+            setChartValues,
+            setLoading,
+            initialChartValuesFromParent.id,
+            installedAppVersionId,
+        );
+    }
 
-	async function redirectToChartValues() {
-		let id = chartId || chartIdFromDeploymentDetail;
-		let url = getChartValuesURL(id);
-		push(url);
-	}
-
-	async function fetchChartVersionsData(id: number, valueUpdateRequired = false) {
-		try {
-			setLoading(true)
-			const { result } = await getChartVersionsMin(id);
-			setChartVersionsData(result);
-			if (valueUpdateRequired) {
-				setSelectedVersionUpdatePage(result[0])
-			}
-		}
-		catch (err) {
-			showError(err)
-		}
-		finally {
-			setLoading(false)
-		}
-	}
-
-	async function handlerepoChartFocus() {
-		if (!repoChartAPIMade) {
-			setRepoChartAPIMade(true)
-			const matchedCharts = (await getChartsByKeyword(name)).result;
-			filterMatchedCharts(matchedCharts);
-		}
-	}
-
-	function filterMatchedCharts(matchedCharts) {
-		if (repoChartOptions !== null) {
-			const deprecatedCharts = [];
-			const nonDeprecatedCharts = [];
-			for (let i = 0; i < matchedCharts.length; i++) {
-				if (matchedCharts[i].deprecated) {
-					deprecatedCharts.push(matchedCharts[i]);
-				}
-				else {
-					nonDeprecatedCharts.push(matchedCharts[i])
-				}
-			}
-			setRepoChartOptions(nonDeprecatedCharts.concat(deprecatedCharts))
-			return nonDeprecatedCharts.concat(deprecatedCharts)
-		}
-		return [];
-	}
-
-	async function repoChartLoadOptions(inputValue: string, callback) {
-		const matchedCharts = (await getChartsByKeyword(inputValue)).result;
-		callback(filterMatchedCharts(matchedCharts));
-	}
-
-	function repoChartOptionLabel(props) {
-		const { innerProps, innerRef } = props;
-		const isCurrentlySelected = props.data.chartId === repoChartValue.chartId;
-		return (
-			<div ref={innerRef} {...innerProps} className="repochart-dropdown-wrap">
-				<div className="flex left">
-					{isCurrentlySelected && <img src={checkIcon} className="select__check-icon"></img>}
-					<span>
-						{props.data.chartRepoName}/{props.data.chartName}
-					</span>
-				</div>
-				{props.data.deprecated && <div className="dropdown__deprecated-text">Chart deprecated</div>}
-			</div>
-		)
-	}
-
-	function repoChartSelectOptionLabel({ chartRepoName, chartName }) {
-		return <div>{chartRepoName}/{chartName}</div>
-	}
-
-	function handleRepoChartValueChange(event) {
-		setRepoChartValue(event);
-		fetchChartVersionsData(event.chartId, true);
-		getChartValuesList(event.chartId, installedAppVersionId);
-	}
-
-	let isUpdate = environmentId && teamId;
-	let isDisabled = isUpdate ? false : !(selectedEnvironment && selectedProject && selectedVersion && appName?.length);
-	let chartVersionObj = versions.get(selectedVersion);
-	// fetch chart versions for update route
-	useEffect(() => {
-		if (isUpdate !== null) {
-			fetchChartVersionsData(chartIdFromDeploymentDetail)
-		}
-	}, []);
-	return (<>
-		<div className={`deploy-chart-container bcn-0 ${readmeCollapsed ? 'readmeCollapsed' : 'readmeOpen'} `}  style={{height: 'calc(100vh - 90px)'}}>
-		<div className="header-container flex column">
-              {
-			  !isUpdate ? <>
-			  <div className="title">{chartName}/ {name}</div>
-                <div className="border" /> 
-				</> : ''
-				}
+    let isUpdate = environmentId && teamId;
+    let isDisabled = isUpdate ? false : !(selectedEnvironment && selectedProject && selectedVersion && appName?.length);
+    let chartVersionObj = versions.get(selectedVersion);
+    // fetch chart versions for update route
+    useEffect(() => {
+        if (isUpdate !== null) {
+            fetchChartVersionsData(
+                chartIdFromDeploymentDetail,
+                false,
+                false,
+                setSelectedVersionUpdatePage,
+                setChartVersionsData,
+                setLoading,
+            );
+        }
+    }, []);
+    return (
+        <>
+            <div
+                className={`deploy-chart-container bcn-0 ${readmeCollapsed ? 'readmeCollapsed' : 'readmeOpen'} `}
+                style={{ height: 'calc(100vh - 90px)' }}
+            >
+                <div className="header-container flex column">
+                    {!isUpdate ? (
+                        <>
+                            <div className="title">
+                                {chartName}/ {name}
+                            </div>
+                            <div className="border" />
+                        </>
+                    ) : (
+                        ''
+                    )}
+                </div>
+                <ActiveReadmeColumn
+                    readmeCollapsed={readmeCollapsed}
+                    toggleReadmeCollapsed={toggleReadmeCollapsed}
+                    defaultReadme={readme}
+                    selectedVersionUpdatePage={selectedVersionUpdatePage}
+                />
+                <div className="deploy-chart-body">
+                    <div className="overflown" ref={deployChartForm}>
+                        <div className="hide-scroll">
+                            <label className="form__row form__row--w-100">
+                                <span className="form__label">App Name</span>
+                                <input
+                                    autoComplete="off"
+                                    tabIndex={1}
+                                    placeholder="App name"
+                                    className="form__input"
+                                    value={appName}
+                                    autoFocus
+                                    disabled={!!isUpdate}
+                                    onChange={(e) => setAppName(e.target.value)}
+                                />
+                            </label>
+                            <label className="form__row form__row--w-100">
+                                <span className="form__label">Project</span>
+                                <ReactSelect
+                                    components={{
+                                        IndicatorSeparator: null,
+                                        DropdownIndicator,
+                                    }}
+                                    isDisabled={!!isUpdate}
+                                    placeholder="Select Project"
+                                    value={selectedProject}
+                                    styles={{
+                                        ...styles,
+                                        ...menuList,
+                                    }}
+                                    onChange={selectProject}
+                                    options={projects}
+                                />
+                            </label>
+                            <ChartEnvironmentSelector
+                                isUpdate={!!isUpdate}
+                                selectedEnvironment={selectedEnvironment}
+                                selectEnvironment={selectEnvironment}
+                                environments={environments}
+                            />
+                            <ChartDeprecated
+                                isUpdate={!!isUpdate}
+                                deprecated={deprecated}
+                                chartName={chartName}
+                                name={name}
+                            />
+                            <ChartRepoSelector
+                                isUpdate={!!isUpdate}
+                                repoChartValue={repoChartValue}
+                                handleRepoChartValueChange={handleRepoChartValueChange}
+                                chartDetails={{
+                                    appStoreApplicationVersionId: appStoreVersion,
+                                    chartRepoName: chartName,
+                                    chartId: appStoreId,
+                                    chartName: name,
+                                    version: versions.get(selectedVersion).version,
+                                    deprecated: deprecated,
+                                }}
+                            />
+                            <ChartVersionValuesSelector
+                                isUpdate={!!isUpdate}
+                                selectedVersion={selectedVersion}
+                                selectVersion={selectVersion}
+                                chartVersionObj={chartVersionObj}
+                                versions={versions}
+                                selectedVersionUpdatePage={selectedVersionUpdatePage}
+                                setSelectedVersionUpdatePage={setSelectedVersionUpdatePage}
+                                chartVersionsData={chartVersionsData}
+                                chartValuesList={chartValuesList}
+                                chartValues={chartValues}
+                                redirectToChartValues={redirectToChartValues}
+                                setChartValues={setChartValues}
+                            />
+                            <ChartValuesEditor
+                                valuesText={textRef}
+                                onChange={setTextRef}
+                                repoChartValue={repoChartValue}
+                                hasChartChanged={hasChartChanged()}
+                                editorRef={deployChartEditor}
+                            />
+                        </div>
+                    </div>
+                </div>
+                <div className="cta-container">
+                    {isUpdate && (
+                        <button className="cta delete" onClick={(e) => toggleConfirmation(true)}>
+                            Delete Application
+                        </button>
+                    )}
+                    <button
+                        type="button"
+                        tabIndex={6}
+                        disabled={isDisabled || loading}
+                        className={`cta flex-1 ml-16 mr-16 ${isDisabled ? 'disabled' : ''}`}
+                        onClick={deploy}
+                    >
+                        {loading ? <Progressing /> : isUpdate ? 'update and deploy' : 'deploy chart'}
+                    </button>
+                </div>
+                {confirmation && (
+                    <DeleteChartDialog
+                        appName={originalName}
+                        handleDelete={handleDelete}
+                        toggleConfirmation={toggleConfirmation}
+                    />
+                )}
+                {showForceDeleteDialog && (
+                    <ForceDeleteDialog
+                        forceDeleteDialogTitle={forceDeleteDialogTitle}
+                        onClickDelete={() => handleDelete(true)}
+                        closeDeleteModal={() => {
+                            toggleConfirmation(false);
+                            setForceDeleteDialog(false);
+                        }}
+                        forceDeleteDialogMessage={forceDeleteDialogMessage}
+                    />
+                )}
             </div>
-			<ReadmeColumn readmeCollapsed={readmeCollapsed} toggleReadmeCollapsed={toggleReadmeCollapsed} readme={readme} />
-			<div className="deploy-chart-body">
-				<div className="overflown" ref={deployChartForm}>
-					<div className="hide-scroll">
-						<label className="form__row form__row--w-100">
-							<span className="form__label">App Name</span>
-							<input autoComplete="off" tabIndex={1} placeholder="App name" className="form__input" value={appName} autoFocus disabled={!!isUpdate} onChange={e => setAppName(e.target.value)} />
-						</label>
-						<label className="form__row form__row--w-100">
-							<span className="form__label">Project</span>
-							<ReactSelect
-								components={{
-									IndicatorSeparator: null,
-									DropdownIndicator
-								}}
-								isDisabled={!!isUpdate}
-								placeholder="Select Project"
-								value={selectedProject}
-								styles={{
-									...styles,
-									...menuList,
-								}}
-								onChange={selectProject}
-								options={projects}
-							/>
-						</label>
-						<div className="form__row form__row--w-100">
-							<span className="form__label">Environment</span>
-							<ReactSelect
-								components={{
-									IndicatorSeparator: null,
-									DropdownIndicator
-								}}
-								isDisabled={!!isUpdate}
-								placeholder="Select Environment"
-								value={selectedEnvironment}
-								styles={{
-									...styles,
-									...menuList,
-								}}
-								onChange={selectEnvironment}
-								options={environments}
-							/>
-						</div>
-						{isUpdate && deprecated &&
-							<div className="info__container--update-chart">
-								<div className="flex left">
-									<AlertTriangle className="icon-dim-24 update-chart" />
-									<div className="info__container--update-chart-text">{chartName}/{name} is deprecated</div>
-								</div>
-								<div className="info__container--update-chart-disclaimer">
-									Selected chart has been deprecated. Please select another chart to continue receiving updates in future.
-								</div>
-							</div>
-						}
+        </>
+    );
+};
 
-						{
-							isUpdate &&
-							<div className="form__row form__row--w-100">
-								<span className="form__label">Repo/Chart</span>
-								<AsyncSelect
-									cacheOptions
-									defaultOptions={repoChartOptions}
-									formatOptionLabel={repoChartSelectOptionLabel}
-									value={repoChartValue}
-									loadOptions={repoChartLoadOptions}
-									onFocus={handlerepoChartFocus}
-									onChange={handleRepoChartValueChange}
-									components={{
-										IndicatorSeparator: () => null,
-										Option: repoChartOptionLabel
-									}}
-									styles={{
-										control: (base, state) => ({
-											...base,
-											boxShadow: 'none',
-											border: state.isFocused ? '1px solid var(--B500)' : '1px solid var(--N500)',
-											cursor: 'pointer'
-										}),
-										option: (base, state) => {
-											return ({
-												...base,
-												color: 'var(--N900)',
-												backgroundColor: state.isFocused ? 'var(--N100)' : 'white',
-												padding: '10px 12px'
-											})
-										},
-									}}
-								/>
-								{
-									repoChartValue.deprecated &&
-									<div className="deprecated-text-image flex left">
-										<AlertTriangle className="icon-dim-16 update-chart" />
-										<span className="deprecated-text">This chart has been deprecated. Select another chart.</span>
-									</div>
-								}
-							</div>
-						}
-						<div className="form__row form__row--flex form__row--w-100">
-							{
-								isUpdate === null ?
-									<div className="w-50">
-										<span className="form__label">Chart Version</span>
-										<Select tabIndex={4} rootClassName="select-button--default" value={selectedVersion} onChange={event => selectVersion(event.target.value)}>
-											<Select.Button>{chartVersionObj ? chartVersionObj.version : 'Select Version'}</Select.Button>
-											{Array.from(versions).map(([versionId, versionData], idx) => <Select.Option key={versionId} value={versionId}>{versionData.version}</Select.Option>)}
-										</Select>
-									</div>
-									:
-									<div className="w-50">
-										<span className="form__label">Chart Version</span>
-										<Select tabIndex={4} rootClassName="select-button--default" value={selectedVersionUpdatePage.id} onChange={event => setSelectedVersionUpdatePage({ id: event.target.value, version: event.target.innerText })}>
-											<Select.Button>{selectedVersionUpdatePage.version}</Select.Button>
-											{chartVersionsData.map(({ version, id }) => <Select.Option key={id} value={id}>{version}</Select.Option>)}
-										</Select>
-									</div>
-							}
-							<span className="mr-16"></span>
-							<div className="w-50">
-								<span className="form__label">Chart Values*</span>
-								<ChartValuesSelect chartValuesList={chartValuesList} chartValues={chartValues} redirectToChartValues={redirectToChartValues}
-									onChange={(event) => { setChartValues(event) }} />
-							</div>
-						</div>
-						<div className="code-editor-container" ref={deployChartEditor}>
-							<CodeEditor
-								value={textRef}
-								noParsing
-								mode="yaml"
-								onChange={value => { setTextRef(value) }}>
-								<CodeEditor.Header>
-									<span className="bold">values.yaml</span>
-								</CodeEditor.Header>
-								{hasChartChanged() &&
-									<CodeEditor.Information
-										text={`Please ensure that the values are compatible with "${repoChartValue.chartRepoName}/${repoChartValue.chartName}"`} />}
-							</CodeEditor>
-						</div>
-					</div>
-				</div>
-			</div>
-			<div className="cta-container">
-				{isUpdate && <button className="cta delete" onClick={e => toggleConfirmation(true)}>Delete Application</button>}
-				<button type="button" tabIndex={6}
-					disabled={isDisabled || loading}
-					className={`cta flex-1 ml-16 mr-16 ${isDisabled ? 'disabled' : ''}`}
-					onClick={deploy}>
-					{loading ? <Progressing /> : isUpdate ? 'update and deploy' : 'deploy chart'}
-				</button>
-			</div>
-			{confirmation && <DeleteDialog title={`Delete '${originalName}' ?`}
-				delete={() => handleDelete(false)}
-				closeDelete={() => toggleConfirmation(false)}
-			>
-				<DeleteDialog.Description >
-					<p>This will delete all resources associated with this application.</p>
-					<p>Deleted applications cannot be restored.</p>
-				</DeleteDialog.Description>
-			</DeleteDialog>
-			}
-			{
-				showForceDeleteDialog && <ForceDeleteDialog
-					forceDeleteDialogTitle={forceDeleteDialogTitle}
-					onClickDelete={() => handleDelete(true)}
-					closeDeleteModal={() => { toggleConfirmation(false); setForceDeleteDialog(false) }}
-					forceDeleteDialogMessage={forceDeleteDialogMessage}
-				/>
-			}
-		</div>
-	</>
-	)
-}
-
-export default DeployChart
+export default DeployChart;

--- a/src/components/v2/values/DeployChart.tsx
+++ b/src/components/v2/values/DeployChart.tsx
@@ -83,6 +83,7 @@ const DeployChart: React.FC<DeployChartProps> = ({
     const [forceDeleteDialogMessage, setForceDeleteErrorMessage] = useState('');
     const [forceDeleteDialogTitle, setForceDeleteErroTitle] = useState('');
     const [textRef, setTextRef] = useState(rawValues);
+    const [fetchingValuesYaml, setFetchingValuesYaml] = useState(false);
     const [repoChartValue, setRepoChartValue] = useState<ChartRepoOtions>({
         appStoreApplicationVersionId: appStoreVersion,
         chartRepoName: chartName,
@@ -239,6 +240,7 @@ const DeployChart: React.FC<DeployChartProps> = ({
 
     useEffect(() => {
         if (chartValues.id && chartValues.chartVersion) {
+            setFetchingValuesYaml(true);
             getChartValues(chartValues.id, chartValues.kind)
                 .then((response) => {
                     let values = response.result.values || '';
@@ -247,9 +249,12 @@ const DeployChart: React.FC<DeployChartProps> = ({
                     if (chartValues && cv && cv.version !== chartValues.chartVersion) {
                         setCodeEditorError(true);
                     } else setCodeEditorError(false);
+
+                    setFetchingValuesYaml(false);
                 })
                 .catch((error) => {
                     showError(error);
+                    setFetchingValuesYaml(false);
                 });
         }
     }, [chartValues]);
@@ -432,6 +437,7 @@ const DeployChart: React.FC<DeployChartProps> = ({
                                 setChartValues={setChartValues}
                             />
                             <ChartValuesEditor
+                                loading={fetchingValuesYaml}
                                 valuesText={textRef}
                                 onChange={setTextRef}
                                 repoChartValue={repoChartValue}

--- a/src/components/v2/values/DeployChart.tsx
+++ b/src/components/v2/values/DeployChart.tsx
@@ -99,7 +99,6 @@ const DeployChart: React.FC<DeployChartProps> = ({
     const { chartId, envId } = useParams<{ chartId; envId }>();
     const [showCodeEditorError, setCodeEditorError] = useState(false);
     const deployChartForm = useRef(null);
-    const deployChartEditor = useRef(null);
     const history = useHistory();
     const { url } = useRouteMatch();
 
@@ -189,18 +188,6 @@ const DeployChart: React.FC<DeployChartProps> = ({
             setLoading(false);
         }
     };
-    useEffect(() => {
-        // scroll to the editor view with animation for only update-chart
-        // subtracting - 100 from offset top because of floating header's tab
-        if (envId) {
-            setTimeout(() => {
-                deployChartForm.current?.scrollTo({
-                    top: deployChartEditor.current.offsetTop - 100,
-                    behavior: 'smooth',
-                });
-            }, 1000);
-        }
-    }, []);
 
     useEffect(() => {
         if (chartId) {
@@ -449,7 +436,8 @@ const DeployChart: React.FC<DeployChartProps> = ({
                                 onChange={setTextRef}
                                 repoChartValue={repoChartValue}
                                 hasChartChanged={hasChartChanged()}
-                                editorRef={deployChartEditor}
+                                parentRef={deployChartForm}
+                                autoFocus={!!envId}
                             />
                         </div>
                     </div>

--- a/src/components/v2/values/DeployChart.tsx
+++ b/src/components/v2/values/DeployChart.tsx
@@ -99,7 +99,7 @@ const DeployChart: React.FC<DeployChartProps> = ({
     const { push } = useHistory();
     const { chartId, envId } = useParams<{ chartId; envId }>();
     const [showCodeEditorError, setCodeEditorError] = useState(false);
-    const deployChartForm = useRef(null);
+    const deployChartForm = useRef<HTMLDivElement>(null);
     const history = useHistory();
     const { url } = useRouteMatch();
 

--- a/src/components/v2/values/common/ChartValuesSelectors.tsx
+++ b/src/components/v2/values/common/ChartValuesSelectors.tsx
@@ -183,7 +183,9 @@ export const ChartRepoSelector = ({
                     <div className="flex sticky-information__bottom">
                         <Info className="code-editor__information-info-icon" />
                         Unable to find the desired chart? To connect a chart repo or Re-sync connected repos.&nbsp;
-                        <NavLink to={URLS.GLOBAL_CONFIG_CHART}>Go to chart repository</NavLink>
+                        <NavLink to={URLS.GLOBAL_CONFIG_CHART} target="_blank">
+                            Go to chart repository
+                        </NavLink>
                     </div>
                 </div>
             </components.MenuList>

--- a/src/components/v2/values/common/ChartValuesSelectors.tsx
+++ b/src/components/v2/values/common/ChartValuesSelectors.tsx
@@ -17,6 +17,8 @@ import {
     ChartVersionSelectorType,
     ChartValuesSelectorType,
     ChartVersionValuesSelectorType,
+    ChartValuesEditorType,
+    ChartRepoDetailsType,
 } from './chartValuesSelectors.type';
 import { getChartsByKeyword } from '../../../charts/charts.service';
 import { ChartRepoOtions } from '../DeployChart';
@@ -125,11 +127,11 @@ export const ChartRepoSelector = ({
         callback(filterMatchedCharts(matchedCharts));
     }
 
-    function repoChartSelectOptionLabel({ chartRepoName, chartName, version }) {
+    function repoChartSelectOptionLabel({ chartRepoName, chartName, version }: ChartRepoDetailsType) {
         return <div>{!chartRepoName ? `${chartName} (${version})` : `${chartRepoName}/${chartName}`}</div>;
     }
 
-    function repoChartOptionLabel(props) {
+    function repoChartOptionLabel(props: any) {
         const { innerProps, innerRef } = props;
         const isCurrentlySelected = props.data.chartId === repoChartValue.chartId;
         return (
@@ -145,7 +147,7 @@ export const ChartRepoSelector = ({
         );
     }
 
-    function customMenuListItem(props): JSX.Element {
+    function customMenuListItem(props: any): JSX.Element {
         return (
             <components.MenuList {...props}>
                 {props.children}
@@ -472,13 +474,7 @@ export const ChartValuesEditor = ({
     repoChartValue,
     hasChartChanged,
     editorRef,
-}: {
-    valuesText: string;
-    onChange: (value: string) => void;
-    repoChartValue: ChartRepoOtions;
-    hasChartChanged: boolean;
-    editorRef?: React.MutableRefObject<any>;
-}) => {
+}: ChartValuesEditorType) => {
     return (
         <div className="code-editor-container" {...(editorRef && { ref: editorRef })}>
             <CodeEditor value={valuesText} noParsing mode="yaml" onChange={onChange}>

--- a/src/components/v2/values/common/ChartValuesSelectors.tsx
+++ b/src/components/v2/values/common/ChartValuesSelectors.tsx
@@ -183,7 +183,6 @@ export const ChartRepoSelector = ({
             <input
                 className="form__input"
                 value={`${releaseInfo.deployedAppDetail.chartName} (${releaseInfo.deployedAppDetail.chartVersion})`}
-                autoFocus
                 disabled={true}
             />
         </label>

--- a/src/components/v2/values/common/ChartValuesSelectors.tsx
+++ b/src/components/v2/values/common/ChartValuesSelectors.tsx
@@ -5,7 +5,7 @@ import { menuList } from '../../../charts/charts.util';
 import { DropdownIndicator, styles } from '../../common/ReactSelect.utils';
 import { ReactComponent as AlertTriangle } from '../../../../assets/icons/ic-alert-triangle.svg';
 import { ReactComponent as Error } from '../../../../assets/icons/ic-warning.svg';
-import { ReactComponent as Refresh } from '../../../../assets/icons/ic-restore.svg';
+import { ReactComponent as Refetch } from '../../../../assets/icons/ic-restore.svg';
 import { ReactComponent as Info } from '../../../../assets/icons/ic-info-filled.svg';
 import checkIcon from '../../../../assets/icons/appstatus/ic-check.svg';
 import { ChartValuesSelect } from '../../../charts/util/ChartValueSelect';
@@ -28,6 +28,7 @@ import { NavLink } from 'react-router-dom';
 import { URLS } from '../../../../config';
 import { getChartRelatedReadMe } from './chartValues.api';
 import { ChartVersionType } from '../../../charts/charts.types';
+import Tippy from '@tippyjs/react';
 
 export const ChartEnvironmentSelector = ({
     isExternal,
@@ -89,19 +90,19 @@ export const ChartRepoSelector = ({
     const [repoChartOptions, setRepoChartOptions] = useState<ChartRepoOtions[] | null>(
         isExternal && !installedAppInfo ? [] : [chartDetails],
     );
-    const [refreshingCharts, setRefreshingCharts] = useState(false);
+    const [refetchingCharts, setRefetchingCharts] = useState(false);
 
-    async function handleRepoChartFocus(forceRefresh?: boolean) {
-        if (!repoChartAPIMade || forceRefresh) {
+    async function handleRepoChartFocus(refetch: boolean) {
+        if (!repoChartAPIMade || refetch) {
             const matchedCharts = (await getChartsByKeyword(chartDetails.chartName)).result;
             filterMatchedCharts(matchedCharts);
             setRepoChartAPIMade(true);
-            setRefreshingCharts(false);
+            setRefetchingCharts(false);
         }
     }
 
-    function refreshCharts() {
-        setRefreshingCharts(true);
+    function refetchCharts() {
+        setRefetchingCharts(true);
         handleRepoChartFocus(true);
     }
 
@@ -207,7 +208,7 @@ export const ChartRepoSelector = ({
                         onFocus={() => handleRepoChartFocus(false)}
                         onChange={handleRepoChartValueChange}
                         noOptionsMessage={() => 'No matching results'}
-                        isLoading={!repoChartAPIMade || refreshingCharts}
+                        isLoading={!repoChartAPIMade || refetchingCharts}
                         components={{
                             IndicatorSeparator: () => null,
                             LoadingIndicator: () => null,
@@ -251,15 +252,15 @@ export const ChartRepoSelector = ({
                             },
                         }}
                     />
-                    {isExternal && (
+                    <Tippy className="default-tt " arrow={false} content={'Refetch Charts'}>
                         <button
-                            className={`refresh-charts${refreshingCharts ? ' refreshing' : ''} flex p-10 ml-8`}
-                            onClick={refreshCharts}
-                            disabled={refreshingCharts}
+                            className={`refetch-charts${refetchingCharts ? ' refetching' : ''} flex p-10 ml-8`}
+                            onClick={refetchCharts}
+                            disabled={refetchingCharts}
                         >
-                            <Refresh className="icon-dim-16" />
+                            <Refetch className="icon-dim-16" />
                         </button>
-                    )}
+                    </Tippy>
                 </div>
                 {repoChartValue.deprecated && (
                     <div className="deprecated-text-image flex left">

--- a/src/components/v2/values/common/ChartValuesSelectors.tsx
+++ b/src/components/v2/values/common/ChartValuesSelectors.tsx
@@ -1,0 +1,496 @@
+import React, { useState, useEffect } from 'react';
+import ReactSelect, { components } from 'react-select';
+import AsyncSelect from 'react-select/async';
+import { menuList } from '../../../charts/charts.util';
+import { DropdownIndicator, styles } from '../../common/ReactSelect.utils';
+import { ReactComponent as AlertTriangle } from '../../../../assets/icons/ic-alert-triangle.svg';
+import { ReactComponent as Error } from '../../../../assets/icons/ic-warning.svg';
+import { ReactComponent as Refresh } from '../../../../assets/icons/ic-restore.svg';
+import { ReactComponent as Info } from '../../../../assets/icons/ic-info-filled.svg';
+import checkIcon from '../../../../assets/icons/appstatus/ic-check.svg';
+import { ChartValuesSelect } from '../../../charts/util/ChartValueSelect';
+import { DeleteDialog, Select } from '../../../common';
+import {
+    ChartEnvironmentSelectorType,
+    ChartRepoSelectorType,
+    ChartDeprecatedType,
+    ChartVersionSelectorType,
+    ChartValuesSelectorType,
+    ChartVersionValuesSelectorType,
+} from './chartValuesSelectors.type';
+import { getChartsByKeyword } from '../../../charts/charts.service';
+import { ChartRepoOtions } from '../DeployChart';
+import ReadmeColumn from './ReadmeColumn.component';
+import CodeEditor from '../../../CodeEditor/CodeEditor';
+import { NavLink } from 'react-router-dom';
+import { URLS } from '../../../../config';
+import { getChartRelatedReadMe } from './chartValues.api';
+import { ChartVersionType } from '../../../charts/charts.types';
+
+export const ChartEnvironmentSelector = ({
+    isExternal,
+    installedAppInfo,
+    releaseInfo,
+    isUpdate,
+    selectedEnvironment,
+    selectEnvironment,
+    environments,
+}: ChartEnvironmentSelectorType): JSX.Element => {
+    return isExternal ? (
+        <label className="form__row form__row--w-100">
+            <span className="form__label">Environment</span>
+            <input
+                className="form__input"
+                value={`${
+                    installedAppInfo
+                        ? installedAppInfo.environmentName
+                        : releaseInfo.deployedAppDetail.environmentDetail.clusterName +
+                          '__' +
+                          releaseInfo.deployedAppDetail.environmentDetail.namespace
+                }`}
+                autoFocus
+                disabled={true}
+            />
+        </label>
+    ) : (
+        <div className="form__row form__row--w-100">
+            <span className="form__label">Environment</span>
+            <ReactSelect
+                components={{
+                    IndicatorSeparator: null,
+                    DropdownIndicator,
+                }}
+                isDisabled={!!isUpdate}
+                placeholder="Select Environment"
+                value={selectedEnvironment}
+                styles={{
+                    ...styles,
+                    ...menuList,
+                }}
+                onChange={selectEnvironment}
+                options={environments}
+            />
+        </div>
+    );
+};
+
+export const ChartRepoSelector = ({
+    isExternal,
+    installedAppInfo,
+    releaseInfo,
+    isUpdate,
+    repoChartValue,
+    handleRepoChartValueChange,
+    chartDetails,
+}: ChartRepoSelectorType) => {
+    const [repoChartAPIMade, setRepoChartAPIMade] = useState(false);
+    const [repoChartOptions, setRepoChartOptions] = useState<ChartRepoOtions[] | null>(
+        isExternal && !installedAppInfo ? [] : [chartDetails],
+    );
+    const [refreshingCharts, setRefreshingCharts] = useState(false);
+
+    async function handleRepoChartFocus(forceRefresh?: boolean) {
+        if (!repoChartAPIMade || forceRefresh) {
+            const matchedCharts = (await getChartsByKeyword(chartDetails.chartName)).result;
+            filterMatchedCharts(matchedCharts);
+            setRepoChartAPIMade(true);
+            setRefreshingCharts(false);
+        }
+    }
+
+    function refreshCharts() {
+        setRefreshingCharts(true);
+        handleRepoChartFocus(true);
+    }
+
+    function filterMatchedCharts(matchedCharts) {
+        if (repoChartOptions !== null) {
+            const deprecatedCharts = [];
+            const nonDeprecatedCharts = [];
+            for (let i = 0; i < matchedCharts.length; i++) {
+                if (matchedCharts[i].deprecated) {
+                    deprecatedCharts.push(matchedCharts[i]);
+                } else {
+                    nonDeprecatedCharts.push(matchedCharts[i]);
+                }
+            }
+            setRepoChartOptions(nonDeprecatedCharts.concat(deprecatedCharts));
+            return nonDeprecatedCharts.concat(deprecatedCharts);
+        }
+        return [];
+    }
+
+    async function repoChartLoadOptions(inputValue: string, callback) {
+        const matchedCharts = (await getChartsByKeyword(inputValue)).result;
+        callback(filterMatchedCharts(matchedCharts));
+    }
+
+    function repoChartSelectOptionLabel({ chartRepoName, chartName, version }) {
+        return <div>{!chartRepoName ? `${chartName} (${version})` : `${chartRepoName}/${chartName}`}</div>;
+    }
+
+    function repoChartOptionLabel(props) {
+        const { innerProps, innerRef } = props;
+        const isCurrentlySelected = props.data.chartId === repoChartValue.chartId;
+        return (
+            <div ref={innerRef} {...innerProps} className="repochart-dropdown-wrap">
+                <div className="flex left">
+                    {isCurrentlySelected && <img src={checkIcon} className="select__check-icon"></img>}
+                    <span>
+                        {props.data.chartRepoName}/{props.data.chartName}
+                    </span>
+                </div>
+                {props.data.deprecated && <div className="dropdown__deprecated-text">Chart deprecated</div>}
+            </div>
+        );
+    }
+
+    function customMenuListItem(props): JSX.Element {
+        return (
+            <components.MenuList {...props}>
+                {props.children}
+                <div
+                    className="flex react-select__bottom bcn-0 pt-10 pb-2"
+                    style={{
+                        bottom: '-4px',
+                    }}
+                >
+                    <div
+                        className="flex"
+                        style={{
+                            backgroundColor: '#F3F0FF',
+                            justifyContent: 'flex-start',
+                            padding: '10px 12px',
+                            margin: '8px 8px',
+                            borderRadius: '4px',
+                        }}
+                    >
+                        <Info className="code-editor__information-info-icon" />
+                        Unable to find the desired chart? To connect a chart repo or Re-sync connected repos.&nbsp;
+                        <NavLink
+                            to={URLS.GLOBAL_CONFIG_CHART}
+                            style={{
+                                color: 'var(--B500)',
+                            }}
+                        >
+                            Go to chart repository
+                        </NavLink>
+                    </div>
+                </div>
+            </components.MenuList>
+        );
+    }
+
+    return isExternal && installedAppInfo ? (
+        <label className="form__row form__row--w-100">
+            <span className="form__label">Chart</span>
+            <input
+                className="form__input"
+                value={`${releaseInfo.deployedAppDetail.chartName} (${releaseInfo.deployedAppDetail.chartVersion})`}
+                autoFocus
+                disabled={true}
+            />
+        </label>
+    ) : (
+        (isExternal || isUpdate) && (
+            <div className="form__row form__row--w-100">
+                <span className="form__label">{isExternal ? 'Chart' : 'Repo/Chart'}</span>
+                <div className="repo-chart-selector flex">
+                    <AsyncSelect
+                        cacheOptions
+                        defaultOptions={repoChartOptions}
+                        formatOptionLabel={repoChartSelectOptionLabel}
+                        value={repoChartValue}
+                        loadOptions={repoChartLoadOptions}
+                        onFocus={() => handleRepoChartFocus(false)}
+                        onChange={handleRepoChartValueChange}
+                        noOptionsMessage={() => 'No matching results'}
+                        isLoading={!repoChartAPIMade || refreshingCharts}
+                        components={{
+                            IndicatorSeparator: () => null,
+                            LoadingIndicator: () => null,
+                            Option: repoChartOptionLabel,
+                            MenuList: customMenuListItem,
+                        }}
+                        styles={{
+                            control: (base, state) => ({
+                                ...base,
+                                boxShadow: 'none',
+                                border: state.isFocused ? '1px solid var(--B500)' : '1px solid var(--N200)',
+                                cursor: 'pointer',
+                            }),
+                            option: (base, state) => {
+                                return {
+                                    ...base,
+                                    color: 'var(--N900)',
+                                    backgroundColor: state.isFocused ? 'var(--N100)' : 'white',
+                                    padding: '10px 12px',
+                                };
+                            },
+                            dropdownIndicator: (base, state) => {
+                                return {
+                                    ...base,
+                                    color: 'var(--N400)',
+                                    transition: 'all .2s ease',
+                                    transform: state.selectProps.menuIsOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+                                };
+                            },
+                            loadingMessage: (base) => {
+                                return {
+                                    ...base,
+                                    color: 'var(--N600)',
+                                };
+                            },
+                            noOptionsMessage: (base) => {
+                                return {
+                                    ...base,
+                                    color: 'var(--N600)',
+                                };
+                            },
+                        }}
+                    />
+                    {isExternal && (
+                        <button
+                            className={`refresh-charts${refreshingCharts ? ' refreshing' : ''} flex p-10 ml-8`}
+                            onClick={refreshCharts}
+                            disabled={refreshingCharts}
+                        >
+                            <Refresh className="icon-dim-16" />
+                        </button>
+                    )}
+                </div>
+                {repoChartValue.deprecated && (
+                    <div className="deprecated-text-image flex left">
+                        <AlertTriangle className="icon-dim-16 update-chart" />
+                        <span className="deprecated-text">This chart has been deprecated. Select another chart.</span>
+                    </div>
+                )}
+                {isExternal && !installedAppInfo && !repoChartValue.chartRepoName && (
+                    <div className="no-helm-chart-linked flex left">
+                        <Error className="icon-dim-16" />
+                        <span className="no-helm-chart-linked-text">
+                            This app is not linked to a helm chart. Select a helm chart to keep up with latest chart
+                            versions.
+                        </span>
+                    </div>
+                )}
+            </div>
+        )
+    );
+};
+
+export const ChartDeprecated = ({ isUpdate, deprecated, chartName, name }: ChartDeprecatedType): JSX.Element => {
+    return (
+        isUpdate &&
+        deprecated && (
+            <div className="info__container--update-chart">
+                <div className="flex left">
+                    <AlertTriangle className="icon-dim-24 update-chart" />
+                    <div className="info__container--update-chart-text">
+                        {chartName}/{name} is deprecated
+                    </div>
+                </div>
+                <div className="info__container--update-chart-disclaimer">
+                    Selected chart has been deprecated. Please select another chart to continue receiving updates in
+                    future.
+                </div>
+            </div>
+        )
+    );
+};
+
+const ChartVersionSelector = ({
+    isUpdate,
+    selectedVersion,
+    selectVersion,
+    chartVersionObj,
+    versions,
+    selectedVersionUpdatePage,
+    setSelectedVersionUpdatePage,
+    chartVersionsData,
+}: ChartVersionSelectorType) => {
+    return !isUpdate ? (
+        <div className="w-50">
+            <span className="form__label">Chart Version</span>
+            <Select
+                tabIndex={4}
+                rootClassName="select-button--default"
+                value={selectedVersion}
+                onChange={(event) => selectVersion(event.target.value)}
+            >
+                <Select.Button>{chartVersionObj ? chartVersionObj.version : 'Select Version'}</Select.Button>
+                {Array.from(versions).map(([versionId, versionData], idx) => (
+                    <Select.Option key={versionId} value={versionId}>
+                        {versionData.version}
+                    </Select.Option>
+                ))}
+            </Select>
+        </div>
+    ) : (
+        <div className="w-50">
+            <span className="form__label">Chart Version</span>
+            <Select
+                tabIndex={4}
+                rootClassName="select-button--default"
+                value={selectedVersionUpdatePage?.id}
+                onChange={(event) =>
+                    setSelectedVersionUpdatePage({
+                        id: event.target.value,
+                        version: event.target.innerText,
+                    })
+                }
+            >
+                <Select.Button>{selectedVersionUpdatePage?.version}</Select.Button>
+                {chartVersionsData.map(({ version, id }) => (
+                    <Select.Option key={id} value={id}>
+                        {version}
+                    </Select.Option>
+                ))}
+            </Select>
+        </div>
+    );
+};
+
+const ChartValuesSelector = ({
+    chartValuesList,
+    chartValues,
+    redirectToChartValues,
+    setChartValues,
+    hideVersionFromLabel,
+}: ChartValuesSelectorType) => {
+    return (
+        <div className="w-50">
+            <span className="form__label">Chart Values*</span>
+            <ChartValuesSelect
+                chartValuesList={chartValuesList}
+                chartValues={chartValues}
+                redirectToChartValues={redirectToChartValues}
+                onChange={(event) => {
+                    setChartValues(event);
+                }}
+                hideVersionFromLabel={hideVersionFromLabel}
+            />
+        </div>
+    );
+};
+
+export const ChartVersionValuesSelector = ({
+    isUpdate,
+    selectedVersion,
+    selectVersion,
+    chartVersionObj,
+    versions,
+    selectedVersionUpdatePage,
+    setSelectedVersionUpdatePage,
+    chartVersionsData,
+    chartValuesList,
+    chartValues,
+    redirectToChartValues,
+    setChartValues,
+    hideVersionFromLabel,
+}: ChartVersionValuesSelectorType) => {
+    return (
+        <div className="form__row form__row--flex form__row--w-100">
+            <ChartVersionSelector
+                isUpdate={isUpdate}
+                selectedVersion={selectedVersion}
+                selectVersion={selectVersion}
+                chartVersionObj={chartVersionObj}
+                versions={versions}
+                selectedVersionUpdatePage={selectedVersionUpdatePage}
+                setSelectedVersionUpdatePage={setSelectedVersionUpdatePage}
+                chartVersionsData={chartVersionsData}
+            />
+            <span className="mr-16"></span>
+            <ChartValuesSelector
+                chartValuesList={chartValuesList}
+                chartValues={chartValues}
+                redirectToChartValues={redirectToChartValues}
+                setChartValues={setChartValues}
+                hideVersionFromLabel={hideVersionFromLabel}
+            />
+        </div>
+    );
+};
+
+export const ActiveReadmeColumn = ({
+    readmeCollapsed,
+    toggleReadmeCollapsed,
+    defaultReadme,
+    selectedVersionUpdatePage,
+}: {
+    readmeCollapsed: boolean;
+    toggleReadmeCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
+    defaultReadme: string;
+    selectedVersionUpdatePage: ChartVersionType;
+}) => {
+    const [activeReadMe, setActiveReadMe] = useState<string>(defaultReadme);
+    const [fetchingReadMe, setFetchingReadMe] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (selectedVersionUpdatePage && selectedVersionUpdatePage.id) {
+            getChartRelatedReadMe(selectedVersionUpdatePage.id, setFetchingReadMe, setActiveReadMe);
+        }
+    }, [selectedVersionUpdatePage]);
+
+    return (
+        <ReadmeColumn
+            readmeCollapsed={readmeCollapsed}
+            toggleReadmeCollapsed={toggleReadmeCollapsed}
+            readme={activeReadMe}
+            loading={fetchingReadMe}
+        />
+    );
+};
+
+export const DeleteChartDialog = ({
+    appName,
+    handleDelete,
+    toggleConfirmation,
+}: {
+    appName: string;
+    handleDelete: (force?: boolean) => void;
+    toggleConfirmation: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
+    return (
+        <DeleteDialog
+            title={`Delete '${appName}' ?`}
+            delete={() => handleDelete(false)}
+            closeDelete={() => toggleConfirmation(false)}
+        >
+            <DeleteDialog.Description>
+                <p>This will delete all resources associated with this application.</p>
+                <p>Deleted applications cannot be restored.</p>
+            </DeleteDialog.Description>
+        </DeleteDialog>
+    );
+};
+
+export const ChartValuesEditor = ({
+    valuesText,
+    onChange,
+    repoChartValue,
+    hasChartChanged,
+    editorRef,
+}: {
+    valuesText: string;
+    onChange: (value: string) => void;
+    repoChartValue: ChartRepoOtions;
+    hasChartChanged: boolean;
+    editorRef?: React.MutableRefObject<any>;
+}) => {
+    return (
+        <div className="code-editor-container" {...(editorRef && { ref: editorRef })}>
+            <CodeEditor value={valuesText} noParsing mode="yaml" onChange={onChange}>
+                <CodeEditor.Header>
+                    <span className="bold">values.yaml</span>
+                </CodeEditor.Header>
+                {hasChartChanged && (
+                    <CodeEditor.Information
+                        text={`Please ensure that the values are compatible with "${repoChartValue.chartRepoName}/${repoChartValue.chartName}"`}
+                    />
+                )}
+            </CodeEditor>
+        </div>
+    );
+};

--- a/src/components/v2/values/common/ChartValuesSelectors.tsx
+++ b/src/components/v2/values/common/ChartValuesSelectors.tsx
@@ -437,6 +437,7 @@ export const ActiveReadmeColumn = ({
 };
 
 export const ChartValuesEditor = ({
+    loading,
     valuesText,
     onChange,
     repoChartValue,
@@ -461,7 +462,7 @@ export const ChartValuesEditor = ({
 
     return (
         <div className="code-editor-container" ref={editorRef}>
-            <CodeEditor value={valuesText} noParsing mode="yaml" onChange={onChange}>
+            <CodeEditor value={valuesText} noParsing mode="yaml" onChange={onChange} loading={loading}>
                 <CodeEditor.Header>
                     <span className="bold">values.yaml</span>
                 </CodeEditor.Header>

--- a/src/components/v2/values/common/ChartValuesSelectors.tsx
+++ b/src/components/v2/values/common/ChartValuesSelectors.tsx
@@ -8,8 +8,9 @@ import { ReactComponent as Error } from '../../../../assets/icons/ic-warning.svg
 import { ReactComponent as Refetch } from '../../../../assets/icons/ic-restore.svg';
 import { ReactComponent as Info } from '../../../../assets/icons/ic-info-filled.svg';
 import checkIcon from '../../../../assets/icons/appstatus/ic-check.svg';
+import warn from '../../../../assets/icons/ic-warning.svg';
 import { ChartValuesSelect } from '../../../charts/util/ChartValueSelect';
-import { DeleteDialog, Select } from '../../../common';
+import { ConfirmationDialog, DeleteDialog, Select } from '../../../common';
 import {
     ChartEnvironmentSelectorType,
     ChartRepoSelectorType,
@@ -446,6 +447,29 @@ export const ActiveReadmeColumn = ({
     );
 };
 
+export const ChartValuesEditor = ({
+    valuesText,
+    onChange,
+    repoChartValue,
+    hasChartChanged,
+    editorRef,
+}: ChartValuesEditorType) => {
+    return (
+        <div className="code-editor-container" {...(editorRef && { ref: editorRef })}>
+            <CodeEditor value={valuesText} noParsing mode="yaml" onChange={onChange}>
+                <CodeEditor.Header>
+                    <span className="bold">values.yaml</span>
+                </CodeEditor.Header>
+                {hasChartChanged && (
+                    <CodeEditor.Information
+                        text={`Please ensure that the values are compatible with "${repoChartValue.chartRepoName}/${repoChartValue.chartName}"`}
+                    />
+                )}
+            </CodeEditor>
+        </div>
+    );
+};
+
 export const DeleteChartDialog = ({
     appName,
     handleDelete,
@@ -469,25 +493,38 @@ export const DeleteChartDialog = ({
     );
 };
 
-export const ChartValuesEditor = ({
-    valuesText,
-    onChange,
-    repoChartValue,
-    hasChartChanged,
-    editorRef,
-}: ChartValuesEditorType) => {
+export const AppNotLinkedDialog = ({
+    close,
+    update,
+}: {
+    close: () => void;
+    update: (forceUpdate: boolean) => void;
+}) => {
     return (
-        <div className="code-editor-container" {...(editorRef && { ref: editorRef })}>
-            <CodeEditor value={valuesText} noParsing mode="yaml" onChange={onChange}>
-                <CodeEditor.Header>
-                    <span className="bold">values.yaml</span>
-                </CodeEditor.Header>
-                {hasChartChanged && (
-                    <CodeEditor.Information
-                        text={`Please ensure that the values are compatible with "${repoChartValue.chartRepoName}/${repoChartValue.chartName}"`}
-                    />
-                )}
-            </CodeEditor>
-        </div>
+        <ConfirmationDialog>
+            <ConfirmationDialog.Icon src={warn} />
+            <ConfirmationDialog.Body title="This app is not linked to a helm chart">
+                <p className="fs-13 cn-7 lh-1-54">
+                    We strongly recommend linking the app to a helm chart for better application management.
+                </p>
+            </ConfirmationDialog.Body>
+            <ConfirmationDialog.ButtonGroup>
+                <div className="flex right">
+                    <button type="button" className="cta cancel" onClick={close}>
+                        Go back
+                    </button>
+                    <button
+                        type="button"
+                        className="cta ml-12 no-decor"
+                        onClick={() => {
+                            close();
+                            update(true);
+                        }}
+                    >
+                        Deploy without linking helm chart
+                    </button>
+                </div>
+            </ConfirmationDialog.ButtonGroup>
+        </ConfirmationDialog>
     );
 };

--- a/src/components/v2/values/common/ChartValuesSelectors.tsx
+++ b/src/components/v2/values/common/ChartValuesSelectors.tsx
@@ -20,6 +20,7 @@ import {
     ChartVersionValuesSelectorType,
     ChartValuesEditorType,
     ChartRepoDetailsType,
+    ChartSelectorType,
 } from './chartValuesSelectors.type';
 import { getChartsByKeyword } from '../../../charts/charts.service';
 import { ChartRepoOtions } from '../DeployChart';
@@ -77,10 +78,22 @@ export const ChartEnvironmentSelector = ({
     );
 };
 
+export const StaticChartRepoInput = ({ releaseInfo }: ChartSelectorType) => {
+    return (
+        <label className="form__row form__row--w-100">
+            <span className="form__label">Chart</span>
+            <input
+                className="form__input"
+                value={`${releaseInfo.deployedAppDetail.chartName} (${releaseInfo.deployedAppDetail.chartVersion})`}
+                disabled={true}
+            />
+        </label>
+    );
+};
+
 export const ChartRepoSelector = ({
     isExternal,
     installedAppInfo,
-    releaseInfo,
     isUpdate,
     repoChartValue,
     handleRepoChartValueChange,
@@ -177,16 +190,7 @@ export const ChartRepoSelector = ({
         );
     }
 
-    return isExternal && installedAppInfo ? (
-        <label className="form__row form__row--w-100">
-            <span className="form__label">Chart</span>
-            <input
-                className="form__input"
-                value={`${releaseInfo.deployedAppDetail.chartName} (${releaseInfo.deployedAppDetail.chartVersion})`}
-                disabled={true}
-            />
-        </label>
-    ) : (
+    return (
         (isExternal || isUpdate) && (
             <div className="form__row form__row--w-100">
                 <span className="form__label">{isExternal ? 'Chart' : 'Repo/Chart'}</span>

--- a/src/components/v2/values/common/ReadmeColumn.component.tsx
+++ b/src/components/v2/values/common/ReadmeColumn.component.tsx
@@ -3,16 +3,24 @@ import ReactGA from 'react-ga';
 import { DropdownIcon, Page, Progressing } from '../../../common';
 import { MarkDown } from '../../../charts/discoverChartDetail/DiscoverChartDetails';
 import '../../../charts/modal/DeployChart.scss';
+import MessageUI, { MsgUIType } from '../../common/message.ui';
 
 function ReadmeColumn({ readmeCollapsed, toggleReadmeCollapsed, readme, loading = false, ...props }) {
-
     return (
         <div className="deploy-chart__readme-column">
-            {loading && !readmeCollapsed ? (
-                <Progressing pageLoader />
-            ) : (
-                <MarkDown markdown={readme} className="deploy-chart__readme-markdown" />
+            {loading && !readmeCollapsed && <Progressing pageLoader />}
+            {!loading && readme && (
+                <MessageUI
+                    icon={MsgUIType.ERROR}
+                    msg="Readme is not available for the selected chart version"
+                    size={16}
+                    theme="light-gray"
+                    iconClassName="no-readme-icon"
+                    msgStyle={{ color: 'var(--N700)', marginTop: '0' }}
+                    {...(readmeCollapsed && { bodyStyle: { width: '0' } })}
+                />
             )}
+            {!loading && !readme && <MarkDown markdown={readme} className="deploy-chart__readme-markdown" />}
             <aside className="flex column" onClick={readme ? (e) => {
                 if (readmeCollapsed) {
                     ReactGA.event({
@@ -28,7 +36,7 @@ function ReadmeColumn({ readmeCollapsed, toggleReadmeCollapsed, readme, loading 
                 {readmeCollapsed && <Page className="rotate" style={{ ['--rotateBy' as any]: `0deg` }} />}
             </aside>
         </div>
-    )
+    );
 }
 
-export default ReadmeColumn
+export default ReadmeColumn;

--- a/src/components/v2/values/common/ReadmeColumn.component.tsx
+++ b/src/components/v2/values/common/ReadmeColumn.component.tsx
@@ -9,7 +9,7 @@ function ReadmeColumn({ readmeCollapsed, toggleReadmeCollapsed, readme, loading 
     return (
         <div className="deploy-chart__readme-column">
             {loading && !readmeCollapsed && <Progressing pageLoader />}
-            {!loading && readme && (
+            {!loading && !readme && (
                 <MessageUI
                     icon={MsgUIType.ERROR}
                     msg="Readme is not available for the selected chart version"
@@ -20,7 +20,7 @@ function ReadmeColumn({ readmeCollapsed, toggleReadmeCollapsed, readme, loading 
                     {...(readmeCollapsed && { bodyStyle: { width: '0' } })}
                 />
             )}
-            {!loading && !readme && <MarkDown markdown={readme} className="deploy-chart__readme-markdown" />}
+            {!loading && readme && <MarkDown markdown={readme} className="deploy-chart__readme-markdown" />}
             <aside className="flex column" onClick={readme ? (e) => {
                 if (readmeCollapsed) {
                     ReactGA.event({

--- a/src/components/v2/values/common/ReadmeColumn.component.tsx
+++ b/src/components/v2/values/common/ReadmeColumn.component.tsx
@@ -1,14 +1,18 @@
 import React, { useState, useEffect, useRef } from 'react';
 import ReactGA from 'react-ga';
-import { DropdownIcon, Page } from '../../../common';
+import { DropdownIcon, Page, Progressing } from '../../../common';
 import { MarkDown } from '../../../charts/discoverChartDetail/DiscoverChartDetails';
 import '../../../charts/modal/DeployChart.scss';
 
-function ReadmeColumn({ readmeCollapsed, toggleReadmeCollapsed, readme, ...props }) {
+function ReadmeColumn({ readmeCollapsed, toggleReadmeCollapsed, readme, loading = false, ...props }) {
 
     return (
         <div className="deploy-chart__readme-column">
-            <MarkDown markdown={readme} className="deploy-chart__readme-markdown" />
+            {loading && !readmeCollapsed ? (
+                <Progressing pageLoader />
+            ) : (
+                <MarkDown markdown={readme} className="deploy-chart__readme-markdown" />
+            )}
             <aside className="flex column" onClick={readme ? (e) => {
                 if (readmeCollapsed) {
                     ReactGA.event({

--- a/src/components/v2/values/common/ReadmeColumn.component.tsx
+++ b/src/components/v2/values/common/ReadmeColumn.component.tsx
@@ -8,7 +8,11 @@ import MessageUI, { MsgUIType } from '../../common/message.ui';
 function ReadmeColumn({ readmeCollapsed, toggleReadmeCollapsed, readme, loading = false, ...props }) {
     return (
         <div className="deploy-chart__readme-column">
-            {loading && !readmeCollapsed && <Progressing pageLoader />}
+            {loading && (
+                <div {...(readmeCollapsed && { style: { width: '0' } })}>
+                    <Progressing pageLoader />
+                </div>
+            )}
             {!loading && !readme && (
                 <MessageUI
                     icon={MsgUIType.ERROR}

--- a/src/components/v2/values/common/chartValues.api.ts
+++ b/src/components/v2/values/common/chartValues.api.ts
@@ -68,11 +68,7 @@ export async function getChartRelatedReadMe(
     try {
         setFetchingReadMe(true);
         const { result } = await getReadme(id);
-
-        // If ReadMe for specific version/id is available then only update the active ReadMe.
-        if (result.readme) {
-            setActiveReadMe(result.readme);
-        }
+        setActiveReadMe(result.readme);
         setFetchingReadMe(false);
     } catch (err) {
         setFetchingReadMe(false);

--- a/src/components/v2/values/common/chartValues.api.ts
+++ b/src/components/v2/values/common/chartValues.api.ts
@@ -21,7 +21,7 @@ export async function fetchChartVersionsData(
         if (isExternal) {
             const specificVersion = result.find((e) => e.version === currentChartVersion);
             if (specificVersion) {
-                selectVersion(specificVersion.id);
+                selectVersion && selectVersion(specificVersion.id);
                 setSelectedVersionUpdatePage(specificVersion);
             } else {
                 setSelectedVersionUpdatePage(result[0]);
@@ -55,6 +55,7 @@ export async function getChartValuesList(
             });
         }
     } catch (err) {
+        showError(err);
     } finally {
         setLoading && setLoading(false);
     }
@@ -71,6 +72,8 @@ export async function getChartRelatedReadMe(
         setActiveReadMe(result.readme);
         setFetchingReadMe(false);
     } catch (err) {
+        showError(err);
+    } finally {
         setFetchingReadMe(false);
     }
 }

--- a/src/components/v2/values/common/chartValues.api.ts
+++ b/src/components/v2/values/common/chartValues.api.ts
@@ -1,0 +1,80 @@
+import React from 'react';
+import { getChartValuesCategorizedListParsed, getChartVersionsMin, getReadme } from '../../../charts/charts.service';
+import { ChartVersionType } from '../../../charts/charts.types';
+import { showError } from '../../../common';
+
+export async function fetchChartVersionsData(
+    id: number,
+    isExternal: boolean,
+    valueUpdateRequired: boolean,
+    setSelectedVersionUpdatePage: React.Dispatch<React.SetStateAction<ChartVersionType>>,
+    setChartVersionsData: React.Dispatch<React.SetStateAction<ChartVersionType[]>>,
+    setLoading?: React.Dispatch<React.SetStateAction<boolean>>,
+    currentChartVersion?: string,
+    selectVersion?: React.Dispatch<React.SetStateAction<number>>,
+) {
+    try {
+        setLoading && setLoading(true);
+        const { result } = await getChartVersionsMin(id);
+        setChartVersionsData(result);
+
+        if (isExternal) {
+            const specificVersion = result.find((e) => e.version === currentChartVersion);
+            if (specificVersion) {
+                selectVersion(specificVersion.id);
+                setSelectedVersionUpdatePage(specificVersion);
+            } else {
+                setSelectedVersionUpdatePage(result[0]);
+            }
+        } else if (valueUpdateRequired) {
+            setSelectedVersionUpdatePage(result[0]);
+        }
+    } catch (err) {
+        showError(err);
+    } finally {
+        setLoading && setLoading(false);
+    }
+}
+
+export async function getChartValuesList(
+    id: number,
+    setChartValuesList: React.Dispatch<React.SetStateAction<any>>,
+    setChartValues: React.Dispatch<React.SetStateAction<any>>,
+    setLoading?: React.Dispatch<React.SetStateAction<boolean>>,
+    initId?: number,
+    installedAppVersionId = null,
+) {
+    setLoading && setLoading(true);
+    try {
+        const { result } = await getChartValuesCategorizedListParsed(id, installedAppVersionId);
+        setChartValuesList(result);
+        if (installedAppVersionId) {
+            setChartValues({
+                id: initId,
+                kind: 'EXISTING',
+            });
+        }
+    } catch (err) {
+    } finally {
+        setLoading && setLoading(false);
+    }
+}
+
+export async function getChartRelatedReadMe(
+    id: number,
+    setFetchingReadMe: React.Dispatch<React.SetStateAction<boolean>>,
+    setActiveReadMe: React.Dispatch<React.SetStateAction<string>>,
+) {
+    try {
+        setFetchingReadMe(true);
+        const { result } = await getReadme(id);
+
+        // If ReadMe for specific version/id is available then only update the active ReadMe.
+        if (result.readme) {
+            setActiveReadMe(result.readme);
+        }
+        setFetchingReadMe(false);
+    } catch (err) {
+        setFetchingReadMe(false);
+    }
+}

--- a/src/components/v2/values/common/chartValuesSelectors.type.ts
+++ b/src/components/v2/values/common/chartValuesSelectors.type.ts
@@ -68,5 +68,6 @@ export interface ChartValuesEditorType {
     onChange: (value: string) => void;
     repoChartValue: ChartRepoOtions;
     hasChartChanged: boolean;
-    editorRef?: React.MutableRefObject<any>;
+    parentRef: React.MutableRefObject<any>;
+    autoFocus: boolean;
 }

--- a/src/components/v2/values/common/chartValuesSelectors.type.ts
+++ b/src/components/v2/values/common/chartValuesSelectors.type.ts
@@ -16,9 +16,15 @@ export interface ChartEnvironmentSelectorType extends ChartSelectorType {
     environments?: any[];
 }
 
+export interface ChartRepoDetailsType {
+    chartRepoName: string;
+    chartName: string;
+    version: string;
+}
+
 export interface ChartRepoSelectorType extends ChartSelectorType {
     repoChartValue?: ChartRepoOtions;
-    repoChartSelectOptionLabel?: ({ chartRepoName, chartName }) => JSX.Element;
+    repoChartSelectOptionLabel?: (chartRepoDetails: ChartRepoDetailsType) => JSX.Element;
     handleRepoChartValueChange?: (event: any) => void;
     repoChartOptionLabel?: (props: any) => JSX.Element;
     chartDetails?: ChartRepoOtions;
@@ -42,13 +48,13 @@ export interface ChartVersionSelectorType {
     selectVersion: React.Dispatch<React.SetStateAction<number>>;
     chartVersionObj?: any;
     versions?: Map<number, VersionType>;
-    selectedVersionUpdatePage: any;
+    selectedVersionUpdatePage: VersionType;
     setSelectedVersionUpdatePage: React.Dispatch<React.SetStateAction<VersionType>>;
     chartVersionsData: VersionType[];
 }
 
 export interface ChartValuesSelectorType {
-    chartValuesList: any[];
+    chartValuesList: ChartValuesType[];
     chartValues: ChartValuesType;
     setChartValues: React.Dispatch<React.SetStateAction<ChartValuesType>>;
     redirectToChartValues?: () => Promise<void>;
@@ -56,3 +62,11 @@ export interface ChartValuesSelectorType {
 }
 
 export interface ChartVersionValuesSelectorType extends ChartVersionSelectorType, ChartValuesSelectorType {}
+
+export interface ChartValuesEditorType {
+    valuesText: string;
+    onChange: (value: string) => void;
+    repoChartValue: ChartRepoOtions;
+    hasChartChanged: boolean;
+    editorRef?: React.MutableRefObject<any>;
+}

--- a/src/components/v2/values/common/chartValuesSelectors.type.ts
+++ b/src/components/v2/values/common/chartValuesSelectors.type.ts
@@ -64,6 +64,7 @@ export interface ChartValuesSelectorType {
 export interface ChartVersionValuesSelectorType extends ChartVersionSelectorType, ChartValuesSelectorType {}
 
 export interface ChartValuesEditorType {
+    loading: boolean;
     valuesText: string;
     onChange: (value: string) => void;
     repoChartValue: ChartRepoOtions;

--- a/src/components/v2/values/common/chartValuesSelectors.type.ts
+++ b/src/components/v2/values/common/chartValuesSelectors.type.ts
@@ -1,5 +1,4 @@
-import { OptionsType } from 'react-select';
-import { ChartValuesType } from '../../../charts/charts.types';
+import { ChartValuesType, ChartVersionType } from '../../../charts/charts.types';
 import { InstalledAppInfo, ReleaseInfo } from '../../../external-apps/ExternalAppService';
 import { ChartRepoOtions } from '../DeployChart';
 
@@ -37,20 +36,15 @@ export interface ChartDeprecatedType {
     name: string;
 }
 
-export interface VersionType {
-    id: number;
-    version: any;
-}
-
 export interface ChartVersionSelectorType {
     isUpdate?: boolean;
     selectedVersion: number;
     selectVersion: React.Dispatch<React.SetStateAction<number>>;
-    chartVersionObj?: any;
-    versions?: Map<number, VersionType>;
-    selectedVersionUpdatePage: VersionType;
-    setSelectedVersionUpdatePage: React.Dispatch<React.SetStateAction<VersionType>>;
-    chartVersionsData: VersionType[];
+    chartVersionObj?: ChartVersionType;
+    versions?: Map<number, ChartVersionType>;
+    selectedVersionUpdatePage: ChartVersionType;
+    setSelectedVersionUpdatePage: React.Dispatch<React.SetStateAction<ChartVersionType>>;
+    chartVersionsData: ChartVersionType[];
 }
 
 export interface ChartValuesSelectorType {
@@ -69,6 +63,6 @@ export interface ChartValuesEditorType {
     onChange: (value: string) => void;
     repoChartValue: ChartRepoOtions;
     hasChartChanged: boolean;
-    parentRef: React.MutableRefObject<any>;
+    parentRef: React.MutableRefObject<HTMLDivElement>;
     autoFocus: boolean;
 }

--- a/src/components/v2/values/common/chartValuesSelectors.type.ts
+++ b/src/components/v2/values/common/chartValuesSelectors.type.ts
@@ -1,0 +1,58 @@
+import { OptionsType } from 'react-select';
+import { ChartValuesType } from '../../../charts/charts.types';
+import { InstalledAppInfo, ReleaseInfo } from '../../../external-apps/ExternalAppService';
+import { ChartRepoOtions } from '../DeployChart';
+
+export interface ChartSelectorType {
+    isExternal?: boolean;
+    releaseInfo?: ReleaseInfo;
+    installedAppInfo?: InstalledAppInfo;
+    isUpdate?: boolean;
+}
+
+export interface ChartEnvironmentSelectorType extends ChartSelectorType {
+    selectedEnvironment?: { label: string; value: number };
+    selectEnvironment?: React.Dispatch<React.SetStateAction<{ label: string; value: number }>>;
+    environments?: any[];
+}
+
+export interface ChartRepoSelectorType extends ChartSelectorType {
+    repoChartValue?: ChartRepoOtions;
+    repoChartSelectOptionLabel?: ({ chartRepoName, chartName }) => JSX.Element;
+    handleRepoChartValueChange?: (event: any) => void;
+    repoChartOptionLabel?: (props: any) => JSX.Element;
+    chartDetails?: ChartRepoOtions;
+}
+
+export interface ChartDeprecatedType {
+    isUpdate: boolean;
+    deprecated: boolean;
+    chartName: string;
+    name: string;
+}
+
+export interface VersionType {
+    id: number;
+    version: any;
+}
+
+export interface ChartVersionSelectorType {
+    isUpdate?: boolean;
+    selectedVersion: number;
+    selectVersion: React.Dispatch<React.SetStateAction<number>>;
+    chartVersionObj?: any;
+    versions?: Map<number, VersionType>;
+    selectedVersionUpdatePage: any;
+    setSelectedVersionUpdatePage: React.Dispatch<React.SetStateAction<VersionType>>;
+    chartVersionsData: VersionType[];
+}
+
+export interface ChartValuesSelectorType {
+    chartValuesList: any[];
+    chartValues: ChartValuesType;
+    setChartValues: React.Dispatch<React.SetStateAction<ChartValuesType>>;
+    redirectToChartValues?: () => Promise<void>;
+    hideVersionFromLabel?: boolean;
+}
+
+export interface ChartVersionValuesSelectorType extends ChartVersionSelectorType, ChartValuesSelectorType {}

--- a/src/components/v2/values/ea/EAValues.component.tsx
+++ b/src/components/v2/values/ea/EAValues.component.tsx
@@ -189,7 +189,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
             return;
         }
 
-        if (!forceUpdate && !repoChartValue?.chartRepoName) {
+        if (!forceUpdate && !installedAppInfo) {
             setShowAppNotLinkedDialog(true);
             return;
         }
@@ -203,7 +203,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
         }
 
         setUpdateInProgress(true);
-        const payload = repoChartValue.chartRepoName
+        const payload = !installedAppInfo
             ? {
                   appId: appId,
                   valuesYaml: modifiedValuesYaml,
@@ -216,7 +216,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
                   valuesYaml: modifiedValuesYaml,
               };
 
-        (repoChartValue.chartRepoName
+        (!installedAppInfo
             ? linkToChartStore(payload as LinkToChartStoreRequest)
             : updateApplicationRelease(payload as UpdateApplicationRequest)
         )

--- a/src/components/v2/values/ea/EAValues.component.tsx
+++ b/src/components/v2/values/ea/EAValues.component.tsx
@@ -101,9 +101,10 @@ function ExternalAppValues({ appId }: { appId: string }) {
 
     useEffect(() => {
         if (
-            chartValues?.id &&
-            chartValues?.chartVersion &&
-            chartValues?.name !== releaseInfo?.deployedAppDetail.appName
+            chartValues &&
+            chartValues.id &&
+            chartValues.chartVersion &&
+            chartValues.name !== releaseInfo?.deployedAppDetail.appName
         ) {
             getChartValues(chartValues.id, chartValues.kind)
                 .then((response) => {
@@ -112,7 +113,11 @@ function ExternalAppValues({ appId }: { appId: string }) {
                 .catch((error) => {
                     showError(error);
                 });
-        } else if (chartValues?.name === releaseInfo?.deployedAppDetail.appName && releaseInfo?.mergedValues) {
+        } else if (
+            releaseInfo &&
+            releaseInfo.mergedValues &&
+            releaseInfo.deployedAppDetail.appName === chartValues?.name
+        ) {
             setModifiedValuesYaml(YAML.stringify(JSON.parse(releaseInfo?.mergedValues)));
         }
     }, [chartValues]);

--- a/src/components/v2/values/ea/EAValues.component.tsx
+++ b/src/components/v2/values/ea/EAValues.component.tsx
@@ -188,7 +188,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
             return
         }
 
-        if (!forceUpdate && !installedAppInfo) {
+        if (!forceUpdate && !installedAppInfo && !repoChartValue?.chartRepoName) {
             setShowAppNotLinkedDialog(true)
             return
         }
@@ -204,7 +204,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
         setUpdateInProgress(true)
 
         try {
-            if (!installedAppInfo && !forceUpdate) {
+            if (!forceUpdate && !installedAppInfo) {
                 const payload: LinkToChartStoreRequest = {
                     appId: appId,
                     valuesYaml: modifiedValuesYaml,

--- a/src/components/v2/values/ea/EAValues.component.tsx
+++ b/src/components/v2/values/ea/EAValues.component.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { useHistory, useRouteMatch } from 'react-router';
-import { toast } from 'react-toastify';
-import { showError, Progressing, ErrorScreenManager } from '../../../common';
+import React, { useState, useEffect, useRef } from 'react'
+import { useHistory, useRouteMatch } from 'react-router'
+import { toast } from 'react-toastify'
+import { showError, Progressing, ErrorScreenManager } from '../../../common'
 import {
     getReleaseInfo,
     ReleaseInfoResponse,
@@ -12,12 +12,12 @@ import {
     UpdateApplicationRequest,
     linkToChartStore,
     LinkToChartStoreRequest,
-} from '../../../external-apps/ExternalAppService';
-import { deleteInstalledChart, getChartValues } from '../../../charts/charts.service';
-import { ServerErrors } from '../../../../modals/commonTypes';
-import { URLS } from '../../../../config';
-import YAML from 'yaml';
-import '../../../charts/modal/DeployChart.scss';
+} from '../../../external-apps/ExternalAppService'
+import { deleteInstalledChart, getChartValues } from '../../../charts/charts.service'
+import { ServerErrors } from '../../../../modals/commonTypes'
+import { URLS } from '../../../../config'
+import YAML from 'yaml'
+import '../../../charts/modal/DeployChart.scss'
 import {
     ChartEnvironmentSelector,
     ChartRepoSelector,
@@ -27,41 +27,41 @@ import {
     ChartValuesEditor,
     AppNotLinkedDialog,
     StaticChartRepoInput,
-} from '../common/ChartValuesSelectors';
-import { ChartRepoOtions } from '../DeployChart';
-import { ChartValuesType, ChartVersionType } from '../../../charts/charts.types';
-import { fetchChartVersionsData, getChartValuesList } from '../common/chartValues.api';
-import { getChartValuesURL } from '../../../charts/charts.helper';
+} from '../common/ChartValuesSelectors'
+import { ChartRepoOtions } from '../DeployChart'
+import { ChartValuesType, ChartVersionType } from '../../../charts/charts.types'
+import { fetchChartVersionsData, getChartValuesList } from '../common/chartValues.api'
+import { getChartValuesURL } from '../../../charts/charts.helper'
 
 function ExternalAppValues({ appId }: { appId: string }) {
-    const history = useHistory();
-    const { url } = useRouteMatch();
+    const history = useHistory()
+    const { url } = useRouteMatch()
 
-    const [isLoading, setIsLoading] = useState(true);
-    const [fetchingValuesYaml, setFetchingValuesYaml] = useState(false);
-    const [isUpdateInProgress, setUpdateInProgress] = useState(false);
-    const [isDeleteInProgress, setDeleteInProgress] = useState(false);
-    const [errorResponseCode, setErrorResponseCode] = useState(undefined);
-    const [readmeCollapsed, toggleReadmeCollapsed] = useState(true);
-    const [releaseInfo, setReleaseInfo] = useState<ReleaseInfo>(undefined);
-    const [showDeleteAppConfirmationDialog, setShowDeleteAppConfirmationDialog] = useState(false);
-    const [showAppNotLinkedDialog, setShowAppNotLinkedDialog] = useState(false);
-    const [modifiedValuesYaml, setModifiedValuesYaml] = useState('');
-    const [installedAppInfo, setInstalledAppInfo] = useState<InstalledAppInfo>(undefined);
-    const [repoChartValue, setRepoChartValue] = useState<ChartRepoOtions>();
-    const [chartVersionsData, setChartVersionsData] = useState<ChartVersionType[]>([]);
-    const [chartValuesList, setChartValuesList] = useState<ChartValuesType[]>([]);
-    const [selectedVersion, selectVersion] = useState<any>();
-    const [selectedVersionUpdatePage, setSelectedVersionUpdatePage] = useState<ChartVersionType>();
-    const [chartValues, setChartValues] = useState<ChartValuesType>();
-    const deployChartRef = useRef<HTMLDivElement>(null);
+    const [isLoading, setIsLoading] = useState(true)
+    const [fetchingValuesYaml, setFetchingValuesYaml] = useState(false)
+    const [isUpdateInProgress, setUpdateInProgress] = useState(false)
+    const [isDeleteInProgress, setDeleteInProgress] = useState(false)
+    const [errorResponseCode, setErrorResponseCode] = useState(undefined)
+    const [readmeCollapsed, toggleReadmeCollapsed] = useState(true)
+    const [releaseInfo, setReleaseInfo] = useState<ReleaseInfo>(undefined)
+    const [showDeleteAppConfirmationDialog, setShowDeleteAppConfirmationDialog] = useState(false)
+    const [showAppNotLinkedDialog, setShowAppNotLinkedDialog] = useState(false)
+    const [modifiedValuesYaml, setModifiedValuesYaml] = useState('')
+    const [installedAppInfo, setInstalledAppInfo] = useState<InstalledAppInfo>(undefined)
+    const [repoChartValue, setRepoChartValue] = useState<ChartRepoOtions>()
+    const [chartVersionsData, setChartVersionsData] = useState<ChartVersionType[]>([])
+    const [chartValuesList, setChartValuesList] = useState<ChartValuesType[]>([])
+    const [selectedVersion, selectVersion] = useState<any>()
+    const [selectedVersionUpdatePage, setSelectedVersionUpdatePage] = useState<ChartVersionType>()
+    const [chartValues, setChartValues] = useState<ChartValuesType>()
+    const deployChartRef = useRef<HTMLDivElement>(null)
 
     // component load
     useEffect(() => {
         getReleaseInfo(appId)
             .then((releaseInfoResponse: ReleaseInfoResponse) => {
-                let _releaseInfo = releaseInfoResponse.result.releaseInfo;
-                setReleaseInfo(_releaseInfo);
+                const _releaseInfo = releaseInfoResponse.result.releaseInfo
+                setReleaseInfo(_releaseInfo)
 
                 if (!releaseInfoResponse.result.installedAppInfo) {
                     setRepoChartValue({
@@ -71,39 +71,39 @@ function ExternalAppValues({ appId }: { appId: string }) {
                         chartName: _releaseInfo.deployedAppDetail.chartName,
                         version: _releaseInfo.deployedAppDetail.chartVersion,
                         deprecated: false,
-                    });
+                    })
 
                     const _chartVersionData: ChartVersionType = {
                         id: 0,
                         version: _releaseInfo.deployedAppDetail.chartVersion,
-                    };
+                    }
 
-                    setSelectedVersionUpdatePage(_chartVersionData);
-                    setChartVersionsData([_chartVersionData]);
+                    setSelectedVersionUpdatePage(_chartVersionData)
+                    setChartVersionsData([_chartVersionData])
 
                     const _chartValues: ChartValuesType = {
                         id: 0,
                         kind: 'EXISTING',
                         name: _releaseInfo.deployedAppDetail.appName,
-                    };
+                    }
 
-                    setChartValues(_chartValues);
-                    setChartValuesList([_chartValues]);
+                    setChartValues(_chartValues)
+                    setChartValuesList([_chartValues])
                 }
-                setInstalledAppInfo(releaseInfoResponse.result.installedAppInfo);
-                setModifiedValuesYaml(YAML.stringify(JSON.parse(_releaseInfo.mergedValues)));
-                setIsLoading(false);
+                setInstalledAppInfo(releaseInfoResponse.result.installedAppInfo)
+                setModifiedValuesYaml(YAML.stringify(JSON.parse(_releaseInfo.mergedValues)))
+                setIsLoading(false)
             })
             .catch((errors: ServerErrors) => {
-                showError(errors);
-                setErrorResponseCode(errors.code);
-                setIsLoading(false);
-            });
-    }, []);
+                showError(errors)
+                setErrorResponseCode(errors.code)
+                setIsLoading(false)
+            })
+    }, [])
 
     useEffect(() => {
         if (releaseInfo && chartValues) {
-            setFetchingValuesYaml(true);
+            setFetchingValuesYaml(true)
             if (
                 chartValues.id &&
                 chartValues.chartVersion &&
@@ -111,22 +111,22 @@ function ExternalAppValues({ appId }: { appId: string }) {
             ) {
                 getChartValues(chartValues.id, chartValues.kind)
                     .then((response) => {
-                        setModifiedValuesYaml(response.result.values || '');
-                        setFetchingValuesYaml(false);
+                        setModifiedValuesYaml(response.result.values || '')
+                        setFetchingValuesYaml(false)
                     })
                     .catch((error) => {
-                        showError(error);
-                        setFetchingValuesYaml(false);
-                    });
+                        showError(error)
+                        setFetchingValuesYaml(false)
+                    })
             } else if (releaseInfo.mergedValues && releaseInfo.deployedAppDetail.appName === chartValues.name) {
-                setModifiedValuesYaml(YAML.stringify(JSON.parse(releaseInfo?.mergedValues)));
-                setFetchingValuesYaml(false);
+                setModifiedValuesYaml(YAML.stringify(JSON.parse(releaseInfo?.mergedValues)))
+                setFetchingValuesYaml(false)
             }
         }
-    }, [chartValues]);
+    }, [chartValues])
 
     const handleRepoChartValueChange = (event) => {
-        setRepoChartValue(event);
+        setRepoChartValue(event)
         fetchChartVersionsData(
             event.chartId,
             true,
@@ -136,7 +136,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
             undefined,
             releaseInfo.deployedAppDetail.chartVersion,
             selectVersion,
-        );
+        )
         getChartValuesList(
             event.chartId,
             (_chartValuesList: ChartValuesType[]) => {
@@ -145,102 +145,100 @@ function ExternalAppValues({ appId }: { appId: string }) {
                         id: 0,
                         kind: 'EXISTING',
                         name: releaseInfo.deployedAppDetail.appName,
-                    };
+                    }
 
-                    _chartValuesList?.push(_defaultChartValues);
-                    setChartValues(_defaultChartValues);
+                    _chartValuesList?.push(_defaultChartValues)
+                    setChartValues(_defaultChartValues)
                 }
 
-                setChartValuesList(_chartValuesList);
+                setChartValuesList(_chartValuesList)
             },
             setChartValues,
-        );
-    };
+        )
+    }
 
     const deleteApplication = () => {
         if (isDeleteInProgress) {
-            return;
+            return
         }
-        setDeleteInProgress(true);
-        setShowDeleteAppConfirmationDialog(false);
+        setDeleteInProgress(true)
+        setShowDeleteAppConfirmationDialog(false)
         getDeleteApplicationApi()
             .then(() => {
-                setDeleteInProgress(false);
-                toast.success('Successfully deleted.');
-                let _url = `${URLS.APP}/${URLS.APP_LIST}/${URLS.APP_LIST_HELM}`;
-                history.push(_url);
+                setDeleteInProgress(false)
+                toast.success('Successfully deleted.')
+                history.push(`${URLS.APP}/${URLS.APP_LIST}/${URLS.APP_LIST_HELM}`)
             })
             .catch((errors: ServerErrors) => {
-                showError(errors);
-                setDeleteInProgress(false);
-            });
-    };
+                showError(errors)
+                setDeleteInProgress(false)
+            })
+    }
 
     const getDeleteApplicationApi = (): Promise<any> => {
         if (installedAppInfo && installedAppInfo.installedAppId) {
-            return deleteInstalledChart(installedAppInfo.installedAppId);
+            return deleteInstalledChart(installedAppInfo.installedAppId)
         } else {
-            return deleteApplicationRelease(appId);
+            return deleteApplicationRelease(appId)
         }
-    };
+    }
 
-    const updateApplication = (forceUpdate?: boolean) => {
+    const updateApplication = async (forceUpdate?: boolean) => {
         if (isUpdateInProgress) {
-            return;
+            return
         }
 
         if (!forceUpdate && !installedAppInfo) {
-            setShowAppNotLinkedDialog(true);
-            return;
+            setShowAppNotLinkedDialog(true)
+            return
         }
 
         // validate data
         try {
-            JSON.stringify(YAML.parse(modifiedValuesYaml));
+            JSON.stringify(YAML.parse(modifiedValuesYaml))
         } catch (err) {
-            toast.error(`Encountered data validation error while updating. “${err}”`);
-            return;
+            toast.error(`Encountered data validation error while updating. “${err}”`)
+            return
         }
 
-        setUpdateInProgress(true);
-        const payload = !installedAppInfo
-            ? {
-                  appId: appId,
-                  valuesYaml: modifiedValuesYaml,
-                  appStoreApplicationVersionId: selectedVersionUpdatePage.id,
-                  referenceValueId: selectedVersionUpdatePage.id,
-                  referenceValueKind: chartValues.kind,
-              }
-            : {
-                  appId: appId,
-                  valuesYaml: modifiedValuesYaml,
-              };
+        setUpdateInProgress(true)
 
-        (!installedAppInfo
-            ? linkToChartStore(payload as LinkToChartStoreRequest)
-            : updateApplicationRelease(payload as UpdateApplicationRequest)
-        )
-            .then(() => {
-                setUpdateInProgress(false);
-                toast.success('Update and deployment initiated.');
-                let _url = `${url.split('/').slice(0, -1).join('/')}/${URLS.APP_DETAILS}?refetchData=true`;
-                history.push(_url);
-            })
-            .catch((errors: ServerErrors) => {
-                showError(errors);
-                setUpdateInProgress(false);
-            });
-    };
+        try {
+            if (!installedAppInfo && !forceUpdate) {
+                const payload: LinkToChartStoreRequest = {
+                    appId: appId,
+                    valuesYaml: modifiedValuesYaml,
+                    appStoreApplicationVersionId: selectedVersionUpdatePage.id,
+                    referenceValueId: selectedVersionUpdatePage.id,
+                    referenceValueKind: chartValues.kind,
+                }
+                await linkToChartStore(payload)
+            } else {
+                const payload: UpdateApplicationRequest = {
+                    appId: appId,
+                    valuesYaml: modifiedValuesYaml,
+                }
+                await updateApplicationRelease(payload)
+            }
+
+            setUpdateInProgress(false)
+            toast.success('Update and deployment initiated.')
+            history.push(`${url.split('/').slice(0, -1).join('/')}/${URLS.APP_DETAILS}?refetchData=true`)
+        } catch (err) {
+            showError(err)
+            setUpdateInProgress(false)
+        }
+    }
 
     const OnEditorValueChange = (codeEditorData: string) => {
-        setModifiedValuesYaml(codeEditorData);
-    };
+        setModifiedValuesYaml(codeEditorData)
+    }
 
     const redirectToChartValues = async () => {
         if (repoChartValue?.chartId) {
-            history.push(getChartValuesURL(repoChartValue.chartId));
+            history.push(getChartValuesURL(repoChartValue.chartId))
         }
-    };
+    }
 
     function renderData() {
         return (
@@ -365,7 +363,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
                     <AppNotLinkedDialog close={() => setShowAppNotLinkedDialog(false)} update={updateApplication} />
                 )}
             </div>
-        );
+        )
     }
 
     return (
@@ -384,7 +382,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
 
             {!isLoading && !errorResponseCode && releaseInfo && renderData()}
         </>
-    );
+    )
 }
 
-export default ExternalAppValues;
+export default ExternalAppValues

--- a/src/components/v2/values/ea/EAValues.component.tsx
+++ b/src/components/v2/values/ea/EAValues.component.tsx
@@ -26,9 +26,10 @@ import {
     DeleteChartDialog,
     ChartValuesEditor,
     AppNotLinkedDialog,
+    StaticChartRepoInput,
 } from '../common/ChartValuesSelectors';
 import { ChartRepoOtions } from '../DeployChart';
-import { ChartVersionType } from '../../../charts/charts.types';
+import { ChartValuesType, ChartVersionType } from '../../../charts/charts.types';
 import { fetchChartVersionsData, getChartValuesList } from '../common/chartValues.api';
 import { getChartValuesURL } from '../../../charts/charts.helper';
 
@@ -49,10 +50,10 @@ function ExternalAppValues({ appId }: { appId: string }) {
     const [installedAppInfo, setInstalledAppInfo] = useState<InstalledAppInfo>(undefined);
     const [repoChartValue, setRepoChartValue] = useState<ChartRepoOtions>();
     const [chartVersionsData, setChartVersionsData] = useState<ChartVersionType[]>([]);
-    const [chartValuesList, setChartValuesList] = useState([]);
+    const [chartValuesList, setChartValuesList] = useState<ChartValuesType[]>([]);
     const [selectedVersion, selectVersion] = useState<any>();
     const [selectedVersionUpdatePage, setSelectedVersionUpdatePage] = useState<ChartVersionType>();
-    const [chartValues, setChartValues] = useState<any>({});
+    const [chartValues, setChartValues] = useState<ChartValuesType>();
     const deployChartRef = useRef<HTMLDivElement>(null);
 
     // component load
@@ -72,7 +73,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
                         deprecated: false,
                     });
 
-                    const _chartVersionData = {
+                    const _chartVersionData: ChartVersionType = {
                         id: 0,
                         version: _releaseInfo.deployedAppDetail.chartVersion,
                     };
@@ -80,7 +81,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
                     setSelectedVersionUpdatePage(_chartVersionData);
                     setChartVersionsData([_chartVersionData]);
 
-                    const _chartValues = {
+                    const _chartValues: ChartValuesType = {
                         id: 0,
                         kind: 'EXISTING',
                         name: _releaseInfo.deployedAppDetail.appName,
@@ -138,13 +139,16 @@ function ExternalAppValues({ appId }: { appId: string }) {
         );
         getChartValuesList(
             event.chartId,
-            (_chartValuesList) => {
+            (_chartValuesList: ChartValuesType[]) => {
                 if (!installedAppInfo) {
-                    _chartValuesList?.push({
+                    const _defaultChartValues: ChartValuesType = {
                         id: 0,
                         kind: 'EXISTING',
                         name: releaseInfo.deployedAppDetail.appName,
-                    });
+                    };
+
+                    _chartValuesList?.push(_defaultChartValues);
+                    setChartValues(_defaultChartValues);
                 }
 
                 setChartValuesList(_chartValuesList);
@@ -268,21 +272,23 @@ function ExternalAppValues({ appId }: { appId: string }) {
                                 installedAppInfo={installedAppInfo}
                                 releaseInfo={releaseInfo}
                             />
-                            <ChartRepoSelector
-                                isExternal={true}
-                                installedAppInfo={installedAppInfo}
-                                releaseInfo={releaseInfo}
-                                handleRepoChartValueChange={handleRepoChartValueChange}
-                                repoChartValue={repoChartValue}
-                                chartDetails={{
-                                    appStoreApplicationVersionId: 0,
-                                    chartRepoName: releaseInfo.deployedAppDetail.chartName,
-                                    chartId: 0,
-                                    chartName: releaseInfo.deployedAppDetail.chartName,
-                                    version: releaseInfo.deployedAppDetail.chartVersion,
-                                    deprecated: false,
-                                }}
-                            />
+                            {installedAppInfo && releaseInfo && <StaticChartRepoInput releaseInfo={releaseInfo} />}
+                            {!installedAppInfo && (
+                                <ChartRepoSelector
+                                    isExternal={true}
+                                    installedAppInfo={installedAppInfo}
+                                    handleRepoChartValueChange={handleRepoChartValueChange}
+                                    repoChartValue={repoChartValue}
+                                    chartDetails={{
+                                        appStoreApplicationVersionId: 0,
+                                        chartRepoName: releaseInfo.deployedAppDetail.chartName,
+                                        chartId: 0,
+                                        chartName: releaseInfo.deployedAppDetail.chartName,
+                                        version: releaseInfo.deployedAppDetail.chartVersion,
+                                        deprecated: false,
+                                    }}
+                                />
+                            )}
                             {!installedAppInfo && repoChartValue?.chartRepoName && (
                                 <ChartVersionValuesSelector
                                     isUpdate={true}

--- a/src/components/v2/values/ea/EAValues.component.tsx
+++ b/src/components/v2/values/ea/EAValues.component.tsx
@@ -272,7 +272,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
                                 installedAppInfo={installedAppInfo}
                                 releaseInfo={releaseInfo}
                             />
-                            {installedAppInfo && releaseInfo && <StaticChartRepoInput releaseInfo={releaseInfo} />}
+                            {installedAppInfo && <StaticChartRepoInput releaseInfo={releaseInfo} />}
                             {!installedAppInfo && (
                                 <ChartRepoSelector
                                     isExternal={true}

--- a/src/components/v2/values/ea/EAValues.component.tsx
+++ b/src/components/v2/values/ea/EAValues.component.tsx
@@ -25,6 +25,7 @@ import {
     ActiveReadmeColumn,
     DeleteChartDialog,
     ChartValuesEditor,
+    AppNotLinkedDialog,
 } from '../common/ChartValuesSelectors';
 import { ChartRepoOtions } from '../DeployChart';
 import { ChartVersionType } from '../../../charts/charts.types';
@@ -41,6 +42,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
     const [readmeCollapsed, toggleReadmeCollapsed] = useState(true);
     const [releaseInfo, setReleaseInfo] = useState<ReleaseInfo>(undefined);
     const [showDeleteAppConfirmationDialog, setShowDeleteAppConfirmationDialog] = useState(false);
+    const [showAppNotLinkedDialog, setShowAppNotLinkedDialog] = useState(false);
     const [modifiedValuesYaml, setModifiedValuesYaml] = useState('');
     const [installedAppInfo, setInstalledAppInfo] = useState<InstalledAppInfo>(undefined);
     const [repoChartValue, setRepoChartValue] = useState<ChartRepoOtions>();
@@ -148,8 +150,13 @@ function ExternalAppValues({ appId }: { appId: string }) {
         }
     };
 
-    const updateApplication = () => {
+    const updateApplication = (forceUpdate?: boolean) => {
         if (isUpdateInProgress) {
+            return;
+        }
+
+        if (!forceUpdate && !repoChartValue?.chartRepoName) {
+            setShowAppNotLinkedDialog(true);
             return;
         }
 
@@ -287,7 +294,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
                         className={`cta flex-1 ml-16 mr-16 ${
                             isUpdateInProgress || isDeleteInProgress ? 'disabled' : ''
                         }`}
-                        onClick={updateApplication}
+                        onClick={() => updateApplication(false)}
                     >
                         {isUpdateInProgress ? (
                             <div className="flex">
@@ -307,6 +314,9 @@ function ExternalAppValues({ appId }: { appId: string }) {
                         handleDelete={deleteApplication}
                         toggleConfirmation={setShowDeleteAppConfirmationDialog}
                     />
+                )}
+                {showAppNotLinkedDialog && (
+                    <AppNotLinkedDialog close={() => setShowAppNotLinkedDialog(false)} update={updateApplication} />
                 )}
             </div>
         );

--- a/src/components/v2/values/ea/EAValues.component.tsx
+++ b/src/components/v2/values/ea/EAValues.component.tsx
@@ -37,6 +37,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
     const { url } = useRouteMatch();
 
     const [isLoading, setIsLoading] = useState(true);
+    const [fetchingValuesYaml, setFetchingValuesYaml] = useState(false);
     const [isUpdateInProgress, setUpdateInProgress] = useState(false);
     const [isDeleteInProgress, setDeleteInProgress] = useState(false);
     const [errorResponseCode, setErrorResponseCode] = useState(undefined);
@@ -101,6 +102,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
 
     useEffect(() => {
         if (releaseInfo && chartValues) {
+            setFetchingValuesYaml(true);
             if (
                 chartValues.id &&
                 chartValues.chartVersion &&
@@ -109,12 +111,15 @@ function ExternalAppValues({ appId }: { appId: string }) {
                 getChartValues(chartValues.id, chartValues.kind)
                     .then((response) => {
                         setModifiedValuesYaml(response.result.values || '');
+                        setFetchingValuesYaml(false);
                     })
                     .catch((error) => {
                         showError(error);
+                        setFetchingValuesYaml(false);
                     });
             } else if (releaseInfo.mergedValues && releaseInfo.deployedAppDetail.appName === chartValues.name) {
                 setModifiedValuesYaml(YAML.stringify(JSON.parse(releaseInfo?.mergedValues)));
+                setFetchingValuesYaml(false);
             }
         }
     }, [chartValues]);
@@ -294,6 +299,7 @@ function ExternalAppValues({ appId }: { appId: string }) {
                                 />
                             )}
                             <ChartValuesEditor
+                                loading={fetchingValuesYaml}
                                 valuesText={modifiedValuesYaml}
                                 onChange={OnEditorValueChange}
                                 repoChartValue={repoChartValue}

--- a/src/components/v2/values/ea/EAValues.component.tsx
+++ b/src/components/v2/values/ea/EAValues.component.tsx
@@ -100,25 +100,22 @@ function ExternalAppValues({ appId }: { appId: string }) {
     }, []);
 
     useEffect(() => {
-        if (
-            chartValues &&
-            chartValues.id &&
-            chartValues.chartVersion &&
-            chartValues.name !== releaseInfo?.deployedAppDetail.appName
-        ) {
-            getChartValues(chartValues.id, chartValues.kind)
-                .then((response) => {
-                    setModifiedValuesYaml(response.result.values || '');
-                })
-                .catch((error) => {
-                    showError(error);
-                });
-        } else if (
-            releaseInfo &&
-            releaseInfo.mergedValues &&
-            releaseInfo.deployedAppDetail.appName === chartValues?.name
-        ) {
-            setModifiedValuesYaml(YAML.stringify(JSON.parse(releaseInfo?.mergedValues)));
+        if (releaseInfo && chartValues) {
+            if (
+                chartValues.id &&
+                chartValues.chartVersion &&
+                chartValues.name !== releaseInfo.deployedAppDetail.appName
+            ) {
+                getChartValues(chartValues.id, chartValues.kind)
+                    .then((response) => {
+                        setModifiedValuesYaml(response.result.values || '');
+                    })
+                    .catch((error) => {
+                        showError(error);
+                    });
+            } else if (releaseInfo.mergedValues && releaseInfo.deployedAppDetail.appName === chartValues.name) {
+                setModifiedValuesYaml(YAML.stringify(JSON.parse(releaseInfo?.mergedValues)));
+            }
         }
     }, [chartValues]);
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -126,6 +126,7 @@ export const Routes = {
     CREATE_RESOURCE: 'k8s/resource/create',
     HELM_RELEASE_APP_DELETE_API: 'application/delete',
     HELM_RELEASE_APP_UPDATE_API: 'application/update',
+    HELM_LINK_TO_CHART_STORE_API: 'app-store/deployment/application/helm/link-to-chart-store',
     NAMESPACE: 'env/namespace',
 };
 

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -1696,6 +1696,10 @@ button.anchor {
     background-color: #fff;
 }
 
+.light-gray-background {
+    background-color: var(--N100);
+}
+
 .registry-icon,
 .repository-icon {
     width: 20px;


### PR DESCRIPTION
# Description

Currently, when a chart is an external chart deployed through helm install, it's giving an error on updating.

E.g. Chart name: bitnami/apache
<img width="1361" alt="EA_Updation_error" src="https://user-images.githubusercontent.com/96225587/159204448-e75ced6b-430f-4557-bffc-6af1f85ad9b8.png">

To address this one of the proposed solutions is to put a check on UI whether is external or internal. If it is external then ask for linking (repo/version/chart/values) etc.. and save it in DB using updated/new APIs covered under - [#1270](https://github.com/devtron-labs/devtron/issues/1270).

It also contains a fix for the README bug. For the selected chart; currently, it shows Readme for the chart used for deployment, not the one selected. And updated the toast message on successfully adding the chart repo.

Fixes # https://github.com/devtron-labs/devtron/issues/1339

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been performed manually. Ref - [Test Cases - #1339](https://docs.google.com/document/d/1-zINRI27azY7XpyITEAxXNZMWg9AASRZeSk11dXuq8Q/edit?usp=sharing)

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


