### PR TITLE
FIX: Crlf to lf replace in pre/post script

### DIFF
--- a/src/components/ciPipeline/CIPipeline.tsx
+++ b/src/components/ciPipeline/CIPipeline.tsx
@@ -293,7 +293,7 @@ export default class CIPipeline extends Component<CIPipelineProps, CIPipelineSta
     checkUniqueness(): boolean {
         let list = this.state.form.beforeDockerBuildScripts.concat(this.state.form.afterDockerBuildScripts);
         let stageNameList = list.map((l) => {
-            l.script.replace(/\r\n/g, '\n');
+            l.script = l.script.replace(/\r\n/g, '\n');
             return l.name;
         })
         let set = new Set();

--- a/src/components/ciPipeline/CIPipeline.tsx
+++ b/src/components/ciPipeline/CIPipeline.tsx
@@ -293,6 +293,7 @@ export default class CIPipeline extends Component<CIPipelineProps, CIPipelineSta
     checkUniqueness(): boolean {
         let list = this.state.form.beforeDockerBuildScripts.concat(this.state.form.afterDockerBuildScripts);
         let stageNameList = list.map((l) => {
+            l.script.replace(/\r\n/g, '\n');
             return l.name;
         })
         let set = new Set();


### PR DESCRIPTION
# Description
Line break issue in monaco editor in windows system.

Fixes # (issue)
Replaced '\n\r' to '\n' at the time of saving the config

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


