### PR TITLE
Enhancement: Deployment History - Rollback helm apps feature

### DIFF
--- a/src/components/external-apps/ExternalAppService.ts
+++ b/src/components/external-apps/ExternalAppService.ts
@@ -118,6 +118,17 @@ export interface LinkToChartStoreRequest {
     referenceValueKind: string;
 }
 
+export interface RollbackReleaseRequest {
+    hAppId: string
+    version: number
+    installedAppId?: number
+    installedAppVersionId?: number
+}
+
+interface RollbackReleaseResponse extends ResponseType {
+    result?: ActionResponse
+}
+
 export const getReleaseInfo = (appId: string): Promise<ReleaseInfoResponse> => {
     let url = `${Routes.HELM_RELEASE_INFO_API}?appId=${appId}`
     return get(url);
@@ -152,3 +163,11 @@ export const updateApplicationRelease = (requestPayload: UpdateApplicationReques
 export const linkToChartStore = (request: LinkToChartStoreRequest): Promise<UpdateReleaseResponse> => {
     return put(Routes.HELM_LINK_TO_CHART_STORE_API, request);
 };
+
+export const rollbackApplicationDeployment = (
+    request: RollbackReleaseRequest,
+    isExternal: boolean,
+): Promise<RollbackReleaseResponse> => {
+    const url = isExternal ? Routes.HELM_EA_DEPLOYMENT_ROLLBACK_API : Routes.HELM_DEPLOYMENT_ROLLBACK_API
+    return put(url, request)
+}

--- a/src/components/external-apps/ExternalApps.tsx
+++ b/src/components/external-apps/ExternalApps.tsx
@@ -19,7 +19,7 @@ export default function ExternalApps() {
                 <Switch>
                     <Route path={`${path}/${URLS.APP_DETAILS}`} render={() => <ExternalAppDetail appId={params.appId} appName={params.appName} />} />
                     <Route path={`${path}/${URLS.APP_VALUES}`} render={() => <ExternalAppValues appId={params.appId} />} />
-                    <Route path={`${path}/${URLS.APP_DEPLOYMNENT_HISTORY}`} render={() => <ExternalAppDeploymentHistory appId={params.appId} />} />
+                    <Route path={`${path}/${URLS.APP_DEPLOYMNENT_HISTORY}`} render={() => <ExternalAppDeploymentHistory appId={params.appId} appName={params.appName} />} />
                     <Redirect to={`${path}/${URLS.APP_DETAILS}`} />
                 </Switch>
             </Suspense>

--- a/src/components/v2/deployment-history/ea/EADeploymentHistory.component.tsx
+++ b/src/components/v2/deployment-history/ea/EADeploymentHistory.component.tsx
@@ -1,15 +1,19 @@
 import React, { useState, useEffect } from 'react';
-import { showError, Progressing, ErrorScreenManager } from '../../../common';
+import { showError, Progressing, ErrorScreenManager, ConfirmationDialog } from '../../../common';
 import docker from '../../../../assets/icons/misc/docker.svg';
+import { ReactComponent as DeployButton } from '../../../../assets/icons/ic-deploy.svg';
 import {
     getDeploymentHistory,
     HelmAppDeploymentHistoryResponse,
     HelmAppDeploymentDetail,
     getDeploymentManifestDetails,
     HelmAppDeploymentManifestDetail,
+    rollbackApplicationDeployment,
+    RollbackReleaseRequest,
+    InstalledAppInfo,
 } from '../../../external-apps/ExternalAppService';
 import { ServerErrors } from '../../../../modals/commonTypes';
-import { Moment12HourFormat } from '../../../../config';
+import { Moment12HourFormat, URLS } from '../../../../config';
 import CodeEditor from '../../../CodeEditor/CodeEditor';
 import moment from 'moment';
 import Tippy from '@tippyjs/react';
@@ -17,6 +21,8 @@ import '../../../app/details/cIDetails/ciDetails.scss';
 import YAML from 'yaml';
 import './ea-deployment-history.scss';
 import MessageUI from '../../common/message.ui';
+import { toast } from 'react-toastify';
+import { useHistory, useRouteMatch } from 'react-router';
 
 interface DeploymentManifestDetail extends HelmAppDeploymentManifestDetail {
     loading?: boolean;
@@ -24,13 +30,17 @@ interface DeploymentManifestDetail extends HelmAppDeploymentManifestDetail {
     isApiCallInProgress?: boolean;
 }
 
-function ExternalAppDeploymentHistory({ appId }: { appId: string }) {
+function ExternalAppDeploymentHistory({ appId, appName }: { appId: string; appName: string }) {
     const [isLoading, setIsLoading] = useState(true);
     const [errorResponseCode, setErrorResponseCode] = useState(undefined);
     const [deploymentHistoryArr, setDeploymentHistoryArr] = useState<HelmAppDeploymentDetail[]>([]);
+    const [installedAppInfo, setInstalledAppInfo] = useState<InstalledAppInfo>();
     const [selectedDeploymentHistoryIndex, setSelectedDeploymentHistoryIndex] = useState<number>(0);
     const [selectedDeploymentTabIndex, setSelectedDeploymentTabIndex] = useState<number>(0);
     const [deploymentManifestDetails, setDeploymentManifestDetails] = useState<Map<number, DeploymentManifestDetail>>();
+    const [showRollbackConfirmation, setShowRollbackConfirmation] = useState(false);
+    const history = useHistory()
+    const { url } = useRouteMatch()
 
     const deploymentTabs: string[] = ['Source', 'values.yaml', 'Helm generated manifest'];
 
@@ -43,6 +53,7 @@ function ExternalAppDeploymentHistory({ appId }: { appId: string }) {
                         (a, b) => b.deployedAt.seconds - a.deployedAt.seconds,
                     ) || [];
                 setDeploymentHistoryArr(_deploymentHistoryArr);
+                setInstalledAppInfo(deploymentHistoryResponse.result?.installedAppInfo);
 
                 // init deployment manifest details map
                 let _deploymentManifestDetails = new Map<number, DeploymentManifestDetail>();
@@ -298,18 +309,21 @@ function ExternalAppDeploymentHistory({ appId }: { appId: string }) {
         );
     }
 
-    function renderSelectedDeploymentDetailHeader(){
-        let deployment = deploymentHistoryArr[selectedDeploymentHistoryIndex];
-        return <div className="trigger-details ml-20 pb-20">
-            <div className="trigger-details__summary">
-                <div className="flex column left pt-10">
-                    <div className="cn-9 fs-14 fw-6">Deployed at</div>
-                    <div className="flex left">
-                        <time className="cn-7 fs-12">
-                            {moment(new Date(deployment.deployedAt.seconds * 1000), 'YYYY-MM-DDTHH:mm:ssZ').format(Moment12HourFormat)}
-                        </time>
-                        {
-                            deployment.dockerImages.map((dockerImage, index) => {
+    function renderSelectedDeploymentDetailHeader() {
+        const deployment = deploymentHistoryArr[selectedDeploymentHistoryIndex]
+
+        return (
+            <div className="trigger-details ml-20 mr-20 pb-20">
+                <div className="flex content-space trigger-details__summary">
+                    <div className="flex column left pt-10">
+                        <div className="cn-9 fs-14 fw-6">Deployed at</div>
+                        <div className="flex left">
+                            <time className="cn-7 fs-12">
+                                {moment(new Date(deployment.deployedAt.seconds * 1000), 'YYYY-MM-DDTHH:mm:ssZ').format(
+                                    Moment12HourFormat,
+                                )}
+                            </time>
+                            {deployment.dockerImages.map((dockerImage, index) => {
                                 return (
                                     <div key={index} className="app-commit__hash ml-10">
                                         <Tippy arrow={true} className="default-tt" content={dockerImage}>
@@ -320,27 +334,84 @@ function ExternalAppDeploymentHistory({ appId }: { appId: string }) {
                                         </Tippy>
                                     </div>
                                 )
-                            })
-                        }
+                            })}
+                        </div>
                     </div>
+                    {selectedDeploymentHistoryIndex !== 0 && (
+                        <Tippy className="default-tt" arrow={false} content={'Re-deploy this version'}>
+                            <button
+                                className="flex cta deploy-button"
+                                onClick={() => setShowRollbackConfirmation(true)}
+                            >
+                                <DeployButton className="deploy-button-icon" />
+                                <span className="ml-4">Deploy</span>
+                            </button>
+                        </Tippy>
+                    )}
                 </div>
             </div>
-        </div>
+        )
     }
 
+    async function handleDeployClick() {
+        try {
+            const selectedDeploymentHistory = deploymentHistoryArr[selectedDeploymentHistoryIndex]
+            const requestPayload: RollbackReleaseRequest = {
+                hAppId: appId,
+                version: selectedDeploymentHistory.version,
+            }
+
+            if (installedAppInfo) {
+                requestPayload.installedAppId = installedAppInfo.installedAppId
+                requestPayload.installedAppVersionId = installedAppInfo.installedAppVersionId
+            }
+
+            await rollbackApplicationDeployment(requestPayload, !installedAppInfo)
+            setShowRollbackConfirmation(false)
+            toast.success('Deployment initiated')
+            history.push(`${url.split('/').slice(0, -1).join('/')}/${URLS.APP_DETAILS}?refetchData=true`)
+        } catch (err) {
+            setShowRollbackConfirmation(false)
+            showError(err)
+        }
+    }
+
+    function RollbackConfirmationDialog() {
+        return (
+            <ConfirmationDialog className="rollback-confirmation-dialog">
+                <ConfirmationDialog.Body title={`Rollback "${appName}"`}>
+                    <p className="fs-13 cn-7 lh-1-54">Are you sure you want to deploy a previous version?</p>
+                </ConfirmationDialog.Body>
+                <ConfirmationDialog.ButtonGroup>
+                    <div className="flex right">
+                        <button
+                            type="button"
+                            className="flex cta cancel"
+                            onClick={() => setShowRollbackConfirmation(false)}
+                        >
+                            Cancel
+                        </button>
+                        <button className="flex cta deploy-button" onClick={handleDeployClick}>
+                            <DeployButton className="deploy-button-icon" />
+                            <span className="ml-8">Deploy</span>
+                        </button>
+                    </div>
+                </ConfirmationDialog.ButtonGroup>
+            </ConfirmationDialog>
+        )
+    }
 
     function renderData() {
         return (
             <div className="ci-details">
                 <div className="ci-details__history deployment-cards">
                     <span className="pl-16 pr-16 text-uppercase">Deployments</span>
-                    <div className="flex column top left" style={{overflowY:'auto'}}>
+                    <div className="flex column top left" style={{ overflowY: 'auto' }}>
                         {renderDeploymentCards()}
                     </div>
                 </div>
-                <div className="ci-details__body">
-                    {renderSelectedDeploymentDetail()}
-                </div>
+                <div className="ci-details__body">{renderSelectedDeploymentDetail()}</div>
+                {showRollbackConfirmation && <RollbackConfirmationDialog />}
             </div>
         )
     }

--- a/src/components/v2/deployment-history/ea/ea-deployment-history.scss
+++ b/src/components/v2/deployment-history/ea/ea-deployment-history.scss
@@ -23,3 +23,47 @@
 .error-exclamation-icon path {
     fill: #767D84;
 }
+
+.ci-details {
+    .deploy-button {
+        width: 85px;
+        height: 32px;
+        border-radius: 4px;
+        padding: 0;
+
+        .deploy-button-icon {
+            width: 16px;
+            height: 16px;
+        }
+    }
+}
+
+.confirmation-dialog__body.rollback-confirmation-dialog {
+    width: 360px;
+    height: 210px;
+
+    .confirmation-dialog__title {
+        color: var(--N900);
+    }
+
+    .confirmation-dialog__title + p {
+        font-size: 14px;
+        line-height: 1.5;
+    }
+
+    .cta.cancel {
+        height: 36px;
+    }
+
+    .cta.deploy-button {
+        width: 96px;
+        height: 36px;
+        border-radius: 4px;
+        padding: 0;
+
+        .deploy-button-icon {
+            width: 20px;
+            height: 20px;
+        }
+    }
+}

--- a/src/components/v2/values/common/ChartValuesSelectors.tsx
+++ b/src/components/v2/values/common/ChartValuesSelectors.tsx
@@ -456,13 +456,20 @@ export const ChartValuesEditor = ({
     useEffect(() => {
         // scroll to the editor view with animation for only update-chart
         // subtracting - 100 from offset top because of floating header's tab
-        if (autoFocus && parentRef?.current && editorRef?.current) {
-            setTimeout(() => {
-                parentRef.current.scrollTo({
-                    top: editorRef.current.offsetTop - 100,
+        let timer;
+        if (autoFocus && parentRef && editorRef) {
+            timer = setTimeout(() => {
+                parentRef.current?.scrollTo({
+                    top: editorRef.current?.offsetTop - 100,
                     behavior: 'smooth',
                 });
             }, 1000);
+        }
+
+        return (): void => {
+            if (timer) {
+                clearTimeout(timer);
+            }
         }
     }, []);
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -127,6 +127,8 @@ export const Routes = {
     HELM_RELEASE_APP_DELETE_API: 'application/delete',
     HELM_RELEASE_APP_UPDATE_API: 'application/update',
     HELM_LINK_TO_CHART_STORE_API: 'app-store/deployment/application/helm/link-to-chart-store',
+    HELM_DEPLOYMENT_ROLLBACK_API: 'app-store/deployment/application/rollback',
+    HELM_EA_DEPLOYMENT_ROLLBACK_API: 'application/rollback',
     NAMESPACE: 'env/namespace',
 };
 


### PR DESCRIPTION
# Description

Added the feature to roll back deployed helm apps to previous deployments. Currently, to roll back to a previous deployment, the user has to copy-paste YAML from the deployment history section. Using this new feature, the user should be able to do this in a few clicks rather than having to copy-paste.

![image.png](https://images.zenhubusercontent.com/6006777d4d3453ae8b648c3d/ea18e9b5-f0f9-41f8-818b-ded48b20a1e1)

Fixes # https://github.com/devtron-labs/devtron/issues/1388

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been performed manually. Ref - [Test Cases - #1388](https://docs.google.com/document/d/1olPYfNnHj_alVlJ0DUPgHoMVQeovNrBNhVM4tP7Gi6U/edit?usp=sharing)


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


