### PR TITLE
Tippy & Group label for log analyzer

### DIFF
--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
@@ -263,7 +263,7 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
     let podContainerOptions = getPodContainerOptions(isLogAnalyzer, params, location, logState);
 
     const getPodGroups = () => {
-        let allGroupPods = [], individualPods = []
+        const allGroupPods = [], individualPods = []
 
         const podCreate = (podGroupName, _pod: Options) => {
             podGroupName.push({
@@ -356,7 +356,6 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
                                                     fontWeight: 600,
                                                     fontSize: '10px',
                                                     color: 'var(--n-700)',
-                                                    direction: 'rtl',
                                                     marginLeft: 0,
                                                 }),
                                                 singleValue: (base, state) => ({
@@ -601,7 +600,7 @@ export function getSelectedPodList(selectedOption: string): PodMetaData[] {
                 handleDefaultForSelectedOption(selectedOption.replace('All new ', ''));
             } else if (selectedOption.startsWith('All old ')) {
                 handleDefaultForSelectedOption(selectedOption.replace('All old ', ''));
-            } else if (selectedOption.startsWith('All')) {
+            } else if (selectedOption.startsWith('All ')) {
                 handleDefaultForSelectedOption(selectedOption.replace('All ', ''));
             } else {
                 pods = IndexStore.getAllPods().filter((_pod) => _pod.name == selectedOption);

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
@@ -262,6 +262,31 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
 
     let podContainerOptions = getPodContainerOptions(isLogAnalyzer, params, location, logState);
 
+    const getPodGroups = () => {
+        let allGroupPods = [], individualPods = []
+
+        const podCreate = (podGroupName, _pod) => {
+            podGroupName.push({
+                label: _pod.name,
+                value: _pod.name,
+            })
+        }
+
+        podContainerOptions.podOptions.map((pod) => {
+            pod.name.startsWith('All ') ? podCreate(allGroupPods, pod) : podCreate(individualPods, pod)
+        })
+        return [
+            {
+                label: 'ALL PODS FOR',
+                options: allGroupPods,
+            },
+            {
+                label: 'INDIVIDUAL PODS',
+                options: individualPods,
+            },
+        ]
+    }
+ 
     return isDeleted ? (
         <div>
             <MessageUI msg="This resource no longer exists" size={32} />
@@ -305,14 +330,11 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
                         {isLogAnalyzer && podContainerOptions.podOptions.length > 0 && (
                             <React.Fragment>
                                 <div className="cn-6 ml-8 mr-10 ">Pods</div>
-                                <div className="cn-6 flex left">
+                                <div className="cn-6 flex left"> 
                                     <div style={{ minWidth: '200px' }}>
                                         <Select
                                             placeholder="Select Pod"
-                                            options={podContainerOptions.podOptions.map((_pod) => ({
-                                                label: _pod.name,
-                                                value: _pod.name,
-                                            }))}
+                                            options={getPodGroups()}
                                             defaultValue={getFirstOrNull(
                                                 podContainerOptions.podOptions
                                                     .filter((_pod) => _pod.selected)
@@ -329,12 +351,20 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
                                                     minHeight: '24px !important',
                                                     cursor: 'pointer',
                                                 }),
+                                                groupHeading: (base) => ({
+                                                    ...base,
+                                                    fontWeight: 600,
+                                                    fontSize: '10px',
+                                                    color: 'var(--n-700)',
+                                                    direction: 'rtl',
+                                                    marginLeft: 0,
+                                                }),
                                                 singleValue: (base, state) => ({
                                                     ...base,
                                                     fontWeight: 600,
                                                     color: '#06c',
                                                     direction: 'rtl',
-                                                    marginLeft: 0,
+                                                    marginLeft: "2px",
                                                 }),
                                                 indicatorsContainer: (provided, state) => ({
                                                     ...provided,
@@ -352,7 +382,7 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
                                             }}
                                             components={{
                                                 IndicatorSeparator: null,
-                                                Option,
+                                                Option: (props)=> <Option {...props} showTippy={true} />,
                                             }}
                                         />
                                     </div>
@@ -397,7 +427,7 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
                                                 fontWeight: 600,
                                                 color: '#06c',
                                                 direction: 'rtl',
-                                                marginLeft: 0,
+                                                marginLeft: "2px",
                                             }),
                                             indicatorsContainer: (provided, state) => ({
                                                 ...provided,
@@ -415,7 +445,7 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
                                         }}
                                         components={{
                                             IndicatorSeparator: null,
-                                            Option,
+                                            Option: (props)=> <Option {...props} showTippy={true} />,
                                         }}
                                     />
                                 </div>

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
@@ -265,7 +265,7 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
     const getPodGroups = () => {
         let allGroupPods = [], individualPods = []
 
-        const podCreate = (podGroupName, _pod) => {
+        const podCreate = (podGroupName, _pod: Options) => {
             podGroupName.push({
                 label: _pod.name,
                 value: _pod.name,
@@ -331,7 +331,7 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
                             <React.Fragment>
                                 <div className="cn-6 ml-8 mr-10 ">Pods</div>
                                 <div className="cn-6 flex left"> 
-                                    <div style={{ minWidth: '200px' }}>
+                                    <div style={{ width: '200px' }}>
                                         <Select
                                             placeholder="Select Pod"
                                             options={getPodGroups()}
@@ -364,7 +364,8 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
                                                     fontWeight: 600,
                                                     color: '#06c',
                                                     direction: 'rtl',
-                                                    marginLeft: "2px",
+                                                    textAlign: 'left',
+                                                    marginLeft: '2px',
                                                 }),
                                                 indicatorsContainer: (provided, state) => ({
                                                     ...provided,
@@ -394,7 +395,7 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
                             <React.Fragment>
                                 <div className="cn-6 ml-8 mr-10">Container </div>
 
-                                <div style={{ minWidth: '150px' }}>
+                                <div style={{ width: '150px' }}>
                                     <Select
                                         placeholder="Select Containers"
                                         options={podContainerOptions.containerOptions.map((_container) => ({
@@ -427,7 +428,8 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
                                                 fontWeight: 600,
                                                 color: '#06c',
                                                 direction: 'rtl',
-                                                marginLeft: "2px",
+                                                textAlign: 'left',
+                                                marginLeft: '2px',
                                             }),
                                             indicatorsContainer: (provided, state) => ({
                                                 ...provided,

--- a/src/components/v2/common/ReactSelect.utils.tsx
+++ b/src/components/v2/common/ReactSelect.utils.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ReactComponent as ArrowDown } from '../assets/icons/ic-chevron-down.svg';
 import { ReactComponent as Check } from '../assets/icons/ic-check.svg';
 import { components } from 'react-select';
+import Tippy from '@tippyjs/react';
 
 export const styles = {
     control: (base, state) => ({
@@ -32,14 +33,28 @@ export const styles = {
 }
 
 export function Option(props) {
-    const { selectOption, data } = props;
+    const { selectOption, data, showTippy } = props
     const style = { height: '16px', width: '16px', flex: '0 0 16px' }
-    const onClick = (e) => selectOption(data);
-    return <div className="flex left pl-12" style={{ background: props.isFocused ? 'var(--N100)' : 'transparent' }}>
-        {props.isSelected ? <Check onClick={onClick} className="mr-8 icon-dim-16" style={style} />
-            : <span onClick={onClick} className="mr-8" style={style} />}
-        <components.Option {...props} />
-    </div>
+    const onClick = (e) => selectOption(data)
+    
+    const getOption = () => {
+        return <div className="flex left pl-12" style={{ background: props.isFocused ? 'var(--N100)' : 'transparent' }}>
+                {props.isSelected ? (
+                    <Check onClick={onClick} className="mr-8 icon-dim-16" style={style} />
+                ) : (
+                    <span onClick={onClick} className="mr-8" style={style} />
+                )}
+                <components.Option {...props} />
+            </div>
+    }
+
+    return showTippy ? (
+        <Tippy className="default-white ml-10" arrow={false} placement="right" content={data.label}>
+            {getOption()}
+        </Tippy>
+    ) : (
+        <>{getOption()}</>
+    )
 };
 
 export function DropdownIndicator(props) {

--- a/src/components/v2/common/ReactSelect.utils.tsx
+++ b/src/components/v2/common/ReactSelect.utils.tsx
@@ -52,9 +52,7 @@ export function Option(props) {
         <Tippy className="default-white ml-10" arrow={false} placement="right" content={data.label}>
             {getOption()}
         </Tippy>
-    ) : (
-        <>{getOption()}</>
-    )
+    ) : getOption()
 };
 
 export function DropdownIndicator(props) {

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -1148,6 +1148,14 @@ button.anchor {
     background-color: var(--N900);
 }
 
+.tippy-box.default-white {
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--N900);
+    border: 1px solid var(--N100);
+    background-color: var(--N000);
+}
+
 .devtron-breadcrumb {
     font-size: 12px;
     line-height: 1.34;


### PR DESCRIPTION
# Description

Add grouping labels to differentiate between all pods for group & individual pods. Also, show tippy on hover containing the full name of the pod or pod group.

Fixes - https://github.com/devtron-labs/devtron/issues/1439

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
All tests have been performed manually.

- [x] By hovering on dropdown of select element.
- [x] By checking group divided into actual group pods & individual pods


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


