### PR TITLE
Fix: Grep is not working with double quotes issue fix

### DIFF
--- a/src/components/app/grepSSEworker.ts
+++ b/src/components/app/grepSSEworker.ts
@@ -26,7 +26,7 @@ export default () => {
             let bufferedLogs: Array<string> = []
 
             // Regex to match ANSI color code/escape sequence
-            const ANSI_COLOR_ESCAPE_SEQUENCE_REGEX = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g
+            const ANSI_COLOR_ESCAPE_SEQUENCE_REGEX = /\u001b\[.*?m/g
             if (!log || log.length == 0) {
                 console.log("no log lines")
             } else {

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
@@ -119,7 +119,7 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
 
     const getGrepTokens = (expression) => {
         const options = commandLineParser({
-            args: expression.replace(/[\s]+/, ' ').replace('"', '').split(' '),
+            args: expression.replace(/[\s]+/, ' ').replace(/"/g, '').split(' '),
             booleanKeys: ['v'],
             allowEmbeddedValues: true,
         });

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
@@ -119,7 +119,7 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
 
     const getGrepTokens = (expression) => {
         const options = commandLineParser({
-            args: expression.replace(/[\s]+/, ' ').replace(/"/g, '').split(' '),
+            args: expression.replace(/"/g, '').split(' '),
             booleanKeys: ['v'],
             allowEmbeddedValues: true,
         });
@@ -129,7 +129,7 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
             B = C || c;
         }
 
-        return _args ? { _args: _args[0], a: Number(A || a), b: Number(B || b), v } : null;
+        return _args ? { _args: _args.join(' '), a: Number(A || a), b: Number(B || b), v } : null;
     };
 
     const handleMessage = (event: any) => {


### PR DESCRIPTION
# Description

Currently, when trying to use grep in logs search with terms containing double quotes ("") or spaces, it's not working as expected. These changes will fix the issues.

Fixes # https://github.com/devtron-labs/devtron/issues/1389

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been performed manually.

1. Go to Applications > Select Helm apps tab
2. Select any app > it'll redirect to the App Details page
3. Select the Log Analyzer tab or open the logs tab for any specific pod.
4. Search logs with & without terms containing double quotes or containing spaces (/multiple words). **E.g.** grep Error, grep "Error" or grep "Service Error"
5. Observe

**Expected**: It should search & show logs for the searched terms containing double quotes or spaces.


# Checklist:

* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


