### PR TITLE
Enhancement - added margin based on scroller

### DIFF
--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
@@ -382,7 +382,7 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
                                             }}
                                             components={{
                                                 IndicatorSeparator: null,
-                                                Option: (props)=> <Option {...props} showTippy={true} />,
+                                                Option: (props)=> <Option {...props} showTippy={true} isScrollable={podContainerOptions.podOptions.length > 6} />,
                                             }}
                                         />
                                     </div>

--- a/src/components/v2/common/ReactSelect.utils.tsx
+++ b/src/components/v2/common/ReactSelect.utils.tsx
@@ -33,7 +33,7 @@ export const styles = {
 }
 
 export function Option(props) {
-    const { selectOption, data, showTippy } = props
+    const { selectOption, data, showTippy, isScrollable } = props
     const style = { height: '16px', width: '16px', flex: '0 0 16px' }
     const onClick = (e) => selectOption(data)
     
@@ -49,7 +49,7 @@ export function Option(props) {
     }
 
     return showTippy ? (
-        <Tippy className="default-white ml-10" arrow={false} placement="right" content={data.label}>
+        <Tippy className={`default-white ${isScrollable ? 'ml-12' : ''}`} arrow={false} placement="right" content={data.label}>
             {getOption()}
         </Tippy>
     ) : getOption()


### PR DESCRIPTION
# Description

Added margin tippy on hover containing the full name of the pod or pod group based on scroller.

Fixes - https://github.com/devtron-labs/devtron/issues/1439

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
All tests have been performed manually.

- [x] By hovering on dropdown of select element.

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
