### PR TITLE
Fix: Removed margin to fix tippy extra space issue

### DIFF
--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
@@ -382,7 +382,7 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
                                             }}
                                             components={{
                                                 IndicatorSeparator: null,
-                                                Option: (props)=> <Option {...props} showTippy={true} isScrollable={podContainerOptions.podOptions.length > 6} />,
+                                                Option: (props)=> <Option {...props} showTippy={true} />,
                                             }}
                                         />
                                     </div>

--- a/src/components/v2/common/ReactSelect.utils.tsx
+++ b/src/components/v2/common/ReactSelect.utils.tsx
@@ -33,7 +33,7 @@ export const styles = {
 }
 
 export function Option(props) {
-    const { selectOption, data, showTippy, isScrollable } = props
+    const { selectOption, data, showTippy } = props
     const style = { height: '16px', width: '16px', flex: '0 0 16px' }
     const onClick = (e) => selectOption(data)
     
@@ -49,7 +49,7 @@ export function Option(props) {
     }
 
     return showTippy ? (
-        <Tippy className={`default-white ${isScrollable ? 'ml-12' : ''}`} arrow={false} placement="right" content={data.label}>
+        <Tippy className="default-white" arrow={false} placement="right" content={data.label}>
             {getOption()}
         </Tippy>
     ) : getOption()


### PR DESCRIPTION
# Description

Pod grouping labels & tippy was added as part of https://github.com/devtron-labs/devtron/issues/1439. However, there's some extra spacing between dropdown & tippy. These changes will fix this issue.

![Screenshot 2022-04-01 at 9.35.27 PM.png](https://images.zenhubusercontent.com/61e15405a1d0b1e0e115f611/5d0dc191-f733-446c-94f2-9292b0bef4d8)

Fixes # https://github.com/devtron-labs/devtron/issues/1463

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
All tests have been performed manually. The following are the steps, 

1. Go to Applications > Select Helm apps tab
2. Select any app > it'll redirect to the App Details page (Make sure the app has more than 6 pods)
3. Select the Log Analyzer tab
4. Click on Pods dropdown
5. Hover on any item
6. Observe

### Expected behavior

It should have less margin/spacing between dropdown & tippy similar to Pods dropdown having less than 6 pods.

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


