### PR TITLE
Enhancement: Deployment History - Integrated merged APIs for history & rollback

### DIFF
--- a/src/components/v2/chartDeploymentHistory/ChartDeploymentHistory.component.tsx
+++ b/src/components/v2/chartDeploymentHistory/ChartDeploymentHistory.component.tsx
@@ -473,15 +473,10 @@ function ChartDeploymentHistory({
 
             if (installedAppInfo) {
                 requestPayload.installedAppId = installedAppInfo.installedAppId
-                requestPayload.installedAppVersionId = isExternal
-                    ? installedAppInfo.installedAppVersionId
-                    : selectedDeploymentHistory.installedAppVersionId
+                requestPayload.installedAppVersionId = installedAppInfo.installedAppVersionId
             }
 
-            const { result, errors } = await rollbackApplicationDeployment(
-                requestPayload,
-                isExternal && !installedAppInfo,
-            )
+            const { result, errors } = await rollbackApplicationDeployment(requestPayload)
             setDeploying(false)
             setShowRollbackConfirmation(false)
 

--- a/src/components/v2/chartDeploymentHistory/ChartDeploymentHistory.component.tsx
+++ b/src/components/v2/chartDeploymentHistory/ChartDeploymentHistory.component.tsx
@@ -473,7 +473,6 @@ function ChartDeploymentHistory({
 
             if (installedAppInfo) {
                 requestPayload.installedAppId = installedAppInfo.installedAppId
-                requestPayload.installedAppVersionId = installedAppInfo.installedAppVersionId
             }
 
             const { result, errors } = await rollbackApplicationDeployment(requestPayload)

--- a/src/components/v2/chartDeploymentHistory/chartDeploymentHistory.service.ts
+++ b/src/components/v2/chartDeploymentHistory/chartDeploymentHistory.service.ts
@@ -40,11 +40,7 @@ interface RollbackReleaseResponse extends ResponseType {
 }
 
 export const getDeploymentHistory = (appId: string, isExternal: boolean): Promise<ChartDeploymentHistoryResponse> => {
-    return get(
-        `${Routes.HELM_RELEASE_DEPLOYMENT_HISTORY_API}?${
-            isExternal ? `appId=${appId}&installedAppId=` : `installedAppId=${appId}&appId=`
-        }`,
-    )
+    return get(`${Routes.HELM_RELEASE_DEPLOYMENT_HISTORY_API}?${isExternal ? 'appId' : 'installedAppId'}=${appId}`)
 }
 
 export const getDeploymentManifestDetails = (
@@ -54,8 +50,8 @@ export const getDeploymentManifestDetails = (
 ): Promise<ChartDeploymentManifestDetailResponse> => {
     return get(
         `${Routes.HELM_RELEASE_DEPLOYMENT_MANIFEST_DETAILS_API}?${
-            isExternal ? `appId=${appId}&installedAppId=` : `installedAppId=${appId}&appId=`
-        }&version=${version}`,
+            isExternal ? 'appId' : 'installedAppId'
+        }=${appId}&version=${version}`,
     )
 }
 

--- a/src/components/v2/chartDeploymentHistory/chartDeploymentHistory.service.ts
+++ b/src/components/v2/chartDeploymentHistory/chartDeploymentHistory.service.ts
@@ -40,10 +40,11 @@ interface RollbackReleaseResponse extends ResponseType {
 }
 
 export const getDeploymentHistory = (appId: string, isExternal: boolean): Promise<ChartDeploymentHistoryResponse> => {
-    const url = isExternal
-        ? `${Routes.HELM_RELEASE_DEPLOYMENT_HISTORY_API}?appId=${appId}`
-        : `${Routes.APP_RELEASE_DEPLOYMENT_HISTORY_API}?installedAppId=${appId}`
-    return get(url)
+    return get(
+        `${Routes.HELM_RELEASE_DEPLOYMENT_HISTORY_API}?${
+            isExternal ? `appId=${appId}&installedAppId=` : `installedAppId=${appId}&appId=`
+        }`,
+    )
 }
 
 export const getDeploymentManifestDetails = (
@@ -51,16 +52,13 @@ export const getDeploymentManifestDetails = (
     version: number,
     isExternal: boolean,
 ): Promise<ChartDeploymentManifestDetailResponse> => {
-    const url = isExternal
-        ? `${Routes.HELM_RELEASE_DEPLOYMENT_DETAIL_API}?appId=${appId}&version=${version}`
-        : `${Routes.APP_RELEASE_DEPLOYMENT_DETAIL_API}?installedAppId=${appId}&version=${version}`
-    return get(url)
+    return get(
+        `${Routes.HELM_RELEASE_DEPLOYMENT_MANIFEST_DETAILS_API}?${
+            isExternal ? `appId=${appId}&installedAppId=` : `installedAppId=${appId}&appId=`
+        }&version=${version}`,
+    )
 }
 
-export const rollbackApplicationDeployment = (
-    request: RollbackReleaseRequest,
-    useDefaultRollbackAPI: boolean,
-): Promise<RollbackReleaseResponse> => {
-    const url = useDefaultRollbackAPI ? Routes.APP_DEPLOYMENT_ROLLBACK_API : Routes.HELM_DEPLOYMENT_ROLLBACK_API
-    return put(url, request)
+export const rollbackApplicationDeployment = (request: RollbackReleaseRequest): Promise<RollbackReleaseResponse> => {
+    return put(Routes.HELM_DEPLOYMENT_ROLLBACK_API, request)
 }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -116,7 +116,7 @@ export const Routes = {
     APP_VERSION: 'version',
     HELM_RELEASE_INFO_API: 'application/release-info',
     HELM_RELEASE_DEPLOYMENT_HISTORY_API: 'application/deployment-history',
-    HELM_RELEASE_DEPLOYMENT_DETAIL_API: 'application/deployment-detail',
+    HELM_RELEASE_DEPLOYMENT_MANIFEST_DETAILS_API: 'application/deployment-history/info',
     HELM_RELEASE_APP_DETAIL_API: 'application/app',
     MANIFEST: 'k8s/resource',
     DESIRED_MANIFEST: 'application/desired-manifest',
@@ -127,11 +127,8 @@ export const Routes = {
     HELM_RELEASE_APP_DELETE_API: 'application/delete',
     HELM_RELEASE_APP_UPDATE_API: 'application/update',
     HELM_LINK_TO_CHART_STORE_API: 'app-store/deployment/application/helm/link-to-chart-store',
-    HELM_DEPLOYMENT_ROLLBACK_API: 'app-store/deployment/application/rollback',
-    APP_DEPLOYMENT_ROLLBACK_API: 'application/rollback',
+    HELM_DEPLOYMENT_ROLLBACK_API: 'application/rollback',
     NAMESPACE: 'env/namespace',
-    APP_RELEASE_DEPLOYMENT_HISTORY_API: 'app-store/installed-app/deployment-history',
-    APP_RELEASE_DEPLOYMENT_DETAIL_API: 'app-store/installed-app/deployment-history/info',
 };
 
 export const ViewType = {


### PR DESCRIPTION
# Description

Changes include integration of refactored/merged APIs for deployment history & roll back on the deployment history page instead of using different APIs for external & Devtron charts.

Fixes # https://github.com/devtron-labs/devtron/issues/1421

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been performed manually.

1. Case #1 - 
- Go to Applications > select Helm Apps tab
- Select cluster from the cluster filter in which the app is installed
- Select app > it’ll redirect to the AppDetails page
- Select the Deployment history tab
- Observe

### Expected: It should load & display deployment history (all deployments) for the app.

2. Case #2 - values.yaml & helm generated manifest (for EA)
- Go to Applications > select Helm Apps tab
- Select cluster from the cluster filter in which the app is installed
- Select app > it’ll redirect to the AppDetails page
- Select the Deployment history tab
- Go to the desired deployment
- Click on values.yaml or helm generated manifest (for EA)
- Observe

### Expected: It should load & display values.yaml or helm generated manifest based on selected tab.

3. Case #3 - Rollback
- Go to Applications > select Helm Apps tab
- Select cluster from the cluster filter in which the app is installed
- Select app > it’ll redirect to the AppDetails page
- Select the Deployment history tab
- Go to the desired deployment
- Click on the Deploy button
- Observe

### Expected: It should start the rollback to the selected/desired deployment version.

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


