### PR TITLE
Enhancement - Enabled notes on HelmApp's AppDetails page

### DIFF
--- a/src/components/charts/discoverChartDetail/DiscoverChartDetails.tsx
+++ b/src/components/charts/discoverChartDetail/DiscoverChartDetails.tsx
@@ -423,7 +423,7 @@ function ReadmeRowHorizontal({ readme = null, version = '', ...props }) {
     );
 }
 
-export function MarkDown({ markdown = '', className = '', ...props }) {
+export function MarkDown({ markdown = '', className = '', breaks = false, ...props }) {
     const { hash } = useLocation();
     const renderer = new marked.Renderer();
     renderer.table = function (header, body) {
@@ -453,6 +453,7 @@ export function MarkDown({ markdown = '', className = '', ...props }) {
         renderer,
         gfm: true,
         smartLists: true,
+        ...(breaks && { breaks: true })
     });
 
     function createMarkup() {

--- a/src/components/external-apps/ExternalAppService.ts
+++ b/src/components/external-apps/ExternalAppService.ts
@@ -73,6 +73,7 @@ export interface ChartMetadata {
     home: string
     sources: string[]
     description: string
+    notes?: string
 }
 
 interface HelmReleaseStatus {

--- a/src/components/v2/appDetails/appDetails.type.ts
+++ b/src/components/v2/appDetails/appDetails.type.ts
@@ -140,6 +140,7 @@ export interface AppDetails {
     appType?: AppType;
     additionalData?: any;
     clusterId?: number;
+    notes?: string;
 }
 
 interface MaterialInfo {

--- a/src/components/v2/appDetails/ea/EAAppDetail.component.tsx
+++ b/src/components/v2/appDetails/ea/EAAppDetail.component.tsx
@@ -66,6 +66,7 @@ function ExternalAppDetail({appId, appName}) {
             appStoreAppVersion : helmAppDetail.chartMetadata.chartVersion,
             additionalData : helmAppDetail.releaseStatus,
             clusterId: helmAppDetail.environmentDetails.clusterId,
+            notes: helmAppDetail.chartMetadata.notes,
         }
 
         if(installedAppInfo){

--- a/src/components/v2/appDetails/sourceInfo/environmentStatus/EnvironmentStatus.component.tsx
+++ b/src/components/v2/appDetails/sourceInfo/environmentStatus/EnvironmentStatus.component.tsx
@@ -1,29 +1,33 @@
-import React, { useState } from 'react';
-import AppStatusDetailModal from './AppStatusDetailModal';
-import './environmentStatus.scss';
-import { ReactComponent as Question } from '../../../assets/icons/ic-question.svg';
-import { ReactComponent as Alert } from '../../../assets/icons/ic-alert-triangle.svg';
-import IndexStore from '../../index.store';
-import moment from 'moment';
-import { URLS } from '../../../../../config';
-import { AppType } from "../../../appDetails/appDetails.type";
-import { useSharedState } from '../../../utils/useSharedState';
-import { Link } from 'react-router-dom';
-import { useRouteMatch, useHistory } from 'react-router';
-import Tippy from '@tippyjs/react';
+import React, { useState } from 'react'
+import AppStatusDetailModal from './AppStatusDetailModal'
+import './environmentStatus.scss'
+import { ReactComponent as Question } from '../../../assets/icons/ic-question.svg'
+import { ReactComponent as Alert } from '../../../assets/icons/ic-alert-triangle.svg'
+import { ReactComponent as File } from '../../../../../assets/icons/ic-file.svg'
+import IndexStore from '../../index.store'
+import moment from 'moment'
+import { URLS } from '../../../../../config'
+import { AppType } from '../../../appDetails/appDetails.type'
+import { useSharedState } from '../../../utils/useSharedState'
+import { Link } from 'react-router-dom'
+import { useRouteMatch, useHistory } from 'react-router'
+import Tippy from '@tippyjs/react'
+import NotesDrawer from './NotesDrawer'
 
-function EnvironmentStatusComponent({appStreamData}:{appStreamData: any}) {
-    const [appDetails] = useSharedState(IndexStore.getAppDetails(), IndexStore.getAppDetailsObservable());
-    const [showAppStatusDetail, setShowAppStatusDetail] = useState(false);
-    const status = appDetails.resourceTree?.status || '';
-    const showHibernationStatusMessage = status.toLowerCase() === 'hibernated' || status.toLowerCase() === 'partially hibernated'
-    const { path, url } = useRouteMatch();
-    const history = useHistory();
+function EnvironmentStatusComponent({ appStreamData }: { appStreamData: any }) {
+    const [appDetails] = useSharedState(IndexStore.getAppDetails(), IndexStore.getAppDetailsObservable())
+    const [showAppStatusDetail, setShowAppStatusDetail] = useState(false)
+    const [showNotes, setShowNotes] = useState(false)
+    const status = appDetails.resourceTree?.status || ''
+    const showHibernationStatusMessage =
+        status.toLowerCase() === 'hibernated' || status.toLowerCase() === 'partially hibernated'
+    const { path, url } = useRouteMatch()
+    const history = useHistory()
 
     const onClickUpgrade = () => {
-        let _url = `${url.split('/').slice(0, -1).join('/')}/${URLS.APP_VALUES}`;
-        history.push(_url);
-    };
+        let _url = `${url.split('/').slice(0, -1).join('/')}/${URLS.APP_VALUES}`
+        history.push(_url)
+    }
 
     return (
         <div>
@@ -32,14 +36,22 @@ function EnvironmentStatusComponent({appStreamData}:{appStreamData: any}) {
                     <div className="app-status-card bcn-0 mr-12 br-8 p-16">
                         <div className="lh-1-33 cn-9 flex left">
                             <span>Application status</span>
-                            <Tippy className="default-tt cursor" arrow={false} content={'The health status of your app'}>
+                            <Tippy
+                                className="default-tt cursor"
+                                arrow={false}
+                                content={'The health status of your app'}
+                            >
                                 <Question className="cursor icon-dim-16 ml-4" />
                             </Tippy>
                         </div>
 
                         <div className={`f-${status.toLowerCase()} text-capitalize fw-6 fs-14 flex left`}>
                             <span>{status}</span>
-                            <figure className={`${showHibernationStatusMessage ? 'hibernating' : status.toLowerCase()} app-summary__icon ml-8 icon-dim-20`}></figure>
+                            <figure
+                                className={`${
+                                    showHibernationStatusMessage ? 'hibernating' : status.toLowerCase()
+                                } app-summary__icon ml-8 icon-dim-20`}
+                            ></figure>
                         </div>
                         <div onClick={() => setShowAppStatusDetail(true)}>
                             <span className="cursor cb-5 fw-6">Details</span>
@@ -51,16 +63,28 @@ function EnvironmentStatusComponent({appStreamData}:{appStreamData: any}) {
                     <div className="app-status-card bcn-0 mr-12 br-8 p-16">
                         <div className="lh-1-33 cn-9 flex left">
                             <span>Config apply status</span>
-                            <Tippy className="default-tt cursor" arrow={false} content={'Whether or not your last helm install was successful'}>
+                            <Tippy
+                                className="default-tt cursor"
+                                arrow={false}
+                                content={'Whether or not your last helm install was successful'}
+                            >
                                 <Question className="cursor icon-dim-16 ml-4" />
                             </Tippy>
                         </div>
-                        <div className={`f-${appDetails.additionalData["status"].toLowerCase()} text-capitalize fw-6 fs-14 flex left`}>
-                            <span>{appDetails.additionalData["status"]}</span>
-                            <figure className={`${appDetails.additionalData["status"].toLowerCase()} app-summary__icon ml-8 icon-dim-20`}></figure>
+                        <div
+                            className={`f-${appDetails.additionalData[
+                                'status'
+                            ].toLowerCase()} text-capitalize fw-6 fs-14 flex left`}
+                        >
+                            <span>{appDetails.additionalData['status']}</span>
+                            <figure
+                                className={`${appDetails.additionalData[
+                                    'status'
+                                ].toLowerCase()} app-summary__icon ml-8 icon-dim-20`}
+                            ></figure>
                         </div>
                         <div className="lh-1-33 cn-9 flex left">
-                            <span>{appDetails.additionalData["message"]}</span>
+                            <span>{appDetails.additionalData['message']}</span>
                         </div>
                     </div>
                 )}
@@ -69,7 +93,11 @@ function EnvironmentStatusComponent({appStreamData}:{appStreamData: any}) {
                     <div className="app-status-card bcn-0 br-8 pt-16 pl-16 pb-16 pr-16 mr-12">
                         <div className="cn-9 lh-1-33 flex left">
                             <span>Last updated</span>
-                            <Tippy className="default-tt cursor" arrow={false} content={'When was this app last updated'}>
+                            <Tippy
+                                className="default-tt cursor"
+                                arrow={false}
+                                content={'When was this app last updated'}
+                            >
                                 <Question className="cursor icon-dim-16 ml-4" />
                             </Tippy>
                         </div>
@@ -77,8 +105,7 @@ function EnvironmentStatusComponent({appStreamData}:{appStreamData: any}) {
                             {moment(appDetails?.lastDeployedTime, 'YYYY-MM-DDTHH:mm:ssZ').fromNow()}
                         </div>
                         {appDetails?.lastDeployedBy && appDetails?.lastDeployedBy}
-                        {
-                            appDetails.appType == AppType.EXTERNAL_HELM_CHART &&
+                        {appDetails.appType == AppType.EXTERNAL_HELM_CHART && (
                             <div>
                                 <Link
                                     className="cb-5 fw-6"
@@ -87,7 +114,7 @@ function EnvironmentStatusComponent({appStreamData}:{appStreamData: any}) {
                                     Details
                                 </Link>
                             </div>
-                        }
+                        )}
                     </div>
                 )}
 
@@ -95,28 +122,38 @@ function EnvironmentStatusComponent({appStreamData}:{appStreamData: any}) {
                     <div className="app-status-card bcn-0 br-8 pt-16 pl-16 pb-16 pr-16 mr-12">
                         <div className="cn-9 lh-1-33 flex left">
                             <span>Chart used</span>
-                            <Tippy className="default-tt cursor" arrow={false} content={'Chart used to deploy to this application'}>
+                            <Tippy
+                                className="default-tt cursor"
+                                arrow={false}
+                                content={'Chart used to deploy to this application'}
+                            >
                                 <Question className="cursor icon-dim-16 ml-4" />
                             </Tippy>
                         </div>
                         <div className=" fw-6 fs-14">
-                            {
-                                appDetails.appStoreChartName &&
-                                <span>{appDetails.appStoreChartName}/</span>
-                            }
+                            {appDetails.appStoreChartName && <span>{appDetails.appStoreChartName}/</span>}
                             {appDetails.appStoreAppName}({appDetails.appStoreAppVersion})
                         </div>
-                        {
-                            appDetails.appStoreChartId &&
-                            <div>
-                                <Link
-                                    className="cb-5 fw-6"
-                                    to={`${URLS.CHARTS}/discover/chart/${appDetails.appStoreChartId}`}
-                                >
-                                    View Chart
-                                </Link>
-                            </div>
-                        }
+                        <div className="flex left">
+                            {appDetails.notes && (
+                                <div className="flex cb-5 fw-6 cursor" onClick={() => setShowNotes(true)}>
+                                    <File className="app-notes__icon icon-dim-16 mr-4" /> Notes.txt
+                                </div>
+                            )}
+                            {appDetails.notes && appDetails.appStoreChartId && (
+                                <div className="app-status-card__divider" />
+                            )}
+                            {appDetails.appStoreChartId && (
+                                <div>
+                                    <Link
+                                        className="cb-5 fw-6"
+                                        to={`${URLS.CHARTS}/discover/chart/${appDetails.appStoreChartId}`}
+                                    >
+                                        View Chart
+                                    </Link>
+                                </div>
+                            )}
+                        </div>
                     </div>
                 )}
 
@@ -139,14 +176,22 @@ function EnvironmentStatusComponent({appStreamData}:{appStreamData: any}) {
             {showAppStatusDetail && (
                 <AppStatusDetailModal
                     close={() => {
-                        setShowAppStatusDetail(false);
+                        setShowAppStatusDetail(false)
                     }}
                     appStreamData={appStreamData}
                     showAppStatusMessage={showHibernationStatusMessage}
                 />
             )}
+            {showNotes && (
+                <NotesDrawer
+                    notes={appDetails.notes}
+                    close={() => {
+                        setShowNotes(false)
+                    }}
+                />
+            )}
         </div>
-    );
+    )
 }
 
-export default EnvironmentStatusComponent;
+export default EnvironmentStatusComponent

--- a/src/components/v2/appDetails/sourceInfo/environmentStatus/NotesDrawer.tsx
+++ b/src/components/v2/appDetails/sourceInfo/environmentStatus/NotesDrawer.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useRef } from 'react'
+import { Drawer } from '../../../../common'
+import { ReactComponent as Close } from '../../../assets/icons/ic-close.svg'
+import { MarkDown } from '../../../../charts/discoverChartDetail/DiscoverChartDetails'
+import './environmentStatus.scss'
+
+function NotesDrawer({ notes, close }: { notes: string; close: () => void }) {
+    const appNotesRef = useRef<HTMLDivElement>(null)
+
+    const escKeyPressHandler = (evt): void => {
+        if (evt && evt.key === 'Escape' && typeof close === 'function') {
+            evt.preventDefault()
+            close()
+        }
+    }
+
+    const outsideClickHandler = (evt): void => {
+        if (
+            appNotesRef.current &&
+            !appNotesRef.current.contains(evt.target) &&
+            typeof close === 'function'
+        ) {
+            close()
+        }
+    }
+
+    useEffect(() => {
+        document.addEventListener('keydown', escKeyPressHandler)
+        return (): void => {
+            document.removeEventListener('keydown', escKeyPressHandler)
+        }
+    }, [escKeyPressHandler])
+
+    useEffect(() => {
+        document.addEventListener('click', outsideClickHandler)
+        return (): void => {
+            document.removeEventListener('click', outsideClickHandler)
+        }
+    }, [outsideClickHandler])
+
+    return (
+        <Drawer position="right" width="50%">
+            <div className="app-notes-modal bcn-0" ref={appNotesRef}>
+                <div className="app-notes__header box-shadow pb-12 pt-12 mb-20 bcn-0">
+                    <div className="title flex content-space cn-9 fs-16 fw-6 pl-20 pr-20 ">
+                        Notes
+                        <span className="cursor" onClick={close}>
+                            <Close className="icon-dim-24" />
+                        </span>
+                    </div>
+                </div>
+                <div className="app-notes__body">
+                    <MarkDown className="app-notes__markdown" markdown={notes} breaks={true} />
+                </div>
+            </div>
+        </Drawer>
+    )
+}
+
+export default NotesDrawer

--- a/src/components/v2/appDetails/sourceInfo/environmentStatus/environmentStatus.scss
+++ b/src/components/v2/appDetails/sourceInfo/environmentStatus/environmentStatus.scss
@@ -3,7 +3,8 @@
     min-height: 92px;
 }
 
-.app-status-detail-modal {
+.app-status-detail-modal,
+.app-notes-modal {
     margin: auto;
     margin-right: 0;
     height: 100%;
@@ -76,7 +77,8 @@
     }
 }
 
-.app-status-detail__header {
+.app-status-detail__header,
+.app-notes__header {
     position: absolute;
     width: 100%;
 }
@@ -91,4 +93,26 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+svg.app-notes__icon {
+    path:not(:first-of-type) {
+        stroke: var(--B500);
+    }
+}
+
+.app-notes__body {
+    padding-top: 56px;
+}
+
+.app-notes__markdown {
+    padding: 10px 20px;
+    overflow-wrap: break-word;
+}
+
+.app-status-card__divider {
+    width: 1px;
+    height: 12px;
+    background-color: var(--N200);
+    margin: 0 8px;
 }


### PR DESCRIPTION
# Description

These changes will enable the `Notes.txt` option in the `Chart used` section right before `View chart` if notes are available.

![Screenshot 2022-04-11 at 10.16.19 AM.png](https://images.zenhubusercontent.com/61e15405a1d0b1e0e115f611/3e06ec8c-b8c4-4110-8a02-358d18c3bddf)

Fixes # https://github.com/devtron-labs/devtron/issues/1486

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been performed manually.

Case # 1 - Notes are available
1. Go to Applications > Select Helm apps tab
2. Select any app > it'll redirect to the HelmApp's AppDetails page
3. `Chart used` section should have the `Notes.txt` option
4. Click on the `Notes.txt` option
5. Observe

**Expected**: It should open the drawer from the right side containing notes.

Case # 2 - Notes are not available
1. Go to Applications > Select Helm apps tab
2. Select any app > it'll redirect to the HelmApp's AppDetails page
3. Observe

**Expected**: `Notes.txt` option shouldn't be present under the `Chart used` section.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


