### PR TITLE
Enhancement: cleaning kube manifest while comparing

### DIFF
--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -18,6 +18,7 @@ import EditorWorker from 'worker-loader!monaco-editor/esm/vs/editor/editor.worke
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import YamlWorker from 'worker-loader!monaco-yaml/lib/esm/yaml.worker';
 import { MODES } from '../../../src/config/constants';
+import { CleanKubeManifest } from '../../../src/util/Util';
 
 // @ts-ignore
 window.MonacoEnvironment = {
@@ -62,6 +63,7 @@ interface CodeEditorInterface {
     focus?: boolean;
     validatorSchema?: any;
     isKubernetes?: boolean;
+    cleanData?: boolean;
 }
 
 interface CodeEditorHeaderInterface {
@@ -110,7 +112,12 @@ interface CodeEditorState {
     code: string;
     noParsing: boolean;
 }
-const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.memo(function Editor({ value, mode = "json", noParsing = false, defaultValue = "", children, tabSize = 2, lineDecorationsWidth = 0, height = 450, inline = false, shebang = "", minHeight, maxHeight, onChange, readOnly, diffView, theme="", loading, customLoader, focus, validatorSchema ,isKubernetes = true}) {
+const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.memo(function Editor({ value, mode = "json", noParsing = false, defaultValue = "", children, tabSize = 2, lineDecorationsWidth = 0, height = 450, inline = false, shebang = "", minHeight, maxHeight, onChange, readOnly, diffView, theme="", loading, customLoader, focus, validatorSchema ,isKubernetes = true, cleanData = false}) {
+    if (cleanData) {
+        value = CleanKubeManifest(value);
+        defaultValue = CleanKubeManifest(defaultValue);
+    }
+    
     const editorRef = useRef(null)
     const monacoRef = useRef(null)
     const { width, height: windowHeight } = useWindowSize()

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -18,7 +18,7 @@ import EditorWorker from 'worker-loader!monaco-editor/esm/vs/editor/editor.worke
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import YamlWorker from 'worker-loader!monaco-yaml/lib/esm/yaml.worker';
 import { MODES } from '../../../src/config/constants';
-import { CleanKubeManifest } from '../../../src/util/Util';
+import { cleanKubeManifest } from '../../../src/util/Util';
 
 // @ts-ignore
 window.MonacoEnvironment = {
@@ -114,8 +114,8 @@ interface CodeEditorState {
 }
 const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.memo(function Editor({ value, mode = "json", noParsing = false, defaultValue = "", children, tabSize = 2, lineDecorationsWidth = 0, height = 450, inline = false, shebang = "", minHeight, maxHeight, onChange, readOnly, diffView, theme="", loading, customLoader, focus, validatorSchema ,isKubernetes = true, cleanData = false}) {
     if (cleanData) {
-        value = CleanKubeManifest(value);
-        defaultValue = CleanKubeManifest(defaultValue);
+        value = cleanKubeManifest(value);
+        defaultValue = cleanKubeManifest(defaultValue);
     }
     
     const editorRef = useRef(null)

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Manifest.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Manifest.component.tsx
@@ -296,6 +296,7 @@ function ManifestComponent({ selectedTab, isDeleted }) {
                         ) : (
                             <CodeEditor
                                 defaultValue={activeTab === 'Compare' && desiredManifest}
+                                cleanData={activeTab === 'Compare'}
                                 diffView={activeTab === 'Compare'}
                                 theme="vs-dark--dt"
                                 height={"100vh"}

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -1,0 +1,32 @@
+
+const MANIFEST_METADATA_REQUIRED_FIELDS : string[] = ['name', 'namespace', 'labels', 'annotations'];
+
+// Remove Auto-generated fields from kubernetes manifest
+// input - jsonString
+// output - jsonString
+export function CleanKubeManifest(manifestJsonString: string): string {
+    if (!manifestJsonString) {
+        return manifestJsonString;
+    }
+
+    try{
+        let obj = JSON.parse(manifestJsonString);
+
+        // 1 - delete status
+        delete obj['status'];
+
+        // 2 - delete all fields from metadata except some predefined
+        let metadata = obj['metadata'];
+        if(metadata) {
+            for (let key in metadata) {
+                if (!MANIFEST_METADATA_REQUIRED_FIELDS.includes(key)){
+                    delete metadata[key];
+                }
+            }
+        }
+
+        return JSON.stringify(obj);
+    }catch (e){
+        return manifestJsonString;
+    }
+}

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -4,13 +4,13 @@ const MANIFEST_METADATA_REQUIRED_FIELDS : string[] = ['name', 'namespace', 'labe
 // Remove Auto-generated fields from kubernetes manifest
 // input - jsonString
 // output - jsonString
-export function CleanKubeManifest(manifestJsonString: string): string {
+export function cleanKubeManifest(manifestJsonString: string): string {
     if (!manifestJsonString) {
         return manifestJsonString;
     }
 
     try{
-        let obj = JSON.parse(manifestJsonString);
+        const obj = JSON.parse(manifestJsonString);
 
         // 1 - delete status
         delete obj['status'];


### PR DESCRIPTION
# Description

Changes to remove some autogenerated fields from manifest while comparing in app detail.

Fixes # https://github.com/devtron-labs/devtron/issues/1497

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been performed manually.
Compare manifest on app detail. 

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


