### PR TITLE
Enhancement: Container registries -  enabled authentication type options for ECR

### DIFF
--- a/src/components/cluster/cluster.type.ts
+++ b/src/components/cluster/cluster.type.ts
@@ -5,7 +5,8 @@ export const POLLING_INTERVAL = 30000;
 
 export const AuthenticationType = {
     BASIC: "BASIC",
-    ANONYMOUS: "ANONYMOUS"
+    ANONYMOUS: "ANONYMOUS",
+    IAM: 'IAM'
 }
 
 export enum ClusterComponentStatus {

--- a/src/components/dockerRegistry/Docker.tsx
+++ b/src/components/dockerRegistry/Docker.tsx
@@ -26,6 +26,8 @@ import { ReactComponent as Check } from '../../assets/icons/ic-check.svg';
 import DeleteComponent from '../../util/DeleteComponent';
 import { DC_CONTAINER_REGISTRY_CONFIRMATION_MESSAGE, DeleteComponentsName } from '../../config/constantMessaging';
 import ReactSelect, { components } from 'react-select';
+import { RadioGroup, RadioGroupItem } from '../common/formFields/RadioGroup';
+import { AuthenticationType } from '../cluster/cluster.type';
 
 enum CERTTYPE {
     SECURE = 'secure',
@@ -204,6 +206,8 @@ function DockerForm({
     });
     const [deleting, setDeleting] = useState(false);
     const [confirmation, toggleConfirmation] = useState(false);
+    const [isIAMAuthType, setIAMAuthType] = useState(!awsAccessKeyId && !awsSecretAccessKey)
+
     function customHandleChange(e) {
         setCustomState((st) => ({ ...st, [e.target.name]: { value: e.target.value, error: '' } }));
     }
@@ -216,6 +220,26 @@ function DockerForm({
             registryUrl: { value: selectedRegistry.defaultRegistryURL, error: '' },
         }));
     };
+
+
+    const onECRAuthTypeChange = (e) => {
+        if (e.target.value === AuthenticationType.IAM) {
+            setIAMAuthType(true)
+            setCustomState((_state) => ({
+                ..._state,
+                awsAccessKeyId: { value: '', error: '' },
+                awsSecretAccessKey: { value: '', error: '' },
+            }));
+        } else {
+            setIAMAuthType(false)
+            setCustomState((_state) => ({
+                ..._state,
+                awsAccessKeyId: { value: awsAccessKeyId, error: '' },
+                awsSecretAccessKey: { value: awsSecretAccessKey, error: '' },
+            }));
+        }
+    }
+    
 
     function fetchAWSRegion(): string {
         const pattern = /(ecr.)[a-z]{2}-[a-z]*-[0-9]{1}/i;
@@ -299,8 +323,7 @@ function DockerForm({
     function onValidation() {
         if (selectedDockerRegistryType.value === 'ecr') {
             if (
-                !customState.awsAccessKeyId.value ||
-                !customState.awsSecretAccessKey.value ||
+                (!isIAMAuthType && (!customState.awsAccessKeyId.value || !customState.awsSecretAccessKey.value)) ||
                 !customState.registryUrl.value
             ) {
                 setCustomState((st) => ({
@@ -311,8 +334,8 @@ function DockerForm({
                         error: st.awsSecretAccessKey.value ? '' : 'Mandatory',
                     },
                     registryUrl: { ...st.registryUrl, error: st.registryUrl.value ? '' : 'Mandatory' },
-                }));
-                return;
+                }))
+                return
             }
         } else if (selectedDockerRegistryType.value === 'docker-hub') {
             if (!customState.username.value || !customState.password.value) {
@@ -505,29 +528,45 @@ function DockerForm({
             {selectedDockerRegistryType.value === 'ecr' ? (
                 <>
                     <div className="form__row">
-                        <CustomInput
-                            name="awsAccessKeyId"
-                            tabIndex={5}
-                            value={customState.awsAccessKeyId.value}
-                            error={customState.awsAccessKeyId.error}
-                            onChange={customHandleChange}
-                            label={selectedDockerRegistryType.id.label}
-                            autoComplete={'off'}
-                            placeholder={selectedDockerRegistryType.id.placeholder}
-                        />
+                        <span className="form__label">Authentication Type*</span>
+                        <RadioGroup
+                            className="ecr-authType__radio-group"
+                            value={isIAMAuthType ? AuthenticationType.IAM : AuthenticationType.BASIC}
+                            name="ecr-authType"
+                            onChange={(e) => onECRAuthTypeChange(e)}
+                        >
+                            <RadioGroupItem value={AuthenticationType.IAM}> EC2 IAM Role </RadioGroupItem>
+                            <RadioGroupItem value={AuthenticationType.BASIC}> User auth </RadioGroupItem>
+                        </RadioGroup>
                     </div>
-                    <div className="form__row">
-                        <ProtectedInput
-                            name="awsSecretAccessKey"
-                            tabIndex={6}
-                            value={customState.awsSecretAccessKey.value}
-                            error={customState.awsSecretAccessKey.error}
-                            onChange={customHandleChange}
-                            label={selectedDockerRegistryType.password.label}
-                            type="password"
-                            placeholder={selectedDockerRegistryType.password.placeholder}
-                        />
-                    </div>
+                    {!isIAMAuthType && (
+                        <>
+                            <div className="form__row">
+                                <CustomInput
+                                    name="awsAccessKeyId"
+                                    tabIndex={5}
+                                    value={customState.awsAccessKeyId.value}
+                                    error={customState.awsAccessKeyId.error}
+                                    onChange={customHandleChange}
+                                    label={selectedDockerRegistryType.id.label}
+                                    autoComplete={'off'}
+                                    placeholder={selectedDockerRegistryType.id.placeholder}
+                                />
+                            </div>
+                            <div className="form__row">
+                                <ProtectedInput
+                                    name="awsSecretAccessKey"
+                                    tabIndex={6}
+                                    value={customState.awsSecretAccessKey.value}
+                                    error={customState.awsSecretAccessKey.error}
+                                    onChange={customHandleChange}
+                                    label={selectedDockerRegistryType.password.label}
+                                    type="password"
+                                    placeholder={selectedDockerRegistryType.password.placeholder}
+                                />
+                            </div>
+                        </>
+                    )}
                 </>
             ) : (
                 <>
@@ -662,7 +701,7 @@ function DockerForm({
                     }
                 >
                     <input type="checkbox" className="cursor" name="default" checked={Isdefault} onChange={(e) => {}} />
-                    <div className="mr-4"> Set as default </div>
+                    <div className="mr-4"> Set as default registry </div>
                     <Tippy
                         className="default-tt"
                         arrow={false}

--- a/src/css/forms.scss
+++ b/src/css/forms.scss
@@ -208,6 +208,24 @@ p.sentence-case:first-letter {
     border: solid 1px var(--N200);
     border-radius: 4px;
     background-color: var(--white);
+
+    &.ecr-authType__radio-group {
+        border: none;
+
+        .form__radio-item {
+            border-right: none;
+            flex: unset;
+
+            .form__radio-item-content {
+                padding: 12px 16px 12px 0;
+            }
+
+            input:checked ~ .form__radio-item-content .radio__button {
+                background: radial-gradient(var(--B500) 0, var(--B500) 40%, var(--white) 45%, var(--white) 100%);
+                border: 1.5px solid var(--B500);
+            }
+        }
+    }
 }
 
 .form__checkbox {


### PR DESCRIPTION
# Description

Enabled authentication type options for ECR registry type in global configuration. Available options will be,
- EC2 IAM Role **(default)** - if selected, it'll use the IAM role
- User auth - if selected, need to provide secrets to be used manually

![Screenshot 2022-04-14 at 3.40.13 PM.png](https://images.zenhubusercontent.com/61e15405a1d0b1e0e115f611/3344f101-7496-4104-8df3-767315856f7e)

Fixes # https://github.com/devtron-labs/devtron/issues/1509

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been performed manually. 

1. Go to Global configurations
2. Go to Container registries
3. Add a new registry of type ECR or try updating the existing ECR registry
4. Observe

**Expected:** 
- It should show available `Authentication type` options
- `EC2 IAM Role` should be the default for adding a new registry & should not show account secrets inputs.
- For the existing, the registry can be switched to` EC2 IAM Role` from `User auth`
- It should successfully save the registry without asking for account secrets if ` EC2 IAM Role` selected & should mandate the account secrets if `User auth` is selected


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


