### PR TITLE
Fixed broken view events & logs in Helm App detail

### DIFF
--- a/src/components/v2/appDetails/k8Resource/nodeType/NodeDelete.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeType/NodeDelete.component.tsx
@@ -15,6 +15,7 @@ import { deleteResource } from '../../appDetails.api';
 import { NodeType } from '../../appDetails.type';
 import AppDetailsStore from '../../appDetails.store';
 import { appendRefetchDataToUrl } from '../../../../util/URLUtil';
+import { URLS } from '../../../../../config';
 
 function NodeDeleteComponent({ nodeDetails, appDetails }) {
     const { path } = useRouteMatch();
@@ -27,7 +28,8 @@ function NodeDeleteComponent({ nodeDetails, appDetails }) {
 
     function describeNodeWrapper(tab) {
         queryParams.set('kind', params.podName);
-        const newUrl = generatePath(path, { ...params, tab }) + '/' + nodeDetails.name + '/' + tab.toLowerCase();
+        const updatedPath = `${path.substring(0,path.indexOf('/k8s-resources/'))}/${URLS.APP_DETAILS_K8}/${NodeType.Pod.toLowerCase()}`
+        const newUrl = generatePath(updatedPath, { ...params, tab }) + '/' + nodeDetails.name + '/' + tab.toLowerCase();
         history.push(newUrl);
     }
 

--- a/src/components/v2/appDetails/k8Resource/nodeType/NodeDelete.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeType/NodeDelete.component.tsx
@@ -28,9 +28,8 @@ function NodeDeleteComponent({ nodeDetails, appDetails }) {
 
     function describeNodeWrapper(tab) {
         queryParams.set('kind', params.podName);
-        const updatedPath = `${path.substring(0,path.indexOf('/k8s-resources/'))}/${URLS.APP_DETAILS_K8}/${NodeType.Pod.toLowerCase()}`
-        const newUrl = generatePath(updatedPath, { ...params, tab }) + '/' + nodeDetails.name + '/' + tab.toLowerCase();
-        history.push(newUrl);
+        const updatedPath = `${path.substring(0,path.indexOf('/k8s-resources/'))}/${URLS.APP_DETAILS_K8}/${NodeType.Pod.toLowerCase()}/${nodeDetails.name}/${tab.toLowerCase()}`
+        history.push(generatePath(updatedPath, { ...params, tab }));
     }
 
     const PodPopup: React.FC<{


### PR DESCRIPTION
# Description

View events and View container logs are not redirecting to the events and logs tab.

Fixes # https://github.com/devtron-labs/devtron/issues/1512

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
All tests have been performed manually. The following are the steps,

1. Go to Applications > Select Helm apps tab
2. Select any app > it'll redirect to the App Details page > Pods
3. Select the three-dot menu on the right of the individual pod
4. Click on view event or view container log
5. Observe

**Expected behavior**

It should have redirected the user to the event/log tab

**Screenshots**

![Screenshot_20220414_184726.png](https://images.zenhubusercontent.com/61f7a8fc1e558b7ab1d73c6a/08c214ad-e4a8-4f91-a8b1-fe1d5dbece85)

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


