### PR TITLE
Fix - Ready column header is misaligned in NodeDetails issue

### DIFF
--- a/src/components/app/ResourceTreeNodes.tsx
+++ b/src/components/app/ResourceTreeNodes.tsx
@@ -700,28 +700,25 @@ export const GenericRow: React.FC<{ appName: string; environmentName: string; no
                     } else if (column === 'name') {
                         return <Name key={column} nodeDetails={nodeDetails} describeNode={describeNode} addExtraSpace={nodeDetails.kind === Nodes.Containers && containerLevelExternalLinks.length > 0} />;
                     } else if (column === 'external-links') {
-                        if (nodeDetails.kind === Nodes.Pod && podLevelExternalLinks.length > 0) {
-                            return (
-                                <td>
+                        return (
+                            <td>
+                                {nodeDetails.kind === Nodes.Pod && podLevelExternalLinks.length > 0 && (
                                     <NodeLevelExternalLinks
                                         appDetails={appDetails}
                                         nodeLevelExternalLinks={podLevelExternalLinks}
                                         podName={nodeName}
                                     />
-                                </td>
-                            )
-                        } else if (nodeDetails.kind === Nodes.Containers && containerLevelExternalLinks.length > 0) {
-                            return (
-                                <td>
+                                )}
+                                {nodeDetails.kind === Nodes.Containers && containerLevelExternalLinks.length > 0 && (
                                     <NodeLevelExternalLinks
                                         appDetails={appDetails}
                                         nodeLevelExternalLinks={containerLevelExternalLinks}
                                         podName={nodeDetails['pName']}
                                         containerName={nodeName}
                                     />
-                                </td>
-                            )
-                        }
+                                )}
+                            </td>
+                        )
                     } else if (column === '') {
                         return (
                             <Menu nodeDetails={nodeDetails}


### PR DESCRIPTION
# Description

On the Devtron app's AppDetails page, the `Ready` column header is misaligned and displayed over more options under NodeDetails when no external links are configured. These changes will fix this issue.

Fixes # https://github.com/devtron-labs/devtron/issues/1560

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been performed manually.

### Case 1: No External links are configured
1. Make sure no external links are configured
2. Go to the Devtron app's AppDetails page
3. Scroll to node details for Pods
4. Observe

**Expected**: It should show the `Ready` column header over the count

### Case 2: External links are presents
1. Make sure pod level external links are configured
2. Go to the Devtron app's AppDetails page
3. Scroll to node details for Pods
4. Observe

**Expected**: It should show the `Ready` column header over the count

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


