### PR TITLE
Fixed static height of Logs & terminal

### DIFF
--- a/src/components/app/details/appDetails/AppDetails.tsx
+++ b/src/components/app/details/appDetails/AppDetails.tsx
@@ -102,8 +102,7 @@ export default function AppDetail() {
         setEnvironmentId(Number(params.envId));
     }, [params.envId]);
     return (
-        <div style={{ overflowY: 'auto', height: '100%' }}>
-            <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
                 {/* <div className="flex left w-100 p-16">
                     <EnvSelector environments={otherEnvsResult?.result} />
                 </div> */}
@@ -128,7 +127,6 @@ export default function AppDetail() {
                         {(!otherEnvsResult?.result || otherEnvsResult?.result?.length === 0) && <AppNotConfigured text="You have not finished configuring this app" />}
                         {(!params.envId && otherEnvsResult?.result?.length > 0) && <EnvironmentNotConfigured environments={otherEnvsResult?.result} />}
                     </>}
-            </div>
         </div>
     );
 }

--- a/src/components/app/details/appDetails/AppDetails.tsx
+++ b/src/components/app/details/appDetails/AppDetails.tsx
@@ -103,9 +103,6 @@ export default function AppDetail() {
     }, [params.envId]);
     return (
         <div className="app-details-page-wrapper">
-                {/* <div className="flex left w-100 p-16">
-                    <EnvSelector environments={otherEnvsResult?.result} />
-                </div> */}
                 {!params.envId && otherEnvsResult?.result?.length > 0 && (
                     <div className="w-100 pt-16 pr-24 pb-20 pl-24">
                         <SourceInfo

--- a/src/components/app/details/appDetails/AppDetails.tsx
+++ b/src/components/app/details/appDetails/AppDetails.tsx
@@ -102,7 +102,7 @@ export default function AppDetail() {
         setEnvironmentId(Number(params.envId));
     }, [params.envId]);
     return (
-        <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+        <div className="app-details-page-wrapper">
                 {/* <div className="flex left w-100 p-16">
                     <EnvSelector environments={otherEnvsResult?.result} />
                 </div> */}

--- a/src/components/app/details/appDetails/appDetails.scss
+++ b/src/components/app/details/appDetails/appDetails.scss
@@ -1749,3 +1749,9 @@ table.resource-tree {
 .select-material--h450 {
     height: 450px;
 }
+
+.app-details-page-wrapper{
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+}

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/CopyToast.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/CopyToast.tsx
@@ -11,7 +11,6 @@ interface toastType {
 
 function CopyToast({ showCopyToast }: toastType) {
     return (
-        <div id="xterm-logs">
             <span
                 className={`br-8 bcn-0 cn-9 clipboard-toast ${showCopyToast ? 'clipboard-toast--show' : ''}`}
                 style={{ zIndex: 9 }}
@@ -19,7 +18,6 @@ function CopyToast({ showCopyToast }: toastType) {
                 <CheckIcon className="icon-dim-24 scn-9" />
                 <div className="">Copied!</div>
             </span>
-        </div>
     );
 }
 

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/LogViewer.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/LogViewer.component.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import CopyToast, { handleSelectionChange } from './CopyToast';
 import * as XtermWebfont from 'xterm-webfont';
 import { SearchAddon } from 'xterm-addon-search';
+import { AutoSizer } from 'react-virtualized';
 import '../../../../../../../node_modules/xterm/css/xterm.css';
 import './nodeDetailTab.scss';
 import { Subject } from '../../../../../../util/Subject';
@@ -126,14 +127,20 @@ const LogViewerComponent: React.FunctionComponent<logViewerInterface> = ({
 
     return (
         <>
-            <CopyToast showCopyToast={popupText} />
+            <AutoSizer>
+                {({ height, width }) => (
+                    <div style={{ height, width }} id="xterm-logs">
+                        <CopyToast showCopyToast={popupText} />
+                    </div>
+                )}
+            </AutoSizer>
             <Scroller
                 scrollToBottom={scrollToBottom}
                 scrollToTop={scrollToTop}
                 style={{ position: 'fixed', bottom: '30px', right: '30px', zIndex: '3' }}
             />
         </>
-    );
+    )
 };
 
 export default LogViewerComponent;

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/Terminal.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/Terminal.tsx
@@ -290,18 +290,14 @@ function TerminalView(terminalViewProps: TerminalViewProps) {
     };
 
     return (
-        <div className="terminal-view">
+        <div className="terminal-view h-100 w-100">
             <div
                 style={{ zIndex: 4, textTransform: 'capitalize' }}
                 className={`${
                     terminalViewProps.socketConnection !== 'CONNECTED'
-                        ? `${
-                              terminalViewProps.socketConnection === 'CONNECTING' ? 'bcy-2' : 'bcr-7'
-                          }  pl-20`
+                        ? `${terminalViewProps.socketConnection === 'CONNECTING' ? 'bcy-2' : 'bcr-7'}  pl-20`
                         : 'pb-10'
-                } ${
-                    terminalViewProps.socketConnection === 'CONNECTING' ? 'cn-9' : 'cn-0'
-                } m-0 pl-20 w-100`}
+                } ${terminalViewProps.socketConnection === 'CONNECTING' ? 'cn-9' : 'cn-0'} m-0 pl-20 w-100`}
             >
                 {terminalViewProps.socketConnection !== 'CONNECTED' && (
                     <span className={terminalViewProps.socketConnection === 'CONNECTING' ? 'loading-dots' : ''}>
@@ -328,8 +324,8 @@ function TerminalView(terminalViewProps: TerminalViewProps) {
                 )}
             </div>
 
-            <div>
-                <div id="terminal-id" className="pl-20"></div>
+            <div id="terminal-id" className="terminal-container ml-20">
+                <CopyToast showCopyToast={popupText} />
             </div>
 
             {terminalViewProps.socketConnection === 'CONNECTED' && (
@@ -337,8 +333,6 @@ function TerminalView(terminalViewProps: TerminalViewProps) {
                     {terminalViewProps.socketConnection}
                 </p>
             )}
-             
-            <CopyToast showCopyToast={popupText} />
         </div>
     );
 }

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/terminal.css
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/terminal.css
@@ -17,3 +17,9 @@
     width: 100%;
     background: #0a0f22;
 }
+
+.terminal-container {
+    height: calc(100% - 30px);
+    width: auto;
+    overflow: hidden;
+}


### PR DESCRIPTION
# Description

Terminal and log div is not taking dynamic height & not acquiring full height of view

Fixes - https://github.com/devtron-labs/devtron/issues/1668

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
**Describe the bug**

Terminal and log div is not taking dynamic height & not acquiring full height of view 

**To Reproduce**

1. User goes to devtron apps or helm apps 
2. User selects pods & select terminal or logs
3. Terminal and logs is not taking full height

**Expected behavior**

Terminal and logs should take full available height

**Current behavior** 

Terminal and logs is not taking full height

**Screenshots**

![Screenshot_20220517_095928.png](https://images.zenhubusercontent.com/61f7a8fc1e558b7ab1d73c6a/4657610b-8ba2-4de4-829a-0ccc2080f3bd)


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


