### PR TITLE
React-select right align fix

### DIFF
--- a/src/components/CIPipelineN/ConditionContainer.tsx
+++ b/src/components/CIPipelineN/ConditionContainer.tsx
@@ -174,7 +174,7 @@ export function ConditionContainer({ type }: { type: ConditionContainerType }) {
 
     function Option(_props) {
         const { selectProps, selectOption, data } = _props
-        selectProps.styles.option = getCustomOptionSelectionStyle({ direction: 'none', padding: '4px 10px' })
+        selectProps.styles.option = getCustomOptionSelectionStyle({ padding: '4px 10px' })
         return (
             <div className="flex left">
                 <components.Option {..._props}>{_props.children}</components.Option>

--- a/src/components/CIPipelineN/CustomInputVariableSelect.tsx
+++ b/src/components/CIPipelineN/CustomInputVariableSelect.tsx
@@ -231,7 +231,7 @@ function CustomInputVariableSelect({ selectedVariableIndex }: { selectedVariable
 
     function Option(_props) {
         const { selectProps, data } = _props
-        selectProps.styles.option = getCustomOptionSelectionStyle({ direction: 'none', padding: '4px 10px' })
+        selectProps.styles.option = getCustomOptionSelectionStyle({ padding: '4px 10px' })
         if (data.description) {
             return (
                 <Tippy

--- a/src/components/CIPipelineN/TaskTypeDetailComponent.tsx
+++ b/src/components/CIPipelineN/TaskTypeDetailComponent.tsx
@@ -157,7 +157,7 @@ export function TaskTypeDetailComponent() {
 
     function Option(_props) {
         const { selectProps, data } = _props
-        selectProps.styles.option = getCustomOptionSelectionStyle({ direction: 'none', padding: '4px 10px' })
+        selectProps.styles.option = getCustomOptionSelectionStyle({ padding: '4px 10px' })
         if (data.description) {
             return (
                 <Tippy className="variable-description" arrow={false} placement="left" content={data.description}>

--- a/src/components/ciConfig/CIConfig.tsx
+++ b/src/components/ciConfig/CIConfig.tsx
@@ -229,7 +229,7 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
     };
 
     const containerRegistryOption = (props) => {
-        props.selectProps.styles.option = getCustomOptionSelectionStyle({ direction: 'none' });
+        props.selectProps.styles.option = getCustomOptionSelectionStyle();
         return (
             <components.Option {...props}>
                 <div style={{ display: 'flex' }}>
@@ -270,7 +270,7 @@ function Form({ dockerRegistries, sourceConfig, ciConfig, reload, appId }) {
     };
 
     const repositoryOption = (props) => {
-        props.selectProps.styles.option = getCustomOptionSelectionStyle({ direction: 'none' })
+        props.selectProps.styles.option = getCustomOptionSelectionStyle()
         return (
             <components.Option {...props}>
                 {props.data.url.includes('gitlab') && <GitLab className="mr-8 vertical-align-middle icon-dim-20" />}

--- a/src/components/dockerRegistry/Docker.tsx
+++ b/src/components/dockerRegistry/Docker.tsx
@@ -413,7 +413,7 @@ function DockerForm({
     ];
 
     const registryOptions = (props) => {
-        props.selectProps.styles.option = getCustomOptionSelectionStyle({ direction: 'none'})
+        props.selectProps.styles.option = getCustomOptionSelectionStyle()
         return (
             <components.Option {...props}>
                 <div style={{ display: 'flex' }}>

--- a/src/components/hyperion/EnvironmentSelect.tsx
+++ b/src/components/hyperion/EnvironmentSelect.tsx
@@ -13,10 +13,10 @@ export default function HyperionEnvironmentSelect({ selectEnvironment, environme
         return (
             <components.ValueContainer {...props}>
                 {length > 0 ? (
-                    <>
+                    <div className='flex'>
                         {!props.selectProps.menuIsOpen && value}
                         {React.cloneElement(props.children[1])}
-                    </>
+                    </div>
                 ) : (
                     <>{props.children}</>
                 )}

--- a/src/components/material/MaterialView.tsx
+++ b/src/components/material/MaterialView.tsx
@@ -119,7 +119,7 @@ export class MaterialView extends Component<MaterialViewProps, MaterialViewState
                         components={{
                             IndicatorSeparator: null,
                             Option: (props) => {
-                                props.selectProps.styles.option = getCustomOptionSelectionStyle({ direction: 'none' })
+                                props.selectProps.styles.option = getCustomOptionSelectionStyle()
                                 return <components.Option {...props}>
                                     {props.data.url.includes("gitlab") ? <GitLab className="mr-8 vertical-align-middle icon-dim-20" /> : null}
                                     {props.data.url.includes("github") ? <GitHub className="mr-8 vertical-align-middle icon-dim-20" /> : null}

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
@@ -372,7 +372,7 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
                                             }}
                                             components={{
                                                 IndicatorSeparator: null,
-                                                Option: (props)=> <Option {...props} showTippy={true} />,
+                                                Option: (props)=> <Option {...props} showTippy={true} style={{direction:'rtl'}}/>,
                                             }}
                                         />
                                     </div>
@@ -426,7 +426,7 @@ function LogsComponent({ selectedTab, isDeleted, logSearchTerms, setLogSearchTer
                                         }}
                                         components={{
                                             IndicatorSeparator: null,
-                                            Option: (props)=> <Option {...props} showTippy={true} />,
+                                            Option: (props)=> <Option {...props} showTippy={true} style={{direction:'rtl'}}/>,
                                         }}
                                     />
                                 </div>

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Terminal.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Terminal.component.tsx
@@ -130,7 +130,7 @@ function TerminalComponent({ selectedTab, isDeleted }) {
                         }}
                         components={{
                             IndicatorSeparator: null,
-                            Option,
+                            Option: (props)=> <Option {...props} style={{direction:'rtl'}} />
                         }}
                     />
                 </div>

--- a/src/components/v2/common/ReactSelect.utils.tsx
+++ b/src/components/v2/common/ReactSelect.utils.tsx
@@ -15,7 +15,6 @@ export const getCustomOptionSelectionStyle = (styleOverrides = {}) => {
         overflow: 'hidden',
         textAlign: 'left',
         whiteSpace: 'nowrap',
-        direction: 'rtl',
         cursor: 'pointer',
         ...styleOverrides,
     })
@@ -49,8 +48,8 @@ export const styles = {
 }
 
 export function Option(props) {
-    const { selectProps, data, showTippy } = props
-    selectProps.styles.option = getCustomOptionSelectionStyle()
+    const { selectProps, data, showTippy, style } = props
+    selectProps.styles.option = getCustomOptionSelectionStyle(style)
     const getOption = () => {
         return (
             <div>


### PR DESCRIPTION
# Description

Text inside react - select is align to right

![image.png](https://images.zenhubusercontent.com/61f7a8fc1e558b7ab1d73c6a/2c84192b-a6b8-4205-8864-deb6f34f48cc)

Fixes - https://github.com/devtron-labs/devtron/issues/1721

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


