### PR TITLE
Fix - External link is not generated properly when same key is used multiple times

### DIFF
--- a/src/components/externalLinks/ExternalLinks.utils.ts
+++ b/src/components/externalLinks/ExternalLinks.utils.ts
@@ -90,13 +90,13 @@ export const getParsedURL = (
     containerName?: string,
 ): string => {
     let parsedUrl = url
-        .replace('{appName}', appDetails.appName)
-        .replace('{appId}', `${appDetails.appId}`)
-        .replace('{envId}', `${appDetails.environmentId}`)
-        .replace('{namespace}', `${appDetails.namespace}`)
+        .replace(/{appName}/g, appDetails.appName)
+        .replace(/{appId}/g, `${appDetails.appId}`)
+        .replace(/{envId}/g, `${appDetails.environmentId}`)
+        .replace(/{namespace}/g, appDetails.namespace)
 
     if (!isAppLevel) {
-        parsedUrl = parsedUrl.replace('{podName}', podName).replace('{containerName}', `${containerName}`)
+        parsedUrl = parsedUrl.replace(/{podName}/g, podName).replace(/{containerName}/g, containerName)
     }
 
     return parsedUrl

--- a/src/components/v2/appDetails/ea/EAAppDetail.component.tsx
+++ b/src/components/v2/appDetails/ea/EAAppDetail.component.tsx
@@ -76,9 +76,10 @@ function ExternalAppDetail({appId, appName}) {
             notes: helmAppDetail.chartMetadata.notes,
         }
 
-        if(installedAppInfo){
+        if (installedAppInfo) {
             genericAppDetail.appStoreChartId = installedAppInfo.appStoreChartId;
             genericAppDetail.environmentName = installedAppInfo.environmentName;
+            genericAppDetail.environmentId = installedAppInfo.environmentId;
         }
 
         return genericAppDetail


### PR DESCRIPTION
# Description

These changes fix the issue when any key ({namespace}, {containerName}, etc. ) in an external link is used two or more times causing the URL/link to be not generated.

Fixes # https://github.com/devtron-labs/devtron/issues/1752

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tests have been performed manually,

1. Go to Global configurations
2. Go to the External Link section
3. Add new link as - https://devtron.info/grafana/{containerName}/test/{containerName}
4. Go to the AppDetails page
5. Observe the app level external link section

**Expected behavior**

It should generate the proper link even when the same key is used multiple times.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
