### PR TITLE
Secret/Secret Override issue fix

### DIFF
--- a/src/components/secrets/Secret.tsx
+++ b/src/components/secrets/Secret.tsx
@@ -347,7 +347,7 @@ export const SecretForm: React.FC<SecretFormProps> = function (props) {
             setFilePermissionValue({ value: filePermissionValue.value, error: 'This is octal number, use numbers between 0 to 7' });
             return;
         }
-        if(selectedTab === 'Data Volume' && isSubPathChecked ){
+        if(selectedTab === 'Data Volume' && isSubPathChecked  && !isExternalValues){
             if (!externalSubpathValues.value) {
                 setExternalSubpathValues({ value: externalSubpathValues.value, error: 'This is a required field' });
                 return;


### PR DESCRIPTION
# Description
User is unable to save 'Secret/Secret Override' when Set SubPath is checked

Fixes # (issue)
Added check of subpath for Kubernetes External Secret only

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Manually tested


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


