### PR TITLE
Removed Custom charts option from EA_ONLY mode

### DIFF
--- a/src/components/globalConfigurations/GlobalConfiguration.tsx
+++ b/src/components/globalConfigurations/GlobalConfiguration.tsx
@@ -157,7 +157,7 @@ function NavItem({ hostURLConfig, serverMode }) {
             name: 'Custom charts',
             href: URLS.GLOBAL_CONFIG_CUSTOM_CHARTS,
             component: CustomChartList,
-            isAvailableInEA: true,
+            isAvailableInEA: false,
         },
         { name: 'SSO login services', href: URLS.GLOBAL_CONFIG_LOGIN, component: SSOLogin, isAvailableInEA: true },
         { name: 'User access', href: URLS.GLOBAL_CONFIG_AUTH, component: UserGroup, isAvailableInEA: true },


### PR DESCRIPTION
Removed Custom charts option from EA_ONLY mode

# Description

Custom is available in EA_ONLY mode. which is not required there

Fixes # (issue)
Adde check for Custom chart

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Manually tested


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


