### PR TITLE
Fixed gitops-validation & usergroup select scroll issue

### DIFF
--- a/src/components/gitOps/GitOpsConfiguration.tsx
+++ b/src/components/gitOps/GitOpsConfiguration.tsx
@@ -451,8 +451,8 @@ class GitOpsConfiguration extends Component<GitOpsProps, GitOpsState> {
                 </div>
 
                 <div className="form__buttons">
-                    <button type="submit" disabled={this.state.saveLoading} onClick={(e) => { e.preventDefault(); this.saveGitOps() }} tabIndex={5} className="cta">
-                        {this.state.saveLoading ? <Progressing /> : "Save"}
+                    <button type="submit" disabled={this.state.saveLoading} onClick={(e) => { e.preventDefault(); this.saveGitOps() }} tabIndex={5} className={`cta ${this.state.saveLoading ? 'cursor-not-allowed': '' }`}>
+                        Save
                     </button>
                 </div>
             </form>

--- a/src/components/gitOps/GitOpsConfiguration.tsx
+++ b/src/components/gitOps/GitOpsConfiguration.tsx
@@ -101,6 +101,7 @@ class GitOpsConfiguration extends Component<GitOpsProps, GitOpsState> {
             statusCode: 0,
             gitList: [],
             saveLoading: false,
+            validateLoading: false,
             providerTab: GitProvider.GITHUB,
             lastActiveGitOp: undefined,
             form: {
@@ -297,7 +298,7 @@ class GitOpsConfiguration extends Component<GitOpsProps, GitOpsState> {
             toast.error("Some Required Fields are missing");
             return;
         }
-        this.setState({ validationStatus: VALIDATION_STATUS.LOADER, saveLoading: true });
+        this.setState({ validationStatus: VALIDATION_STATUS.LOADER, saveLoading: true, validateLoading: true });
         let payload = {
             id: this.state.form.id,
             provider: this.state.form.provider,
@@ -316,10 +317,10 @@ class GitOpsConfiguration extends Component<GitOpsProps, GitOpsState> {
             let resp = response.result
             let errorMap = resp.stageErrorMap;
             if (errorMap != null && Object.keys(errorMap).length > 0) {
-                this.setState({ validationStatus: VALIDATION_STATUS.FAILURE, saveLoading: false, isFormEdited: false,validationError : errorMap || [], deleteRepoError : resp.deleteRepoFailed});
+                this.setState({ validationStatus: VALIDATION_STATUS.FAILURE, saveLoading: false, validateLoading: false, isFormEdited: false,validationError : errorMap || [], deleteRepoError : resp.deleteRepoFailed});
                 toast.error("Configuration validation failed");
             } else {
-                this.setState({ validationStatus: VALIDATION_STATUS.SUCCESS, saveLoading: false, isFormEdited: false, deleteRepoError : resp.deleteRepoFailed});
+                this.setState({ validationStatus: VALIDATION_STATUS.SUCCESS, saveLoading: false, validateLoading: false, isFormEdited: false, deleteRepoError : resp.deleteRepoFailed});
                 toast.success("Configuration validated");
             }
         }).catch((error) => {
@@ -452,7 +453,7 @@ class GitOpsConfiguration extends Component<GitOpsProps, GitOpsState> {
 
                 <div className="form__buttons">
                     <button type="submit" disabled={this.state.saveLoading} onClick={(e) => { e.preventDefault(); this.saveGitOps() }} tabIndex={5} className={`cta ${this.state.saveLoading ? 'cursor-not-allowed': '' }`}>
-                        Save
+                    {this.state.saveLoading && !this.state.validateLoading ? <Progressing /> : "Save"}
                     </button>
                 </div>
             </form>

--- a/src/components/gitOps/gitops.type.ts
+++ b/src/components/gitOps/gitops.type.ts
@@ -39,6 +39,7 @@ export interface GitOpsState {
     isFormEdited: boolean;
     lastActiveGitOp: undefined | GitOpsConfig;
     saveLoading: boolean;
+    validateLoading: boolean;
     isError: {
         host: string;
         username: string;

--- a/src/components/userGroups/User.tsx
+++ b/src/components/userGroups/User.tsx
@@ -375,6 +375,7 @@ export default function UserForm({
                         name="groups"
                         options={availableGroups}
                         hideSelectedOptions={false}
+                        menuShouldBlockScroll={true}
                         onChange={(selected, actionMeta) => setUserGroups((selected || []) as any)}
                         className={`basic-multi-select ${id ? 'mt-8 mb-16' : ''}`}
                     />

--- a/src/components/userGroups/UserGroup.tsx
+++ b/src/components/userGroups/UserGroup.tsx
@@ -53,6 +53,7 @@ import EmptyImage from '../../assets/img/empty-applist@2x.png';
 import EmptySearch from '../../assets/img/empty-noresult@2x.png';
 import './UserGroup.scss';
 import { mainContext } from '../common/navigation/NavigationRoutes';
+import { Option as singleOption } from '../v2/common/ReactSelect.utils';
 import { responseInterceptor } from 'http-proxy-middleware';
 
 interface UserGroup {
@@ -865,6 +866,7 @@ export const DirectPermission: React.FC<DirectPermissionRow> = ({
         <React.Fragment>
             <Select
                 value={permission.team}
+                menuShouldBlockScroll={true}
                 name="team"
                 isMulti={false}
                 placeholder="Select project"
@@ -881,7 +883,7 @@ export const DirectPermission: React.FC<DirectPermissionRow> = ({
                 components={{
                     ClearIndicator: null,
                     IndicatorSeparator: null,
-                    Option,
+                    Option: singleOption,
                     ValueContainer: projectValueContainer,
                 }}
                 styles={{
@@ -923,6 +925,7 @@ export const DirectPermission: React.FC<DirectPermissionRow> = ({
                         classNamePrefix="select"
                         menuPortalTarget={document.body}
                         hideSelectedOptions={false}
+                        menuShouldBlockScroll={true}
                         styles={{
                             ...tempMultiSelectStyles,
                             option: (base, state) => ({
@@ -967,6 +970,7 @@ export const DirectPermission: React.FC<DirectPermissionRow> = ({
                         menuPortalTarget={document.body}
                         hideSelectedOptions={false}
                         styles={tempMultiSelectStyles}
+                        menuShouldBlockScroll={true}
                         components={{
                             ClearIndicator: null,
                             ValueContainer,
@@ -1018,6 +1022,7 @@ export const DirectPermission: React.FC<DirectPermissionRow> = ({
                     onChange={handleDirectPermissionChange}
                     hideSelectedOptions={false}
                     inputValue={appInput}
+                    menuShouldBlockScroll={true}
                     onBlur={() => {
                         setAppInput('');
                     }}
@@ -1041,6 +1046,7 @@ export const DirectPermission: React.FC<DirectPermissionRow> = ({
                 formatOptionLabel={formatOptionLabel}
                 onChange={handleDirectPermissionChange}
                 isDisabled={!permission.team}
+                menuShouldBlockScroll={true}
                 styles={{
                     ...tempMultiSelectStyles,
                     option: (base, state) => ({
@@ -1173,6 +1179,7 @@ export const ChartPermission: React.FC<ChartPermissionRow> = React.memo(({ chart
                         Option,
                     }}
                     styles={{ ...tempMultiSelectStyles }}
+                    menuShouldBlockScroll={true}
                 />
             </div>
             {chartPermission.action === ActionTypes.UPDATE && (
@@ -1202,6 +1209,7 @@ export const ChartPermission: React.FC<ChartPermissionRow> = React.memo(({ chart
                     className="mt-8 mb-8"
                     classNamePrefix="select"
                     hideSelectedOptions={false}
+                    menuShouldBlockScroll={true}
                     components={{
                         ClearIndicator: null,
                         IndicatorSeparator: null,


### PR DESCRIPTION
# Description

Saving GitOps in global configurations, if we only try to Validate, it also shows that it's trying to save too but at backend, it doesn't save which is confusing for the users | In usergroup select option remains at same position after scrolling page & Project select should show normal select interface instead of checkbox

Fixes - https://github.com/devtron-labs/devtron/issues/1592

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Describe the bug**

When saving GitOps in global configurations, if we only try to Validate, it also shows that it's trying to save too but at backend it doesn't save which is confusing for the users

**To Reproduce**

1. Setup a new devtron with cicd module
2. In global configuration, enter gitops credentials and instead of saving - Click `Validate`
3. On UI it also shows that configurations are being Saved as loader runs on Save button too

**Expected behavior**

It should only validate the credentials but it seems like it also saves in database from which user thinks that it's done and he continues with App creation process

**Current behavior** 

With this, the user isn't able to Save deployment template in the app as the GitOps Credentials were not saved in argocd-cm and secret and hence no GitOps which gets saved when we click save button in GitOps and then everything works fine

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


