### PR TITLE
Added tab to show history image tags

### DIFF
--- a/src/components/v2/chartDeploymentHistory/ChartDeploymentHistory.component.tsx
+++ b/src/components/v2/chartDeploymentHistory/ChartDeploymentHistory.component.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { showError, Progressing, ErrorScreenManager, ConfirmationDialog, VisibleModal } from '../../common'
+import { showError, Progressing, ErrorScreenManager, ConfirmationDialog } from '../../common'
 import docker from '../../../assets/icons/misc/docker.svg'
 import { ReactComponent as DeployButton } from '../../../assets/icons/ic-deploy.svg'
 import { InstalledAppInfo } from '../../external-apps/ExternalAppService'
@@ -471,11 +471,9 @@ function ChartDeploymentHistory({
                             </button>
                         </Tippy>
                     )}
-                    {showDockerInfo && (
-                        <VisibleModal className="" close={closeDockerInfoTab}>
+                    {showDockerInfo && 
                             <DockerListModal dockerList={deployment.dockerImages} closeTab={closeDockerInfoTab} />
-                        </VisibleModal>
-                    )}
+                    }
                 </div>
             </div>
         )

--- a/src/components/v2/chartDeploymentHistory/ChartDeploymentHistory.component.tsx
+++ b/src/components/v2/chartDeploymentHistory/ChartDeploymentHistory.component.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { showError, Progressing, ErrorScreenManager, ConfirmationDialog } from '../../common'
+import { showError, Progressing, ErrorScreenManager, ConfirmationDialog, VisibleModal } from '../../common'
 import docker from '../../../assets/icons/misc/docker.svg'
 import { ReactComponent as DeployButton } from '../../../assets/icons/ic-deploy.svg'
 import { InstalledAppInfo } from '../../external-apps/ExternalAppService'
@@ -15,6 +15,7 @@ import MessageUI from '../common/message.ui'
 import { toast } from 'react-toastify'
 import { useHistory, useRouteMatch } from 'react-router'
 import CDEmptyState from '../../app/details/cdDetails/CDEmptyState'
+import DockerListModal from './DockerListModal'
 import {
     ChartDeploymentDetail,
     ChartDeploymentHistoryResponse,
@@ -52,6 +53,7 @@ function ChartDeploymentHistory({
     const [rollbackDialogTitle, setRollbackDialogTitle] = useState('Rollback')
     const [showRollbackConfirmation, setShowRollbackConfirmation] = useState(false)
     const [deploying, setDeploying] = useState(false)
+    const [showDockerInfo,setShowDockerInfo] = useState(false)
     const history = useHistory()
     const { url } = useRouteMatch()
 
@@ -418,6 +420,10 @@ function ChartDeploymentHistory({
         )
     }
 
+    const closeDockerInfoTab = () => {
+        setShowDockerInfo(false)
+    }
+
     function renderSelectedDeploymentDetailHeader() {
         const deployment = deploymentHistoryArr[selectedDeploymentHistoryIndex]
 
@@ -432,7 +438,7 @@ function ChartDeploymentHistory({
                                     Moment12HourFormat,
                                 )}
                             </time>
-                            {deployment.dockerImages.map((dockerImage, index) => {
+                            {deployment.dockerImages.slice(0, 3).map((dockerImage, index) => {
                                 return (
                                     <div key={index} className="app-commit__hash ml-10">
                                         <Tippy arrow={true} className="default-tt" content={dockerImage}>
@@ -444,6 +450,14 @@ function ChartDeploymentHistory({
                                     </div>
                                 )
                             })}
+                            {deployment.dockerImages.length > 3 && (
+                                <div onClick={() => setShowDockerInfo(true)} className="cursor anchor ml-10">
+                                    <span>
+                                        <span className="">{deployment.dockerImages.length - 3}</span>
+                                        <span className="ml-3">more</span>
+                                    </span>
+                                </div>
+                            )}
                         </div>
                     </div>
                     {selectedDeploymentHistoryIndex !== 0 && (
@@ -456,6 +470,11 @@ function ChartDeploymentHistory({
                                 <span className="ml-4">Deploy</span>
                             </button>
                         </Tippy>
+                    )}
+                    {showDockerInfo && (
+                        <VisibleModal className="" close={closeDockerInfoTab}>
+                            <DockerListModal dockerList={deployment.dockerImages} closeTab={closeDockerInfoTab} />
+                        </VisibleModal>
                     )}
                 </div>
             </div>

--- a/src/components/v2/chartDeploymentHistory/DockerListModal.tsx
+++ b/src/components/v2/chartDeploymentHistory/DockerListModal.tsx
@@ -3,36 +3,35 @@ import { ReactComponent as Close } from '../assets/icons/ic-close.svg'
 import docker from '../../../assets/icons/misc/docker.svg'
 import { useKeyDown, VisibleModal } from '../../common'
 
-export default function DockerListModal({ closeTab, dockerList }:{ closeTab: () => void, dockerList: string[]}) {
-    const key = useKeyDown();
+export default function DockerListModal({ closeTab, dockerList }: { closeTab: () => void; dockerList: string[] }) {
+    const key = useKeyDown()
     useEffect(() => {
         if (key.join().includes('Escape')) {
             closeTab()
         }
-    }, [key.join()]);
-    
+    }, [key.join()])
+
     return (
         <VisibleModal className="">
             <div className="docker-wrapper">
-            <div className="docker-header flex-align-center fs-16 fw-6 pl-20 pr-20 pt-17 pb-17">
-                <span className='cn-9'>Deployed images</span>
-                <button type="button" className="transparent flex" onClick={closeTab}>
-                    <Close />
-                </button>
+                <div className="docker-header flex-align-center fs-16 fw-6 pl-20 pr-20 pt-17 pb-17">
+                    <span className="cn-9">Deployed images</span>
+                    <button type="button" className="transparent flex" onClick={closeTab}>
+                        <Close />
+                    </button>
+                </div>
+                <div className="pt-20 pb-6 docker-body">
+                    {dockerList.map((list) => (
+                        <div className="flexbox mb-14 ml-20">
+                            <span className="app-commit__hash mr-8">
+                                <img src={docker} className="commit-hash__icon grayscale" />
+                                <span className="ml-3">{list.split(':')[1] || list}</span>
+                            </span>
+                            <span className="fs-13 fw-4">{list}</span>
+                        </div>
+                    ))}
+                </div>
             </div>
-            <div className='pt-20 pb-6 docker-body'>
-                {dockerList.map((list) => (
-                    <div className='flexbox mb-14 ml-20'>
-                        <span className='app-commit__hash mr-8'>
-                            <img src={docker} className="commit-hash__icon grayscale" />
-                            <span className="ml-3">{list.split(':')[1] || list}</span>
-                        </span>
-                        <span className='fs-13 fw-4'>{list}</span>
-                    </div>
-                ))}
-            </div>
-        </div>
         </VisibleModal>
-        
     )
 }

--- a/src/components/v2/chartDeploymentHistory/DockerListModal.tsx
+++ b/src/components/v2/chartDeploymentHistory/DockerListModal.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { ReactComponent as Close } from '../assets/icons/ic-close.svg'
+import docker from '../../../assets/icons/misc/docker.svg'
+
+export default function DockerListModal({ closeTab, dockerList }) {
+    return (
+        <div className="docker-wrapper" onClick={(e) => e.stopPropagation()}>
+            <div className="docker-header flex-align-center fs-16 fw-6 pl-20 pr-20 pt-17 pb-17">
+                <span className='cn-9'>Deployed images</span>
+                <button type="button" className="transparent flex" onClick={() => closeTab()}>
+                    <Close />
+                </button>
+            </div>
+            <div className='pt-20 pb-6 docker-body'>
+                {dockerList.map((list) => (
+                    <div className='flexbox mb-14 ml-20'>
+                        <span className='app-commit__hash mr-8'>
+                            <img src={docker} className="commit-hash__icon grayscale" />
+                            <span className="ml-3">{list.split(':')[1] || list}</span>
+                        </span>
+                        <span className='fs-13 fw-4'>{list}</span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/src/components/v2/chartDeploymentHistory/DockerListModal.tsx
+++ b/src/components/v2/chartDeploymentHistory/DockerListModal.tsx
@@ -1,13 +1,22 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { ReactComponent as Close } from '../assets/icons/ic-close.svg'
 import docker from '../../../assets/icons/misc/docker.svg'
+import { useKeyDown, VisibleModal } from '../../common'
 
-export default function DockerListModal({ closeTab, dockerList }) {
+export default function DockerListModal({ closeTab, dockerList }:{ closeTab: () => void, dockerList: string[]}) {
+    const key = useKeyDown();
+    useEffect(() => {
+        if (key.join().includes('Escape')) {
+            closeTab()
+        }
+    }, [key.join()]);
+    
     return (
-        <div className="docker-wrapper" onClick={(e) => e.stopPropagation()}>
+        <VisibleModal className="">
+            <div className="docker-wrapper">
             <div className="docker-header flex-align-center fs-16 fw-6 pl-20 pr-20 pt-17 pb-17">
                 <span className='cn-9'>Deployed images</span>
-                <button type="button" className="transparent flex" onClick={() => closeTab()}>
+                <button type="button" className="transparent flex" onClick={closeTab}>
                     <Close />
                 </button>
             </div>
@@ -23,5 +32,7 @@ export default function DockerListModal({ closeTab, dockerList }) {
                 ))}
             </div>
         </div>
+        </VisibleModal>
+        
     )
 }

--- a/src/components/v2/chartDeploymentHistory/chartDeploymentHistory.scss
+++ b/src/components/v2/chartDeploymentHistory/chartDeploymentHistory.scss
@@ -67,3 +67,25 @@
         }
     }
 }
+
+.docker-wrapper {
+    background-color: white;
+    width: 600px;
+    max-height: 500px;
+    margin: auto;
+    border-radius: 0 0 8px 8px;
+
+    .docker-header {
+        height: 56px;
+        display: flex;
+        justify-content: space-between;
+        border-bottom: 1px solid var(--N200);
+    }
+
+    .docker-body {
+        overflow-y: auto;
+        min-height: 0;
+        max-height: 444px;
+    }
+}
+


### PR DESCRIPTION
# Description

In helm deployment history page breaks in case of too many image tags. So, adding popup tab to view all images with data

Fixes - https://github.com/devtron-labs/devtron/issues/2037

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


