### PR TITLE
App metrics collapse | Build history page reload | Deployment history show loader

### DIFF
--- a/src/components/app/details/appDetails/AppDetails.tsx
+++ b/src/components/app/details/appDetails/AppDetails.tsx
@@ -1137,7 +1137,7 @@ const SyncError: React.FC<{ appStreamData: AppStreamData }> = ({ appStreamData }
                 )}
                 <DropDownIcon
                     style={{ marginLeft: 'auto', ['--rotateBy' as any]: `${180 * Number(!collapsed)}deg` }}
-                    className="icon-dim-24 rotate pointer"
+                    className="icon-dim-20 rotate pointer"
                     onClick={(e) => toggleCollapsed(not)}
                 />
             </div>

--- a/src/components/app/details/appDetails/AppMetrics.tsx
+++ b/src/components/app/details/appDetails/AppMetrics.tsx
@@ -4,7 +4,7 @@ import { getIframeSrc, ThroughputSelect, getCalendarValue, isK8sVersionValid, La
 import { ChartTypes, AppMetricsTab, AppMetricsTabType, ChartType, StatusTypes, StatusType, CalendarFocusInput, CalendarFocusInputType } from './appDetails.type';
 import { AppDetailsPathParams } from './appDetails.type';
 import { GraphModal } from './GraphsModal';
-import { DatePickerType2 as DateRangePicker, Progressing } from '../../../common';
+import { DatePickerType2 as DateRangePicker, Progressing, not } from '../../../common';
 import { ReactComponent as GraphIcon } from '../../../../assets/icons/ic-graph.svg';
 import { ReactComponent as Fullscreen } from '../../../../assets/icons/ic-fullscreen-2.svg';
 import { getAppComposeURL, APP_COMPOSE_STAGE, DOCUMENTATION, DEFAULTK8SVERSION } from '../../../../config';
@@ -17,6 +17,7 @@ import PrometheusErrorImage from '../../../../assets/img/ic-error-prometheus.png
 import HostErrorImage from '../../../../assets/img/ic-error-hosturl.png';
 import moment, { Moment } from 'moment';
 import Tippy from '@tippyjs/react';
+import { ReactComponent as DropDownIcon } from '../../../../assets/icons/appstatus/ic-chevron-down.svg';
 
 export const AppMetrics: React.FC<{ appName: string, environment, podMap: Map<string, any>, k8sVersion, addExtraSpace: boolean}> = ({ appName, environment, podMap, k8sVersion, addExtraSpace }) => {
     const { appMetrics, environmentName, infraMetrics } = environment;
@@ -353,14 +354,8 @@ function EnableAppMetrics() {
 }
 
 function AppMetricsEmptyState({ isLoading, isConfigured, isHealthy, hostURLConfig, addSpace }) {
-    if (isLoading) return <div className={`app-metrics-graph__empty-state-wrapper bcn-0 w-100 p-24 ${addSpace}`}>
-        <h4 className="fs-14 fw-6 cn-7 flex left mr-9">
-            <GraphIcon className="mr-8 fcn-7 icon-dim-20" />APPLICATION METRICS
-        </h4>
-        <div style={{ height: '240px' }}>
-            <Progressing pageLoader />
-        </div>
-    </div>
+    const [collapsed, toggleCollapsed] = useState<boolean>(true);
+
     let subtitle = '';
     if (!isConfigured) {
         subtitle = 'We could not connect to prometheus endpoint. Please configure data source and try reloading this page.';
@@ -368,24 +363,72 @@ function AppMetricsEmptyState({ isLoading, isConfigured, isHealthy, hostURLConfi
     else if (!isHealthy) {
         subtitle = 'Datasource configuration is incorrect or prometheus is not healthy. Please review configuration and try reloading this page.';
     }
-    return <div className={`app-metrics-graph__empty-state-wrapper bcn-0 w-100 p-24 ${addSpace}`}>
-        <h4 className="fs-14 fw-6 cn-7 flex left mr-9">
-            <GraphIcon className="mr-8 fcn-7 icon-dim-20" />APPLICATION METRICS
-        </h4>
-        <article className="app-metrics-graph__empty-state">
-            <img src={HostErrorImage} alt="" className="w-100" />
-            <div>
-                <p className="fw-6 fs-14 cn-9">Unable to show metrics due to insufficient/incorrect configurations</p>
-                {(!hostURLConfig || hostURLConfig.value !== window.location.origin) && <>
-                    <p className="fw-4 fs-12 cn-7 mt-16 mb-8">Host url is not configured or is incorrect. Reach out to your DevOps team (super-admin) to configure host url.</p>
-                    <Link to={`${URLS.GLOBAL_CONFIG_HOST_URL}`} className="cta small text" style={{ paddingLeft: "0" }}>Review and update</Link>
-                </>}
-                {(!isConfigured || !isHealthy) && <>
-                    <p className="fw-4 fs-12 cn-7 mt-16 mb-8">{subtitle}</p>
-                    <a className="learn-more__href cta small text pl-0" href={DOCUMENTATION.GLOBAL_CONFIG_CLUSTER} target="_blank" style={{ paddingLeft: "0" }}>See how to fix</a>
-                    <Link to={`${URLS.GLOBAL_CONFIG_CLUSTER}`} className="cta small text" style={{ paddingLeft: "0" }}>Review Configuration</Link>
-                </>}
+    return (
+        <div className={`app-metrics-graph__empty-state-wrapper bcn-0 w-100 pt-18 pb-18 pl-20 pr-20 ${addSpace}`}>
+            <div className='flex left w-100 lh-20'>
+            <span className="fs-14 fw-6 cn-7 flex left mr-16">
+                <GraphIcon className="mr-8 fcn-7 icon-dim-20" />
+                APPLICATION METRICS
+            </span>
+            {collapsed && !isLoading && (
+                    <span className="fw-4 fs-13 cn-7">
+                    Unable to show metrics due to insufficient/incorrect configurations
+                </span>)}
+            <DropDownIcon
+                    style={{ marginLeft: 'auto', ['--rotateBy' as any]: `${180 * Number(!collapsed)}deg` }}
+                    className="icon-dim-20 rotate pointer"
+                    onClick={(e) => toggleCollapsed(not)}
+                />
             </div>
-        </article>
-    </div>
+            {!collapsed && ( isLoading ? (
+                <div style={{ height: '240px' }}>
+                    <Progressing pageLoader />
+                </div>
+            ) : (
+                <article className="app-metrics-graph__empty-state">
+                    <img src={HostErrorImage} alt="" className="w-100" />
+                    <div>
+                        <p className="fw-6 fs-14 cn-9">
+                            Unable to show metrics due to insufficient/incorrect configurations
+                        </p>
+                        {(!hostURLConfig || hostURLConfig.value !== window.location.origin) && (
+                            <>
+                                <p className="fw-4 fs-12 cn-7 mt-16 mb-0">
+                                    Host url is not configured or is incorrect. Reach out to your DevOps team
+                                    (super-admin) to configure host url.
+                                </p>
+                                <Link
+                                    to={`${URLS.GLOBAL_CONFIG_HOST_URL}`}
+                                    className="cta small text"
+                                    style={{ paddingLeft: '0' }}
+                                >
+                                    Review and update
+                                </Link>
+                            </>
+                        )}
+                        {(!isConfigured || !isHealthy) && (
+                            <>
+                                <p className="fw-4 fs-12 cn-7 mt-16 mb-0">{subtitle}</p>
+                                <a
+                                    className="learn-more__href cta small text pl-0"
+                                    href={DOCUMENTATION.GLOBAL_CONFIG_CLUSTER}
+                                    target="_blank"
+                                    style={{ paddingLeft: '0' }}
+                                >
+                                    See how to fix
+                                </a>
+                                <Link
+                                    to={`${URLS.GLOBAL_CONFIG_CLUSTER}`}
+                                    className="cta small text"
+                                    style={{ paddingLeft: '0' }}
+                                >
+                                    Review Configuration
+                                </Link>
+                            </>
+                        )}
+                    </div>
+                </article>
+            ))}
+        </div>
+    )
 }

--- a/src/components/app/details/appDetails/AppMetrics.tsx
+++ b/src/components/app/details/appDetails/AppMetrics.tsx
@@ -365,70 +365,72 @@ function AppMetricsEmptyState({ isLoading, isConfigured, isHealthy, hostURLConfi
     }
     return (
         <div className={`app-metrics-graph__empty-state-wrapper bcn-0 w-100 pt-18 pb-18 pl-20 pr-20 ${addSpace}`}>
-            <div className='flex left w-100 lh-20'>
-            <span className="fs-14 fw-6 cn-7 flex left mr-16">
-                <GraphIcon className="mr-8 fcn-7 icon-dim-20" />
-                APPLICATION METRICS
-            </span>
-            {collapsed && !isLoading && (
+            <div className="flex left w-100 lh-20">
+                <span className="fs-14 fw-6 cn-7 flex left mr-16">
+                    <GraphIcon className="mr-8 fcn-7 icon-dim-20" />
+                    APPLICATION METRICS
+                </span>
+                {collapsed && !isLoading && (
                     <span className="fw-4 fs-13 cn-7">
-                    Unable to show metrics due to insufficient/incorrect configurations
-                </span>)}
-            <DropDownIcon
+                        Unable to show metrics due to insufficient/incorrect configurations
+                    </span>
+                )}
+                <DropDownIcon
                     style={{ marginLeft: 'auto', ['--rotateBy' as any]: `${180 * Number(!collapsed)}deg` }}
                     className="icon-dim-20 rotate pointer"
                     onClick={(e) => toggleCollapsed(not)}
                 />
             </div>
-            {!collapsed && ( isLoading ? (
-                <div style={{ height: '240px' }}>
-                    <Progressing pageLoader />
-                </div>
-            ) : (
-                <article className="app-metrics-graph__empty-state">
-                    <img src={HostErrorImage} alt="" className="w-100" />
-                    <div>
-                        <p className="fw-6 fs-14 cn-9">
-                            Unable to show metrics due to insufficient/incorrect configurations
-                        </p>
-                        {(!hostURLConfig || hostURLConfig.value !== window.location.origin) && (
-                            <>
-                                <p className="fw-4 fs-12 cn-7 mt-16 mb-0">
-                                    Host url is not configured or is incorrect. Reach out to your DevOps team
-                                    (super-admin) to configure host url.
-                                </p>
-                                <Link
-                                    to={`${URLS.GLOBAL_CONFIG_HOST_URL}`}
-                                    className="cta small text"
-                                    style={{ paddingLeft: '0' }}
-                                >
-                                    Review and update
-                                </Link>
-                            </>
-                        )}
-                        {(!isConfigured || !isHealthy) && (
-                            <>
-                                <p className="fw-4 fs-12 cn-7 mt-16 mb-0">{subtitle}</p>
-                                <a
-                                    className="learn-more__href cta small text pl-0"
-                                    href={DOCUMENTATION.GLOBAL_CONFIG_CLUSTER}
-                                    target="_blank"
-                                    style={{ paddingLeft: '0' }}
-                                >
-                                    See how to fix
-                                </a>
-                                <Link
-                                    to={`${URLS.GLOBAL_CONFIG_CLUSTER}`}
-                                    className="cta small text"
-                                    style={{ paddingLeft: '0' }}
-                                >
-                                    Review Configuration
-                                </Link>
-                            </>
-                        )}
+            {!collapsed &&
+                (isLoading ? (
+                    <div style={{ height: '240px' }}>
+                        <Progressing pageLoader />
                     </div>
-                </article>
-            ))}
+                ) : (
+                    <article className="app-metrics-graph__empty-state">
+                        <img src={HostErrorImage} alt="error" className="w-100" />
+                        <div>
+                            <p className="fw-6 fs-14 cn-9">
+                                Unable to show metrics due to insufficient/incorrect configurations
+                            </p>
+                            {(!hostURLConfig || hostURLConfig.value !== window.location.origin) && (
+                                <>
+                                    <p className="fw-4 fs-12 cn-7 mt-16 mb-0">
+                                        Host url is not configured or is incorrect. Reach out to your DevOps team
+                                        (super-admin) to configure host url.
+                                    </p>
+                                    <Link
+                                        to={URLS.GLOBAL_CONFIG_HOST_URL}
+                                        className="cta small text"
+                                        style={{ paddingLeft: '0' }}
+                                    >
+                                        Review and update
+                                    </Link>
+                                </>
+                            )}
+                            {(!isConfigured || !isHealthy) && (
+                                <>
+                                    <p className="fw-4 fs-12 cn-7 mt-16 mb-0">{subtitle}</p>
+                                    <a
+                                        className="learn-more__href cta small text pl-0"
+                                        href={DOCUMENTATION.GLOBAL_CONFIG_CLUSTER}
+                                        target="_blank"
+                                        style={{ paddingLeft: '0' }}
+                                    >
+                                        See how to fix
+                                    </a>
+                                    <Link
+                                        to={URLS.GLOBAL_CONFIG_CLUSTER}
+                                        className="cta small text"
+                                        style={{ paddingLeft: '0' }}
+                                    >
+                                        Review Configuration
+                                    </Link>
+                                </>
+                            )}
+                        </div>
+                    </article>
+                ))}
         </div>
     )
 }

--- a/src/components/app/details/cIDetails/CIDetails.tsx
+++ b/src/components/app/details/cIDetails/CIDetails.tsx
@@ -111,6 +111,7 @@ export default function CIDetails() {
     const [hasMore, setHasMore] = useState<boolean>(false)
     const [triggerHistory, setTriggerHistory] = useState<Map<number, History>>(new Map())
     const [fullScreenView, setFullScreenView] = useState<boolean>(false)
+    const [hasMoreLoading,setHasMoreLoading] = useState<boolean>(false)
     const [pipelinesLoading, result, pipelinesError] = useAsync(() => getCIPipelines(+appId), [appId])
     const [loading, triggerHistoryResult, triggerHistoryError, reloadTriggerHistory, , dependencyState] = useAsync(
         () => getTriggerHistory(+pipelineId, pagination),
@@ -122,7 +123,7 @@ export default function CIDetails() {
     useInterval(pollHistory, 30000)
     const [ref, scrollToTop, scrollToBottom] = useScrollable({ autoBottomScroll: true })
 
-    useEffect(() => {
+    useEffect(() => {     
         if (loading || !triggerHistoryResult) {
             setTriggerHistory(new Map())
         }
@@ -130,6 +131,7 @@ export default function CIDetails() {
             setHasMore(false)
         } else {
             setHasMore(true)
+            setHasMoreLoading(true)
         }
         const newTriggerHistory = (triggerHistoryResult?.result || []).reduce((agg, curr) => {
             agg.set(curr.id, curr)
@@ -170,8 +172,8 @@ export default function CIDetails() {
         }
         setTriggerHistory(mapByKey(result?.result || [], 'id'))
     }
-
-    if (loading || pipelinesLoading) return <Progressing pageLoader />
+    
+    if ((!hasMoreLoading && loading) || pipelinesLoading) return <Progressing pageLoader />
     const pipelines: CIPipeline[] = (result?.result || [])?.filter((pipeline) => pipeline.pipelineType !== 'EXTERNAL') // external pipelines not visible in dropdown
     const pipelinesMap = mapByKey(pipelines, 'id')
     const pipeline = pipelinesMap.get(+pipelineId)
@@ -261,7 +263,7 @@ export function DetectBottom({ callback }) {
         }
     }, [intersected])
 
-    return <span ref={target}></span>
+    return <span className='pb-5' ref={target}></span>
 }
 
 export const BuildCard: React.FC<{ triggerDetails: History }> = React.memo(({ triggerDetails }) => {

--- a/src/components/app/details/cdDetails/CDDetails.tsx
+++ b/src/components/app/details/cdDetails/CDDetails.tsx
@@ -290,6 +290,8 @@ const DeploymentCard: React.FC<{
     triggerDetails: History
 }> = ({ triggerDetails }) => {
     const { path } = useRouteMatch()
+    const { pathname } = useLocation()
+    const currentTab = pathname.split('/').pop()    
     const { triggerId, ...rest } = useParams<{ triggerId: string }>()
     return (
         <ConditionalWrap
@@ -305,7 +307,7 @@ const DeploymentCard: React.FC<{
             )}
         >
             <NavLink
-                to={generatePath(path, { ...rest, triggerId: triggerDetails.id })}
+                to={generatePath(path, { ...rest, triggerId: triggerDetails.id }) + "/" + currentTab}
                 className="w-100 ci-details__build-card"
                 activeClassName="active"
             >

--- a/src/components/app/details/cdDetails/deploymentHistoryDiff/DeploymentHistoryConfigList.component.tsx
+++ b/src/components/app/details/cdDetails/deploymentHistoryDiff/DeploymentHistoryConfigList.component.tsx
@@ -6,6 +6,7 @@ import { DeploymentHistoryParamsType, DeploymentTemplateList } from '../cd.type'
 import { getDeploymentHistoryList } from '../service'
 import { DEPLOYMENT_HISTORY_CONFIGURATION_LIST_MAP } from '../../../../../config'
 import CDEmptyState from '../CDEmptyState'
+import { Progressing } from '../../../../common'
 
 interface TemplateConfiguration {
     setShowTemplate: (boolean) => void
@@ -55,6 +56,8 @@ export default function DeploymentHistoryConfigList({
         <>
             {!deploymentHistoryList && !deploymentListLoader ? (
                 <CDEmptyState />
+            ) : deploymentListLoader ? (
+                <Progressing pageLoader />
             ) : (
                 deploymentHistoryList &&
                 deploymentHistoryList.map((historicalComponent, index) => {


### PR DESCRIPTION
# Description

1. If application metrics not available then the card should be in a collapsed state
2. Build history: Page reloads when scrolling to bottom of build history list
3. Tab selection should retain the selection & No loader present when loading tab in deployment history

Fixes - https://github.com/devtron-labs/devtron/issues/2039, https://github.com/devtron-labs/devtron/issues/2040, https://github.com/devtron-labs/devtron/issues/2042

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


