### PR TITLE
Added confirmation popup on release notes

### DIFF
--- a/src/assets/icons/ic-note.svg
+++ b/src/assets/icons/ic-note.svg
@@ -1,0 +1,7 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.5 7.5H12.5" stroke="#596168" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.5 10H12.5" stroke="#596168" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.5 12.5H10" stroke="#596168" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.2411 16.875H3.75C3.58424 16.875 3.42527 16.8092 3.30806 16.6919C3.19085 16.5747 3.125 16.4158 3.125 16.25V3.75C3.125 3.58424 3.19085 3.42527 3.30806 3.30806C3.42527 3.19085 3.58424 3.125 3.75 3.125H16.25C16.4158 3.125 16.5747 3.19085 16.6919 3.30806C16.8092 3.42527 16.875 3.58424 16.875 3.75V12.2411C16.875 12.3232 16.8588 12.4045 16.8274 12.4803C16.796 12.5561 16.75 12.625 16.6919 12.6831L12.6831 16.6919C12.625 16.75 12.5561 16.796 12.4803 16.8274C12.4045 16.8588 12.3232 16.875 12.2411 16.875V16.875Z" stroke="#596168" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.8184 12.4994H12.5V16.8181" stroke="#596168" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/v2/devtronStackManager/AboutDevtronView.scss
+++ b/src/components/v2/devtronStackManager/AboutDevtronView.scss
@@ -82,3 +82,13 @@
         }
     }
 }
+
+.pre-requisite-mark-down {
+    padding: 0;
+    blockquote {
+        padding: 0;
+        margin: 0;
+        font-size: 13px;
+        border: none;
+    }
+}

--- a/src/components/v2/devtronStackManager/AboutDevtronView.scss
+++ b/src/components/v2/devtronStackManager/AboutDevtronView.scss
@@ -83,12 +83,24 @@
     }
 }
 
-.pre-requisite-mark-down {
+.pre-requisite-modal__mark-down {
     padding: 0;
     blockquote {
         padding: 0;
         margin: 0;
         font-size: 13px;
         border: none;
+    }
+}
+
+.pre-requisite-modal__help-chat {
+    svg {
+        path:first-of-type {
+            stroke: var(--B500);
+        }
+
+        path:not(:first-of-type) {
+            fill: var(--B500);
+        }
     }
 }

--- a/src/components/v2/devtronStackManager/AboutDevtronView.tsx
+++ b/src/components/v2/devtronStackManager/AboutDevtronView.tsx
@@ -17,6 +17,10 @@ function AboutDevtronView({
     selectedTabIndex,
     isActionTriggered,
     handleActionTrigger,
+    showPreRequisiteConfirmationModal,
+    setShowPreRequisiteConfirmationModal,
+    preRequisiteChecked,
+    setPreRequisiteChecked,
 }: AboutDevtronViewType) {
     const aboutDevtronTabs: { name: string; link: string }[] = [
         { name: 'About', link: URLS.STACK_MANAGER_ABOUT },
@@ -119,9 +123,14 @@ function AboutDevtronView({
                         serverInfo={serverInfo}
                         upgradeVersion={releaseNotes[0]?.releaseName}
                         isActionTriggered={isActionTriggered}
+                        releaseNotes={releaseNotes}
                         updateActionTrigger={(isActionTriggered) =>
                             handleActionTrigger('serverAction', isActionTriggered)
                         }
+                        showPreRequisiteConfirmationModal={showPreRequisiteConfirmationModal}
+                        setShowPreRequisiteConfirmationModal={setShowPreRequisiteConfirmationModal}
+                        preRequisiteChecked={preRequisiteChecked}
+                        setPreRequisiteChecked={setPreRequisiteChecked}
                     />
                 )}
             </div>

--- a/src/components/v2/devtronStackManager/DevtronStackManager.component.tsx
+++ b/src/components/v2/devtronStackManager/DevtronStackManager.component.tsx
@@ -444,23 +444,27 @@ export const InstallationWrapper = ({
     >([])
     useEffect(() => {
         if (releaseNotes) {
-            const _preRequisiteList = []
-            for (let index = 0; index < releaseNotes.length; index++) {
-                const element = releaseNotes[index]
-                if (serverInfo && serverInfo.currentVersion === element.releaseName) {
-                    break
-                }
-                if (element.prerequisite && element.prerequisiteMessage) {
-                    _preRequisiteList.push({
-                        version: element.releaseName,
-                        prerequisiteMessage: element.prerequisiteMessage,
-                        tagLink: element.tagLink,
-                    })
-                }
-            }
-            setPreRequisiteList(_preRequisiteList.reverse())
+            fetchPreRequisiteListFromReleaseNotes()
         }
     }, [releaseNotes])
+
+    const fetchPreRequisiteListFromReleaseNotes = () => {
+        const _preRequisiteList = []
+        for (let index = 0; index < releaseNotes.length; index++) {
+            const element = releaseNotes[index]
+            if (element.releaseName === serverInfo?.currentVersion) {
+                break
+            }
+            if (element.prerequisite && element.prerequisiteMessage) {
+                _preRequisiteList.push({
+                    version: element.releaseName,
+                    prerequisiteMessage: element.prerequisiteMessage,
+                    tagLink: element.tagLink,
+                })
+            }
+        }
+        setPreRequisiteList(_preRequisiteList.reverse())
+    }
 
     const handleActionButtonClick = () => {
         if (isActionTriggered) {
@@ -480,7 +484,11 @@ export const InstallationWrapper = ({
         setPreRequisiteChecked(!preRequisiteChecked)
     }
 
-    const renderConfirmationModal = (): JSX.Element | null => {
+    const hidePrerequisiteConfirmationModal = (): void => {
+        setShowPreRequisiteConfirmationModal(false)
+    }
+
+    const renderPrerequisiteConfirmationModal = (): JSX.Element | null => {
         if (!showPreRequisiteConfirmationModal) return null
         return (
             <VisibleModal className="transition-effect">
@@ -489,10 +497,7 @@ export const InstallationWrapper = ({
                         <div className="fw-6 fs-16 cn-9">
                             {`Pre-requisites for update to ${upgradeVersion.toLowerCase()}`}
                         </div>
-                        <CloseIcon
-                            className="pointer mt-2"
-                            onClick={() => setShowPreRequisiteConfirmationModal(false)}
-                        />
+                        <CloseIcon className="pointer mt-2" onClick={hidePrerequisiteConfirmationModal} />
                     </div>
                     <div className="p-20">
                         <div className="fw-6 fs-13 cn-9 mb-12">
@@ -635,7 +640,7 @@ export const InstallationWrapper = ({
                                 installationStatus === ModuleStatus.TIMEOUT ||
                                 installationStatus === ModuleStatus.UNKNOWN))) && <GetHelpCard />}
             </div>
-            {renderConfirmationModal()}
+            {renderPrerequisiteConfirmationModal()}
         </>
     )
 }

--- a/src/components/v2/devtronStackManager/DevtronStackManager.component.tsx
+++ b/src/components/v2/devtronStackManager/DevtronStackManager.component.tsx
@@ -504,7 +504,7 @@ export const InstallationWrapper = ({
                             <div className="fw-4 fs-13 cn-7 mb-12">
                                 <div>Pre-requisites for {preRequisite.version}:</div>
                                 <MarkDown
-                                    className="pre-requisite-mark-down"
+                                    className="pre-requisite-modal__mark-down"
                                     breaks={true}
                                     markdown={preRequisite.prerequisiteMessage}
                                 />
@@ -516,7 +516,7 @@ export const InstallationWrapper = ({
                         <div className="en-2 bw-1 flexbox content-space pt-8 pr-12 pb-8 pl-12 br-4">
                             <span className="cn-9 fs-13 fw-6">Facing issues?</span>
                             <a
-                                className="module-details__help-chat cb-5 flex left"
+                                className="pre-requisite-modal__help-chat fs-13 cb-5 flex left"
                                 href="https://discord.devtron.ai/"
                                 target="_blank"
                                 rel="noreferrer noopener"

--- a/src/components/v2/devtronStackManager/DevtronStackManager.component.tsx
+++ b/src/components/v2/devtronStackManager/DevtronStackManager.component.tsx
@@ -20,13 +20,11 @@ import { ReactComponent as InstallIcon } from '../../../assets/icons/ic-arrow-fo
 import { ReactComponent as RetyrInstallIcon } from '../../../assets/icons/ic-arrow-clockwise.svg'
 import { ReactComponent as SuccessIcon } from '../../../assets/icons/appstatus/healthy.svg'
 import { ReactComponent as UpToDateIcon } from '../../../assets/icons/ic-celebration.svg'
-import { ReactComponent as File } from '../../../assets/icons/ic-file-text.svg'
 import { ReactComponent as Chat } from '../../../assets/icons/ic-chat-circle-dots.svg'
 import { ReactComponent as Info } from '../../../assets/icons/info-filled.svg'
 import { ReactComponent as Warning } from '../../../assets/icons/ic-warning.svg'
 import { ReactComponent as Note } from '../../../assets/icons/ic-note.svg'
 import { ReactComponent as CloseIcon } from '../../../assets/icons/ic-close.svg'
-
 import { Checkbox, CHECKBOX_VALUE, Progressing, showError, ToastBody, VisibleModal } from '../../common'
 import NoIntegrations from '../../../assets/img/empty-noresult@2x.png'
 import LatestVersionCelebration from '../../../assets/gif/latest-version-celebration.gif'

--- a/src/components/v2/devtronStackManager/DevtronStackManager.component.tsx
+++ b/src/components/v2/devtronStackManager/DevtronStackManager.component.tsx
@@ -513,6 +513,17 @@ export const InstallationWrapper = ({
                                 </a>
                             </div>
                         ))}
+                        <div className="en-2 bw-1 flexbox content-space pt-8 pr-12 pb-8 pl-12 br-4">
+                            <span className="cn-9 fs-13 fw-6">Facing issues?</span>
+                            <a
+                                className="module-details__help-chat cb-5 flex left"
+                                href="https://discord.devtron.ai/"
+                                target="_blank"
+                                rel="noreferrer noopener"
+                            >
+                                <Chat className="icon-dim-20 mr-12" /> Chat with support
+                            </a>
+                        </div>
                     </div>
                     <div className="p-16 border-top flexbox content-space">
                         <Checkbox

--- a/src/components/v2/devtronStackManager/DevtronStackManager.component.tsx
+++ b/src/components/v2/devtronStackManager/DevtronStackManager.component.tsx
@@ -486,6 +486,7 @@ export const InstallationWrapper = ({
 
     const hidePrerequisiteConfirmationModal = (): void => {
         setShowPreRequisiteConfirmationModal(false)
+        setPreRequisiteChecked(false)
     }
 
     const renderPrerequisiteConfirmationModal = (): JSX.Element | null => {

--- a/src/components/v2/devtronStackManager/DevtronStackManager.tsx
+++ b/src/components/v2/devtronStackManager/DevtronStackManager.tsx
@@ -64,6 +64,8 @@ export default function DevtronStackManager({
     const stackManagerRef = useRef<HTMLElement>()
     const queryParams = new URLSearchParams(location.search)
 
+    const [showPreRequisiteConfirmationModal, setShowPreRequisiteConfirmationModal] = useState<boolean>(false)
+    const [preRequisiteChecked, setPreRequisiteChecked] = useState<boolean>(false)
     useEffect(() => {
         getModuleDetails()
     }, [])
@@ -393,6 +395,10 @@ export default function DevtronStackManager({
                         handleTabChange={handleTabChange}
                         isActionTriggered={actionTriggered.serverAction}
                         handleActionTrigger={handleActionTrigger}
+                        showPreRequisiteConfirmationModal={showPreRequisiteConfirmationModal}
+                        setShowPreRequisiteConfirmationModal={setShowPreRequisiteConfirmationModal}
+                        preRequisiteChecked={preRequisiteChecked}
+                        setPreRequisiteChecked={setPreRequisiteChecked}
                     />
                 </Route>
                 <Route path={URLS.STACK_MANAGER_ABOUT_RELEASES}>
@@ -406,6 +412,10 @@ export default function DevtronStackManager({
                         handleTabChange={handleTabChange}
                         isActionTriggered={actionTriggered.serverAction}
                         handleActionTrigger={handleActionTrigger}
+                        showPreRequisiteConfirmationModal={showPreRequisiteConfirmationModal}
+                        setShowPreRequisiteConfirmationModal={setShowPreRequisiteConfirmationModal}
+                        preRequisiteChecked={preRequisiteChecked}
+                        setPreRequisiteChecked={setPreRequisiteChecked}
                     />
                 </Route>
                 <Redirect to={URLS.STACK_MANAGER_DISCOVER_MODULES} />

--- a/src/components/v2/devtronStackManager/DevtronStackManager.type.ts
+++ b/src/components/v2/devtronStackManager/DevtronStackManager.type.ts
@@ -23,7 +23,7 @@ export enum ModuleActions {
 export enum InstallationType {
     OSS_KUBECTL = 'oss_kubectl',
     OSS_HELM = 'oss_helm',
-    ENTERPRISE = 'enterprise'
+    ENTERPRISE = 'enterprise',
 }
 
 export interface StackDetailsType {
@@ -106,7 +106,12 @@ export interface InstallationWrapperType {
     upgradeVersion: string
     isUpgradeView?: boolean
     isActionTriggered: boolean
+    releaseNotes?: ReleaseNotes[]
     updateActionTrigger: (isActionTriggered: boolean) => void
+    showPreRequisiteConfirmationModal?: boolean
+    setShowPreRequisiteConfirmationModal?: React.Dispatch<React.SetStateAction<boolean>>
+    preRequisiteChecked?: boolean
+    setPreRequisiteChecked?: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export interface ModuleDetailsInfo {
@@ -132,6 +137,10 @@ export interface AboutDevtronViewType {
     selectedTabIndex: number
     isActionTriggered: boolean
     handleActionTrigger: (actionName: string, actionState: boolean) => void
+    showPreRequisiteConfirmationModal?: boolean
+    setShowPreRequisiteConfirmationModal?: React.Dispatch<React.SetStateAction<boolean>>
+    preRequisiteChecked?: boolean
+    setPreRequisiteChecked?: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export interface ModuleInfo {
@@ -174,6 +183,9 @@ export interface ReleaseNotes {
     createdAt: string
     publishedAt: string
     body: string
+    prerequisite: boolean
+    prerequisiteMessage: string
+    tagLink: string
 }
 
 export interface ReleaseNotesResponse extends ResponseType {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -178,7 +178,7 @@ export const AppConfigStatus = {
 
 export const FullRoutes = {
     LOGIN: `${Routes.LOGIN}`,
-    CENTRAL: 'https://api.devtron.ai',
+    CENTRAL: 'https://api-stage.devtron.ai',
 }
 
 export const PATTERNS = {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -178,7 +178,7 @@ export const AppConfigStatus = {
 
 export const FullRoutes = {
     LOGIN: `${Routes.LOGIN}`,
-    CENTRAL: 'https://api-stage.devtron.ai',
+    CENTRAL: 'https://api.devtron.ai',
 }
 
 export const PATTERNS = {


### PR DESCRIPTION
# Description

Show Prerequisite modal before upgrade to new version, So that it is upfront visible to the user and don't get overlooked
* Show a prerequisite box separately below the install button
* Show a prerequisite modal on click of install button
* Proceed further only when user provides confirmation

Fixes # [(issue)](https://github.com/devtron-labs/dashboard/issues/450)
<img width="907" alt="Screenshot 2022-07-26 at 6 04 57 PM" src="https://user-images.githubusercontent.com/95338474/181007115-50373208-1c82-4dcd-850c-fc5fd4209cf4.png">
<img width="887" alt="Screenshot 2022-07-26 at 6 05 05 PM" src="https://user-images.githubusercontent.com/95338474/181007138-e39a826d-6924-4a7f-b7f7-0f5653465696.png">
<img width="893" alt="Screenshot 2022-07-26 at 6 05 20 PM" src="https://user-images.githubusercontent.com/95338474/181007142-f6b6a210-f1b0-4d53-8107-db38c7d854d0.png">

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Manually tested


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


