### PR TITLE
Fix - NaN is being passed issue

### DIFF
--- a/src/components/userGroups/AppPermissions.tsx
+++ b/src/components/userGroups/AppPermissions.tsx
@@ -180,7 +180,7 @@ export default function AppPermissions({
                 const projectId =
                     serverMode !== SERVER_MODE.EA_ONLY &&
                     directRolefilter.team !== HELM_APP_UNASSIGNED_PROJECT &&
-                    projectsMap.get(directRolefilter.team).id
+                    projectsMap.get(directRolefilter.team)?.id
                 if (!directRolefilter['accessType']) {
                     directRolefilter['accessType'] = ACCESS_TYPE_MAP.DEVTRON_APPS
                 }

--- a/src/components/userGroups/AppPermissions.tsx
+++ b/src/components/userGroups/AppPermissions.tsx
@@ -156,10 +156,12 @@ export default function AppPermissions({
             roleFilters.forEach((element) => {
                 if (element.entity === EntityTypes.DIRECT) {
                     const projectId = projectsMap.get(element.team)?.id
-                    if (!element['accessType']) {
-                        uniqueProjectIdsDevtronApps.push(projectId)
-                    } else if (element['accessType'] === ACCESS_TYPE_MAP.HELM_APPS) {
-                        projectId && uniqueProjectIdsHelmApps.push(projectId)
+                    if (typeof projectId !== 'undefined' && projectId != null) {
+                        if (!element['accessType']) {
+                            uniqueProjectIdsDevtronApps.push(projectId)
+                        } else if (element['accessType'] === ACCESS_TYPE_MAP.HELM_APPS) {
+                            uniqueProjectIdsHelmApps.push(projectId)
+                        }
                     }
                 }
             })

--- a/src/components/userGroups/UserGroup.tsx
+++ b/src/components/userGroups/UserGroup.tsx
@@ -886,7 +886,7 @@ export const DirectPermission: React.FC<DirectPermissionRow> = ({
                 options={(serverMode === SERVER_MODE.EA_ONLY
                     ? [{ name: HELM_APP_UNASSIGNED_PROJECT }]
                     : permission.accessType === ACCESS_TYPE_MAP.HELM_APPS
-                    ? [{ name: HELM_APP_UNASSIGNED_PROJECT }, ...projectsList]
+                    ? [{ name: HELM_APP_UNASSIGNED_PROJECT }, ...(projectsList || [])]
                     : projectsList
                 )?.map((project) => ({ label: project.name, value: project.name }))}
                 className="basic-multi-select"

--- a/src/components/userGroups/UserGroup.tsx
+++ b/src/components/userGroups/UserGroup.tsx
@@ -647,7 +647,7 @@ export const DirectPermission: React.FC<DirectPermissionRow> = ({
     const { environmentsList, projectsList, appsList, envClustersList, appsListHelmApps } = useUserGroupContext()
     const projectId =
         permission.team && serverMode !== SERVER_MODE.EA_ONLY && permission.team.value !== HELM_APP_UNASSIGNED_PROJECT
-            ? projectsList.find((project) => project.name === permission.team.value).id
+            ? projectsList.find((project) => project.name === permission.team.value)?.id
             : null
     const possibleRoles = [ActionTypes.VIEW, ActionTypes.TRIGGER, ActionTypes.ADMIN, ActionTypes.MANAGER]
     const possibleRolesHelmApps = [ActionTypes.VIEW, ActionTypes.EDIT, ActionTypes.ADMIN]


### PR DESCRIPTION
# Description

These changes will address the issue where on the user permissions page, when a logged-in user doesn't have access to a certain project (E.g. dev-test) and tries to access a specific user who has access to it then NaN is being passed as teamId to the API causing the API to fail & isn't loading the projects/permissions list.

Fixes https://github.com/devtron-labs/devtron/issues/2142

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been performed manually. The following are the steps,

1. Go to User Permissions on Global Configurations
2. Try to access another user which has access to a certain project but you (logged in) don't.
3. Open the network tab under developer tools
4. Observe

**Expected:**  It should not pass NaN as teamId to API & load the projects that the logged-in user has access to.

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


