### PR TITLE
Added toast for gmail | Fixed delete popup remain after deletion

### DIFF
--- a/src/components/cluster/Cluster.tsx
+++ b/src/components/cluster/Cluster.tsx
@@ -843,6 +843,11 @@ function Environment({
         }
     }
 
+    const clusterDelete = (): void => {
+        setDeleting(true)
+        handleClose(false)
+    }
+
     return (
         <VisibleModal className="environment-create-modal" close={handleClose}>
             <form className="environment-create-body" onClick={(e) => e.stopPropagation()} onSubmit={handleOnSubmit}>
@@ -937,7 +942,7 @@ function Environment({
                 </div>
                 {confirmation && (
                     <DeleteComponent
-                        setDeleting={setDeleting}
+                        setDeleting={clusterDelete}
                         deleteComponent={deleteEnvironment}
                         payload={getEnvironmentPayload()}
                         title={state.environment_name.value}

--- a/src/components/userGroups/User.tsx
+++ b/src/components/userGroups/User.tsx
@@ -94,7 +94,7 @@ export default function UserForm({
     function validateForm(): boolean {
         if (emailState.emails.length === 0) {
             setEmailState((emailState) => ({ ...emailState, emailError: 'Emails are mandatory.' }));
-            toast.warning('Emails are mandatory.')
+            toast.error('Some required fields are missing')
             return false;
         }
 

--- a/src/components/userGroups/User.tsx
+++ b/src/components/userGroups/User.tsx
@@ -29,6 +29,7 @@ import './UserGroup.scss';
 import AppPermissions from './AppPermissions';
 import { ACCESS_TYPE_MAP, SERVER_MODE } from '../../config';
 import { mainContext } from '../common/navigation/NavigationRoutes';
+import { ReactComponent as Error } from '../../assets/icons/ic-warning.svg'
 
 const CreatableChipStyle = {
     multiValue: (base, state) => {
@@ -93,6 +94,7 @@ export default function UserForm({
     function validateForm(): boolean {
         if (emailState.emails.length === 0) {
             setEmailState((emailState) => ({ ...emailState, emailError: 'Emails are mandatory.' }));
+            toast.warning('Emails are mandatory.')
             return false;
         }
 
@@ -336,7 +338,12 @@ export default function UserForm({
                         onKeyDown={handleKeyDown}
                         onChange={handleEmailChange}
                     />
-                    {emailState.emailError && <label className="form__error">{emailState.emailError}</label>}
+                    {emailState.emailError && (
+                        <label className="form__error">
+                            <Error className="form__icon form__icon--error" />
+                            {emailState.emailError}
+                        </label>
+                    )}
                 </div>
             )}
             {superAdmin && <SuperAdmin superAdmin={localSuperAdmin} setSuperAdmin={setSuperAdmin} />}


### PR DESCRIPTION
# Description

1. Toast when the user forgot to submit an email in user permission
2. Close the delete popup modal when the user delete the cluster

Fixes - https://github.com/devtron-labs/devtron/issues/2115, https://github.com/devtron-labs/devtron/issues/2116

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Testing has been done manually

- [x] In User permission, toast when user save id without entering email id
- [x] In cluster & environment,  delete popup when user delete cluster 


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


