### PR TITLE
Fixed UI bug in app metrics | Fixed width bug in app details error

### DIFF
--- a/src/components/app/details/appDetails/AppDetails.tsx
+++ b/src/components/app/details/appDetails/AppDetails.tsx
@@ -107,7 +107,7 @@ export default function AppDetail() {
     return (
         <div className="app-details-page-wrapper">
                 {!params.envId && otherEnvsResult?.result?.length > 0 && (
-                    <div className="w-100 pt-16 pr-24 pb-20 pl-24">
+                    <div className="w-100 pt-16 pr-20 pb-20 pl-20">
                         <SourceInfo
                             appDetails={null}
                             environments={otherEnvsResult?.result}
@@ -333,7 +333,7 @@ export const Details: React.FC<{
     }
 
     return <React.Fragment>
-         <div className="w-100 pt-16 pr-24 pb-20 pl-24">
+         <div className="w-100 pt-16 pr-20 pb-20 pl-20">
                         <SourceInfo
                             appDetails={appDetails}
                             setDetailed={toggleDetailedStatus}

--- a/src/components/app/details/appDetails/AppMetrics.tsx
+++ b/src/components/app/details/appDetails/AppMetrics.tsx
@@ -300,7 +300,7 @@ export const AppMetrics: React.FC<{ appName: string, environment, podMap: Map<st
                     <div className={`app-metrics-graph chart`}>
                         <div className="app-metrics-graph__title flexbox flex-justify">
                             <div className='flexbox'>
-                                <h3 className="app-details-graph__title flexbox mt-0 ml-0 mb-0 mr-5">Latency</h3>
+                                <h3 className="app-details-graph__title flexbox m-0">Latency</h3>
                                 <h3 className="app-details-graph__title flexbox m-0">
                                     <LatencySelect latency={selectedLatency} handleLatencyChange={handleLatencyChange} />
                                 </h3>

--- a/src/components/app/details/appDetails/AppMetrics.tsx
+++ b/src/components/app/details/appDetails/AppMetrics.tsx
@@ -300,7 +300,7 @@ export const AppMetrics: React.FC<{ appName: string, environment, podMap: Map<st
                     <div className={`app-metrics-graph chart`}>
                         <div className="app-metrics-graph__title flexbox flex-justify">
                             <div className='flexbox'>
-                                <h3 className="app-details-graph__title flexbox m-0">Latency</h3>
+                                <h3 className="app-details-graph__title flexbox m-0 pr-5">Latency</h3>
                                 <h3 className="app-details-graph__title flexbox m-0">
                                     <LatencySelect latency={selectedLatency} handleLatencyChange={handleLatencyChange} />
                                 </h3>

--- a/src/components/app/details/appDetails/AppMetrics.tsx
+++ b/src/components/app/details/appDetails/AppMetrics.tsx
@@ -300,7 +300,7 @@ export const AppMetrics: React.FC<{ appName: string, environment, podMap: Map<st
                     <div className={`app-metrics-graph chart`}>
                         <div className="app-metrics-graph__title flexbox flex-justify">
                             <div className='flexbox'>
-                                <h3 className="app-details-graph__title flexbox m-0 pr-5">Latency</h3>
+                                <h3 className="app-details-graph__title flexbox m-0 pr-4">Latency</h3>
                                 <h3 className="app-details-graph__title flexbox m-0">
                                     <LatencySelect latency={selectedLatency} handleLatencyChange={handleLatencyChange} />
                                 </h3>

--- a/src/components/app/details/appDetails/AppMetrics.tsx
+++ b/src/components/app/details/appDetails/AppMetrics.tsx
@@ -300,7 +300,7 @@ export const AppMetrics: React.FC<{ appName: string, environment, podMap: Map<st
                     <div className={`app-metrics-graph chart`}>
                         <div className="app-metrics-graph__title flexbox flex-justify">
                             <div className='flexbox'>
-                                <h3 className="app-details-graph__title flexbox m-0 mr-5">Latency</h3>
+                                <h3 className="app-details-graph__title flexbox mt-0 ml-0 mb-0 mr-5">Latency</h3>
                                 <h3 className="app-details-graph__title flexbox m-0">
                                     <LatencySelect latency={selectedLatency} handleLatencyChange={handleLatencyChange} />
                                 </h3>

--- a/src/components/app/details/appDetails/AppMetrics.tsx
+++ b/src/components/app/details/appDetails/AppMetrics.tsx
@@ -300,7 +300,7 @@ export const AppMetrics: React.FC<{ appName: string, environment, podMap: Map<st
                     <div className={`app-metrics-graph chart`}>
                         <div className="app-metrics-graph__title flexbox flex-justify">
                             <div className='flexbox'>
-                                <h3 className="app-details-graph__title flexbox m-0">Latency</h3>
+                                <h3 className="app-details-graph__title flexbox m-0 mr-5">Latency</h3>
                                 <h3 className="app-details-graph__title flexbox m-0">
                                     <LatencySelect latency={selectedLatency} handleLatencyChange={handleLatencyChange} />
                                 </h3>

--- a/src/components/app/details/appDetails/SourceInfo.tsx
+++ b/src/components/app/details/appDetails/SourceInfo.tsx
@@ -66,7 +66,10 @@ export function SourceInfo({ appDetails, setDetailed = null, environments, showC
                                     className={`fa fa-angle-right fw-6 fs-14 app-summary__status-name f-${status.toLowerCase()}`}
                                 ></span>
                             </div>
-                            {message && <span className="ellipsis-right w-100">{message}</span>}
+                            <div className="flex left">
+                                {message && <span className="ellipsis-right  select-material--w450">{message}</span>}
+                                {message.length > 73 && <span className='cb-5'>more</span>}
+                            </div>
                         </div>
                     </div>
                 )}

--- a/src/components/app/details/appDetails/SourceInfo.tsx
+++ b/src/components/app/details/appDetails/SourceInfo.tsx
@@ -68,7 +68,7 @@ export function SourceInfo({ appDetails, setDetailed = null, environments, showC
                             </div>
                             <div className="flex left">
                                 {message && <span className="ellipsis-right  select-material--w450">{message}</span>}
-                                {message.length > 73 && <span className='cb-5'>more</span>}
+                                {message?.length > 73 && <span className='cb-5'>more</span>}
                             </div>
                         </div>
                     </div>

--- a/src/components/app/details/appDetails/appDetails.scss
+++ b/src/components/app/details/appDetails/appDetails.scss
@@ -1747,6 +1747,10 @@ table.resource-tree {
     height: 450px;
 }
 
+.select-material--w450 {
+    width: 450px;
+}
+
 .app-details-page-wrapper {
     display: flex;
     flex-direction: column;

--- a/src/components/app/details/appDetails/utils.tsx
+++ b/src/components/app/details/appDetails/utils.tsx
@@ -162,7 +162,7 @@ const throughputAndLatencySelectStyle = {
     }),
     menu: (base, state) => ({
         ...base,
-        width: '150px'
+        width: 'auto'
     }),
     valueContainer: base => ({
         ...base,

--- a/src/components/app/details/appDetails/utils.tsx
+++ b/src/components/app/details/appDetails/utils.tsx
@@ -204,7 +204,7 @@ export function ThroughputSelect(props) {
 }
 
 export function LatencySelect(props) {
-    return <CreatableSelect className="mr-5"
+    return <CreatableSelect className=""
         placeholder="Latency"
         value={{ label: props.latency, value: props.latency }}
         options={[

--- a/src/components/app/details/appDetails/utils.tsx
+++ b/src/components/app/details/appDetails/utils.tsx
@@ -172,8 +172,6 @@ const throughputAndLatencySelectStyle = {
     }),
     singleValue: base => ({
         ...base,
-        position: 'relative',
-        top: '9px',
         maxWidth: '77px',
     }),
     dropdownIndicator: base => ({
@@ -206,7 +204,7 @@ export function ThroughputSelect(props) {
 }
 
 export function LatencySelect(props) {
-    return <CreatableSelect className=""
+    return <CreatableSelect className="mr-5"
         placeholder="Latency"
         value={{ label: props.latency, value: props.latency }}
         options={[


### PR DESCRIPTION
# Description

1. Throughput and Latency (99%) Metrics graph text overlay is clipped from bottom.
2. Error text take width more than full screen in app details page

Fixes - https://github.com/devtron-labs/devtron/issues/2124

**Describe the bug**

1. Throughput and Latency Metrics graph text overlay is clipped from bottom.
2. If error text length is more in that case the screen have more horizonatal length than screen inn app details page

**To Reproduce**

1. Enable App metrics

**Expected behavior**

1. Text should not be clipped
2. Error text should show some fixed length

**Current behavior** 

Text is clipped from the bottom

**Screenshots**

<img width="674" alt="Screenshot 2022-08-02 at 5 40 02 PM" src="https://user-images.githubusercontent.com/71125043/182371590-d5c677c1-2cf5-4a43-8bb5-c31f99da7a69.png">


![image](https://user-images.githubusercontent.com/98738644/184864974-2fe0eac1-3499-40a2-a1bb-3315e43fb783.png)## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


