### PR TITLE
Fix - Deployment groups: Page breaks on clicking on Show source info

### DIFF
--- a/src/components/app/details/triggerView/cdMaterial.tsx
+++ b/src/components/app/details/triggerView/cdMaterial.tsx
@@ -157,9 +157,8 @@ export class CDMaterial extends Component<CDMaterialProps, CDMaterialState> {
               : mat.isSelected ? <Check className="dc__align-right icon-dim-24" /> : "Select"}
           </div>
         </div>
-        {!this.props.isFromDeploymentGroup && <>
         {mat.showSourceInfo && <>
-            {this.state.isSecurityModuleInstalled && <ul className="tab-list tab-list--vulnerability">
+            {this.state.isSecurityModuleInstalled && !this.props.hideInfoTabsContainer && <ul className="tab-list tab-list--vulnerability">
               <li className="tab-list__tab">
                 <button type="button" onClick={(e) => { e.stopPropagation(); this.props.changeTab(index, Number(mat.id), CDModalTab.Changes) }}
                   className={mat.tab === CDModalTab.Changes ? `${tabClasses} active` : `${tabClasses}`}>
@@ -179,7 +178,6 @@ export class CDMaterial extends Component<CDMaterialProps, CDMaterialState> {
             {mat.showSourceInfo ? "Hide Source Info" : "Show Source Info"}
             <img src={arrow} alt="" style={{ 'transform': `${mat.showSourceInfo ? 'rotate(-180deg)' : ''}` }} />
           </button>
-        </>}
       </div >
     })
   }

--- a/src/components/app/details/triggerView/types.ts
+++ b/src/components/app/details/triggerView/types.ts
@@ -18,7 +18,7 @@ export interface CDMaterialProps {
     parentPipelineId?: string
     parentPipelineType?: string
     parentEnvironmentName?: string
-    isFromDeploymentGroup?: boolean
+    hideInfoTabsContainer?: boolean
 }
 
 export interface CDMaterialState{

--- a/src/components/deploymentGroups/DeploymentGroupList.tsx
+++ b/src/components/deploymentGroups/DeploymentGroupList.tsx
@@ -47,6 +47,7 @@ export default class DeploymentGroupList extends Component<BulkActionListProps, 
         this.selectImage = this.selectImage.bind(this)
         this.toggleSourceInfo = this.toggleSourceInfo.bind(this)
         this.triggerDeploy = this.triggerDeploy.bind(this)
+        this.closeCDModal = this.closeCDModal.bind(this)
     }
 
     componentDidMount() {
@@ -137,6 +138,10 @@ export default class DeploymentGroupList extends Component<BulkActionListProps, 
             }
         })
         this.setState({ materials })
+    }
+
+    closeCDModal() {
+        this.setState({ showCDModal: false })
     }
 
     redirectToEdit(deploymentGroup) {
@@ -273,10 +278,8 @@ export default class DeploymentGroupList extends Component<BulkActionListProps, 
                     triggerDeploy={this.triggerDeploy}
                     toggleSourceInfo={this.toggleSourceInfo}
                     selectImage={this.selectImage}
-                    closeCDModal={() => {
-                        this.setState({ showCDModal: false })
-                    }}
-                    isFromDeploymentGroup={true} // adding this for now as implementation of tabs are not available here. will be fixed in coming sprint
+                    closeCDModal={this.closeCDModal}
+                    hideInfoTabsContainer={true}
                 />
             )
         }

--- a/src/components/deploymentGroups/service.ts
+++ b/src/components/deploymentGroups/service.ts
@@ -1,5 +1,6 @@
 import { Routes } from '../../config';
 import { get, post, trash, put } from '../../services/api';
+import { CDModalTab } from '../app/service';
 import { createGitCommitUrl, handleUTCTime, ISTTimeModal } from '../common';
 
 export function deploymentGroupList() {
@@ -23,30 +24,41 @@ export function deleteDeploymentGroup(deploymentGroupId: number | string) {
 }
 
 export function getCDMaterialList(deploymentGroupId) {
-    const url = `${Routes.DEPLOYMENT_GROUP_MATERIAL}/${deploymentGroupId}`;
+    const url = `${Routes.DEPLOYMENT_GROUP_MATERIAL}/${deploymentGroupId}`
     return get(url).then((response) => {
-        let list = response.result.ci_artifacts ? response.result.ci_artifacts.map((material, index) => {
-            return {
-                id: material.id,
-                deployedTime: material.deployed_time && material.deployed_time.length ? handleUTCTime(material.deployed_time, true) : "Not Deployed",
-                materialInfo: material.material_info ? material.material_info.map((mat) => {
-                    return {
-                        modifiedTime: mat.modifiedTime ? ISTTimeModal(mat.modifiedTime) : "",
-                        commitLink: createGitCommitUrl(mat.url, mat.revision),
-                        author: mat.author || "",
-                        message: mat.message || "",
-                        revision: mat.revision || "",
-                        tag: mat.tag || "",
-                    }
-                }) : [],
-                image: material.image.split(':')[1],
-                buildTime: material.build_time || "",
-                isSelected: index == 0,
-                showSourceInfo: false,
-                deployed: material.deployed || false,
-                latest: material.latest || false
-            }
-        }) : [];
+        let list = response.result.ci_artifacts
+            ? response.result.ci_artifacts.map((material, index) => {
+                  return {
+                      id: material.id,
+                      deployedTime:
+                          material.deployed_time && material.deployed_time.length
+                              ? handleUTCTime(material.deployed_time, true)
+                              : 'Not Deployed',
+                      tab: CDModalTab.Changes,
+                      image: material.image.split(':')[1],
+                      vulnerabilities: [],
+                      buildTime: material.build_time || '',
+                      isSelected: index === 0,
+                      showSourceInfo: false,
+                      deployed: material.deployed || false,
+                      latest: material.latest || false,
+                      materialInfo: material.material_info
+                          ? material.material_info.map((mat) => {
+                                return {
+                                    modifiedTime: mat.modifiedTime ? ISTTimeModal(mat.modifiedTime) : '',
+                                    commitLink: createGitCommitUrl(mat.url, mat.revision),
+                                    author: mat.author || '',
+                                    message: mat.message || '',
+                                    revision: mat.revision || '',
+                                    tag: mat.tag || '',
+                                    webhookData: mat.webhookData || '',
+                                    url: mat.url || '',
+                                }
+                            })
+                          : [],
+                  }
+              })
+            : []
         return {
             code: response.code,
             result: list,


### PR DESCRIPTION
# Description

These changes will fix the page break issue on clicking show source info while triggering deployment via deployment groups

Fixes - AB#215

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been performed manually. Now, it's loading source info as expected.

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


