### PR TITLE
ci pipeline escape functionality removed

### DIFF
--- a/src/components/CIPipelineN/CIPipeline.tsx
+++ b/src/components/CIPipelineN/CIPipeline.tsx
@@ -677,14 +677,6 @@ export default function CIPipeline({
         )
     }
 
-    const keys = useKeyDown()
-
-    useEffect(() => {
-      if (keys.join('') === 'Escape' && typeof close === 'function') {
-          close()
-      }
-    }, [keys])
-
     return (
         <VisibleModal className="">
             <div


### PR DESCRIPTION
# Description
Not able to enter a custom value in the "Container-Image" field in pre/post CI tasks.
Solution: CI pipeline escape functionality removed

Fixes https://github.com/devtron-labs/devtron/issues/2472
Fix https://dev.azure.com/DevtronLabs/Devtron/_boards/board/t/Devtron%20Team/Issues

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Try to create a pre/post CI task
- [ ] Now choose the task type as "container-image" instead of shell
- [ ] try to enter a custom value in the "container-image" filed 



# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


