### PR TITLE
remove commit info button in case of external data source

### DIFF
--- a/src/components/app/details/appDetails/AppDetails.tsx
+++ b/src/components/app/details/appDetails/AppDetails.tsx
@@ -400,7 +400,7 @@ export const Details: React.FC<{
                             appDetails={appDetails}
                             setDetailed={toggleDetailedStatus}
                             environments={environments}
-                            showCommitInfo={isAppDeployment ? showCommitInfo : null}
+                            showCommitInfo={isAppDeployment && appDetails.dataSource !== 'EXTERNAL' ? showCommitInfo : null}
                             showHibernateModal={isAppDeployment ? setHibernateConfirmationModal : null}
                             toggleDeploymentDetailedStatus={toggleDeploymentDetailedStatus}
                             deploymentStatus={deploymentStatusDetailsBreakdownData.deploymentStatus}

--- a/src/components/app/service.ts
+++ b/src/components/app/service.ts
@@ -64,7 +64,7 @@ export function getCITriggerInfoModal(
                 lastFetchTime: mat.lastFetchTime || '',
             }
         })
-        if (!materials.find((mat) => mat.isSelected)) {
+        if (materials.length>0 && !materials.find((mat) => mat.isSelected)) {
             materials[0].isSelected = true
         }
         return {


### PR DESCRIPTION
# Description

In a case of external CI there is no material info available due to which FE shows broken page. To fix this we have added a check to hide the commit info button in case of external CI

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Manually tested by creating external CI


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


