### PR TITLE
fix: Login page bug fix for showing toast conditionally

### DIFF
--- a/src/components/common/helpers/Helpers.tsx
+++ b/src/components/common/helpers/Helpers.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { ARGOCDCOOKIENAME } from '../../../config';
 import { toast } from 'react-toastify';
 import { ServerErrors } from '../../../modals/commonTypes';
 import * as Sentry from '@sentry/browser';
@@ -518,7 +519,7 @@ export function useOnline() {
     return online;
 }
 
-function getCookie(sKey) {
+export function getCookie(sKey) { 
     if (!sKey) {
         return null;
     }
@@ -531,7 +532,7 @@ function getCookie(sKey) {
 }
 
 export function getLoginInfo() {
-    const argocdToken = getCookie('argocd.token');
+    const argocdToken = getCookie(ARGOCDCOOKIENAME);
     if (argocdToken) {
         const jwts = argocdToken.split('.');
         try {

--- a/src/components/common/helpers/Helpers.tsx
+++ b/src/components/common/helpers/Helpers.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { ARGOCDCOOKIENAME } from '../../../config';
+import { TOKEN_COOKIE_NAME } from '../../../config';
 import { toast } from 'react-toastify';
 import { ServerErrors } from '../../../modals/commonTypes';
 import * as Sentry from '@sentry/browser';
@@ -532,7 +532,7 @@ export function getCookie(sKey) {
 }
 
 export function getLoginInfo() {
-    const argocdToken = getCookie(ARGOCDCOOKIENAME);
+    const argocdToken = getCookie(TOKEN_COOKIE_NAME);
     if (argocdToken) {
         const jwts = argocdToken.split('.');
         try {

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -5,7 +5,7 @@ import { Switch, Redirect, NavLink } from 'react-router-dom'
 import { Route } from 'react-router'
 import { toast } from 'react-toastify'
 import { ServerErrors } from '../../modals/commonTypes'
-import { URLS, Host, DOCUMENTATION, ARGOCDCOOKIENAME} from '../../config'
+import { URLS, Host, DOCUMENTATION, TOKEN_COOKIE_NAME} from '../../config'
 import { Progressing, showError , getCookie} from '../common'
 import { LoginProps, LoginFormState } from './login.types'
 import { getSSOConfigList, loginAsAdmin } from './login.service'
@@ -34,12 +34,14 @@ export default class Login extends Component<LoginProps, LoginFormState> {
         let queryString = new URLSearchParams(this.props.location.search)
         let queryParam = queryString.get('continue')       
         
-        //RGOCDCOOKIENAME= 'argocd.token', is the only token unique to a user generated as Cookie when they log in,
-        //If a user is still at login page for the first time and hasn't logged in yet then the condition becomes false.
-        //Also if the cookie is deleted/changed after some time at backend then this statement is false.
-        //queryParam is '/' for first time login, queryParam != "/" means user is inside devtron website hence
-        //making queryParam != "/" as true and if getCookie(ARGOCDCOOKIENAME) is false at the same time then toast will appear.
-        if (queryParam && (getCookie(ARGOCDCOOKIENAME) || queryParam != "/")) {
+        //1. TOKEN_COOKIE_NAME= 'argocd.token', is the only token unique to a user generated as Cookie when they log in,
+            //If a user is still at login page for the first time and getCookie(TOKEN_COOKIE_NAME) becomes false.
+            //queryParam is '/' for first time login, queryParam != "/" becomes false at login page. Hence toast won't appear 
+            //at the time of first login.
+        //2. Also if the cookie is deleted/changed after some time from the database at backend then getCookie(TOKEN_COOKIE_NAME)
+            //becomes false but queryParam != "/" will be true and queryParam is also not null hence redirecting users to the 
+            //login page with Please login again toast appearing.
+        if (queryParam && (getCookie(TOKEN_COOKIE_NAME) || queryParam != "/")) {
             toast.error('Please login again')
         }
         if (queryParam && queryParam.includes('login')) {

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -5,8 +5,8 @@ import { Switch, Redirect, NavLink } from 'react-router-dom'
 import { Route } from 'react-router'
 import { toast } from 'react-toastify'
 import { ServerErrors } from '../../modals/commonTypes'
-import { URLS, Host, DOCUMENTATION } from '../../config'
-import { Progressing, showError } from '../common'
+import { URLS, Host, DOCUMENTATION, ARGOCDCOOKIENAME} from '../../config'
+import { Progressing, showError , getCookie} from '../common'
 import { LoginProps, LoginFormState } from './login.types'
 import { getSSOConfigList, loginAsAdmin } from './login.service'
 import './login.css'
@@ -32,9 +32,14 @@ export default class Login extends Component<LoginProps, LoginFormState> {
 
     componentDidMount() {
         let queryString = new URLSearchParams(this.props.location.search)
-        let queryParam = queryString.get('continue')
-
-        if (queryParam) {
+        let queryParam = queryString.get('continue')       
+        
+        //RGOCDCOOKIENAME= 'argocd.token', is the only token unique to a user generated as Cookie when they log in,
+        //If a user is still at login page for the first time and hasn't logged in yet then the condition becomes false.
+        //Also if the cookie is deleted/changed after some time at backend then this statement is false.
+        //queryParam is '/' for first time login, queryParam != "/" means user is inside devtron website hence
+        //making queryParam != "/" as true and if getCookie(ARGOCDCOOKIENAME) is false at the same time then toast will appear.
+        if (queryParam && (getCookie(ARGOCDCOOKIENAME) || queryParam != "/")) {
             toast.error('Please login again')
         }
         if (queryParam && queryParam.includes('login')) {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -2,6 +2,7 @@ export const RequestTimeout = 60000
 export const DEFAULT_STATUS = 'Checking Status...'
 export const Host = process.env.REACT_APP_ORCHESTRATOR_ROOT
 export const DEFAULTK8SVERSION = 'v1.16.0'
+export const ARGOCDCOOKIENAME = 'argocd.token'
 
 export const Routes = {
     GET: 'get',

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -2,7 +2,7 @@ export const RequestTimeout = 60000
 export const DEFAULT_STATUS = 'Checking Status...'
 export const Host = process.env.REACT_APP_ORCHESTRATOR_ROOT
 export const DEFAULTK8SVERSION = 'v1.16.0'
-export const ARGOCDCOOKIENAME = 'argocd.token'
+export const TOKEN_COOKIE_NAME = 'argocd.token'
 
 export const Routes = {
     GET: 'get',


### PR DESCRIPTION
# Description

Show "Please login again" toast on login page only when, we have invalidated existing cookie and redirected user to the login page. When users were coming directly on Devtron login page for the first time "Please login again" toast was appearing which was a bug, it should only appear in certain cases which are as follows:-
1. When there are multiple tabs of Devtron is open, if user logs out from one tab, performing any task in other tab will stop and will get redirected to login page with "Please login again" toast. 
2. When user is inactive for a long time, in that case their cookie(unique user token) will get deleted from the database and they will get redirected to the login page with "Please login again" toast. 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] When any user visits the login page of Devtron for the first time, the code change will not show the toast as shown previously. I tested it multiple time locally.
- [x] I opened multiple tabs of Devtron in my browser, and logged out from one of the tabs, and went to another tab to perform any task, there I was redirected to login page with the "Please login again" toast which is the desired state. I tested it multiple times locally.
- [x] Deleting the cookie(token) of a my test environment via the console with the following command : document.cookie = "argocd.token=; path=/;". This test simulates a situation when a user is inactive for a long time and their cookies are deleted from DB, thereafter if they try to perform any action they will be redirected to login page with the "Please login again" toast which is the desired state. I tested it multiple times locally.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


