### PR TITLE
[HOTFIX] Passing noParsing flag to CodeEditor & framework check fix

### DIFF
--- a/src/components/ciConfig/CICreateDockerfileOption.tsx
+++ b/src/components/ciConfig/CICreateDockerfileOption.tsx
@@ -90,8 +90,8 @@ export default function CICreateDockerfileOption({
             if (
                 currentCIBuildConfig.dockerBuildConfig.language &&
                 _selectedLanguage.value === currentCIBuildConfig.dockerBuildConfig.language &&
-                currentCIBuildConfig.dockerBuildConfig.languageFramework &&
-                _selectedFramework.value === currentCIBuildConfig.dockerBuildConfig.languageFramework
+                (!currentCIBuildConfig.dockerBuildConfig.languageFramework ||
+                    _selectedFramework.value === currentCIBuildConfig.dockerBuildConfig.languageFramework)
             ) {
                 setTemplateData({
                     ...templateData,

--- a/src/components/ciConfig/CICreateDockerfileOption.tsx
+++ b/src/components/ciConfig/CICreateDockerfileOption.tsx
@@ -378,6 +378,7 @@ export default function CICreateDockerfileOption({
                     }
                     value={editorValue || editorData?.data}
                     mode={MODES.DOCKERFILE}
+                    noParsing={true}
                     height="300px"
                     readOnly={configOverrideView && !allowOverride}
                     onChange={handleEditorValueChange}


### PR DESCRIPTION
# Description

This will fix the issue related to unexpected Dockerfile content parsing as YAML causing additional characters to be added or reformatting of the file as YAML content instead of Dockerfile content. Also contains one check fix around the framework.

<img width="1440" alt="Screenshot 2022-11-10 at 1 35 47 AM" src="https://user-images.githubusercontent.com/96225587/200930474-512cd130-b752-4d4c-a0e4-68f9b9bfe778.png">

Fixes - [AB#638](https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/638)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been performed manually by saving different custom contents.

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


