### PR TITLE
fix: Save&Next button break on small screen width fix

### DIFF
--- a/src/components/deploymentConfig/deploymentConfig.scss
+++ b/src/components/deploymentConfig/deploymentConfig.scss
@@ -104,7 +104,8 @@
 
         .form-submit-cta {
             &.cta {
-                min-width: 116px;
+                min-width: 125px;
+                padding: 0 8px;
                 &.disabled {
                     opacity: 0.5;
                     cursor: not-allowed;


### PR DESCRIPTION
# Description

Save & Next button breaks on smaller screen width in Base Deployment Template in App Configurations section. It happens only when user try to create ci pipeline for first time for any app. Only required some padding changes in the CSS file

Image for the same problem:- https://app.usebubbles.com/dsj32qWRAmYfDfATZmMPqQ/untitled-bubble

Fixes https://github.com/devtron-labs/devtron/issues/2535

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested it on local system and on demo1. Inspected the CSS element of the button, it breaks with the current padding which is 16px and min width of 116px. Changed the padding values to 8x and min width value to 125px, after which the button is working fine in Base Deployment Template stage and in Environment Overides section also.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas

