### PR TITLE
fix: checks added in divs showing commit info (now showing empty commit info) when git materials were deleted 

### DIFF
--- a/src/components/app/details/cIDetails/CIDetails.tsx
+++ b/src/components/app/details/cIDetails/CIDetails.tsx
@@ -17,7 +17,17 @@ import {
     not,
     ConditionalWrap,
 } from '../../../common'
-import { Host, Routes, URLS, SourceTypeMap, ModuleNameMap, EVENT_STREAM_EVENTS_MAP, TERMINAL_STATUS_MAP, POD_STATUS, LOGS_RETRY_COUNT } from '../../../../config'
+import {
+    Host,
+    Routes,
+    URLS,
+    SourceTypeMap,
+    ModuleNameMap,
+    EVENT_STREAM_EVENTS_MAP,
+    TERMINAL_STATUS_MAP,
+    POD_STATUS,
+    LOGS_RETRY_COUNT,
+} from '../../../../config'
 import { toast } from 'react-toastify'
 import { NavLink, Switch, Route, Redirect, Link } from 'react-router-dom'
 import { useRouteMatch, useParams, useLocation, useHistory, generatePath } from 'react-router'
@@ -117,8 +127,8 @@ function useCIEventSource(url: string, maxLength?: number) {
     }
 
     useEffect(() => {
-        if(url){
-          getData()
+        if (url) {
+            getData()
         }
         return closeEventSource
     }, [url, maxLength])
@@ -142,8 +152,8 @@ export default function CIDetails() {
     const [fullScreenView, setFullScreenView] = useState<boolean>(false)
     const [hasMoreLoading, setHasMoreLoading] = useState<boolean>(false)
     const [pipelinesLoading, result, pipelinesError] = useAsync(() => getCIPipelines(+appId), [appId])
-    const [, securityModuleStatus, ] = useAsync(() => getModuleInfo(ModuleNameMap.SECURITY), [appId])
-    const [, blobStorageConfiguration, ] = useAsync(() => getModuleConfigured(ModuleNameMap.BLOB_STORAGE), [appId])
+    const [, securityModuleStatus] = useAsync(() => getModuleInfo(ModuleNameMap.SECURITY), [appId])
+    const [, blobStorageConfiguration] = useAsync(() => getModuleConfigured(ModuleNameMap.BLOB_STORAGE), [appId])
     const [loading, triggerHistoryResult, triggerHistoryError, reloadTriggerHistory, , dependencyState] = useAsync(
         () => getTriggerHistory(+pipelineId, pagination),
         [pipelineId, pagination],
@@ -251,7 +261,9 @@ export default function CIDetails() {
                                 pipeline={pipeline}
                                 setFullScreenView={setFullScreenView}
                                 synchroniseState={synchroniseState}
-                                isSecurityModuleInstalled={securityModuleStatus?.result?.status === ModuleStatus.INSTALLED || false}
+                                isSecurityModuleInstalled={
+                                    securityModuleStatus?.result?.status === ModuleStatus.INSTALLED || false
+                                }
                                 isBlobStorageConfigured={blobStorageConfiguration?.result?.enabled || false}
                             />
                         </Route>
@@ -433,7 +445,7 @@ const BuildDetails: React.FC<BuildDetails> = ({
     setFullScreenView,
     synchroniseState,
     isSecurityModuleInstalled,
-    isBlobStorageConfigured
+    isBlobStorageConfigured,
 }) => {
     const { buildId, appId, pipelineId, envId } = useParams<{
         appId: string
@@ -471,7 +483,7 @@ const Details: React.FC<BuildDetails> = ({
     synchroniseState,
     triggerHistory,
     isSecurityModuleInstalled,
-    isBlobStorageConfigured
+    isBlobStorageConfigured,
 }) => {
     const { pipelineId, appId, buildId } = useParams<{ appId: string; buildId: string; pipelineId: string }>()
     const triggerDetails = triggerHistory.get(+buildId)
@@ -549,16 +561,18 @@ const Details: React.FC<BuildDetails> = ({
                                     Artifacts
                                 </NavLink>
                             </li>
-                           {isSecurityModuleInstalled && <li className="tab-list__tab">
-                                <NavLink
-                                    replace
-                                    className="tab-list__tab-link"
-                                    activeClassName="active"
-                                    to={`security`}
-                                >
-                                    Security
-                                </NavLink>
-                            </li>}
+                            {isSecurityModuleInstalled && (
+                                <li className="tab-list__tab">
+                                    <NavLink
+                                        replace
+                                        className="tab-list__tab-link"
+                                        activeClassName="active"
+                                        to={`security`}
+                                    >
+                                        Security
+                                    </NavLink>
+                                </li>
+                            )}
                         </ul>
                     </>
                 )}
@@ -653,18 +667,24 @@ export const TriggerDetails: React.FC<{ triggerDetails: History; abort?: () => P
                 </div>
                 {
                     {
-                      [TERMINAL_STATUS_MAP.SUCCEEDED]: <Succeeded triggerDetails={triggerDetails} type={type} />,
+                        [TERMINAL_STATUS_MAP.SUCCEEDED]: <Succeeded triggerDetails={triggerDetails} type={type} />,
                         [TERMINAL_STATUS_MAP.HEALTHY]: <Succeeded triggerDetails={triggerDetails} type={type} />,
-                        [TERMINAL_STATUS_MAP.RUNNING]: <ProgressingStatus triggerDetails={triggerDetails} abort={abort} type={type} />,
-                        [TERMINAL_STATUS_MAP.PROGRESSING]: <ProgressingStatus triggerDetails={triggerDetails} abort={abort} type={type} />,
-                        [TERMINAL_STATUS_MAP.STARTING]: <ProgressingStatus triggerDetails={triggerDetails} abort={abort} type={type} />,
+                        [TERMINAL_STATUS_MAP.RUNNING]: (
+                            <ProgressingStatus triggerDetails={triggerDetails} abort={abort} type={type} />
+                        ),
+                        [TERMINAL_STATUS_MAP.PROGRESSING]: (
+                            <ProgressingStatus triggerDetails={triggerDetails} abort={abort} type={type} />
+                        ),
+                        [TERMINAL_STATUS_MAP.STARTING]: (
+                            <ProgressingStatus triggerDetails={triggerDetails} abort={abort} type={type} />
+                        ),
                         [TERMINAL_STATUS_MAP.FAILED]: <Failed triggerDetails={triggerDetails} type={type} />,
                         [TERMINAL_STATUS_MAP.ERROR]: <Failed triggerDetails={triggerDetails} type={type} />,
                     }[triggerDetails.status.toLowerCase()]
                 }
-                {!Object.values(TERMINAL_STATUS_MAP).includes(
-                    triggerDetails.status.toLowerCase(),
-                ) && <Generic triggerDetails={triggerDetails} type={type} />}
+                {!Object.values(TERMINAL_STATUS_MAP).includes(triggerDetails.status.toLowerCase()) && (
+                    <Generic triggerDetails={triggerDetails} type={type} />
+                )}
             </div>
         </div>
     )
@@ -688,7 +708,11 @@ const Finished: React.FC<{ triggerDetails: History; colorClass: string; type: 'C
 }) => {
     return (
         <div className="flex column left">
-            <div className={`${triggerDetails.status} fs-14 fw-6 ${colorClass}`}>{triggerDetails.status && triggerDetails.status.toLowerCase()==='cancelled' ? 'ABORTED' : triggerDetails.status}</div>
+            <div className={`${triggerDetails.status} fs-14 fw-6 ${colorClass}`}>
+                {triggerDetails.status && triggerDetails.status.toLowerCase() === 'cancelled'
+                    ? 'ABORTED'
+                    : triggerDetails.status}
+            </div>
             <div className="flex left">
                 {triggerDetails.finishedOn && triggerDetails.finishedOn !== '0001-01-01T00:00:00Z' && (
                     <time className="cn-7 fs-12 mr-12">
@@ -829,7 +853,11 @@ const HistoryLogs: React.FC<{
                     <Switch>
                         <Route path={`${path}/logs`}>
                             <div ref={ref} style={{ height: '100%', overflow: 'auto', background: '#0b0f22' }}>
-                                <LogsRenderer triggerDetails={triggerDetails} setFullScreenView={setFullScreenView} isBlobStorageConfigured={isBlobStorageConfigured} />
+                                <LogsRenderer
+                                    triggerDetails={triggerDetails}
+                                    setFullScreenView={setFullScreenView}
+                                    isBlobStorageConfigured={isBlobStorageConfigured}
+                                />
                             </div>
                         </Route>
                         <Route
@@ -886,7 +914,9 @@ const SelectPipeline: React.FC<Pipelines> = ({ pipelines }) => {
             <label className="form__label">Select Pipeline</label>
             <Select onChange={handlePipelineChange} value={+pipelineId}>
                 <Select.Button rootClassName="select-button--default">
-                    <div className="dc__ellipsis-left w-100 flex right">{pipeline ? pipeline.name : 'Select Pipeline'}</div>
+                    <div className="dc__ellipsis-left w-100 flex right">
+                        {pipeline ? pipeline.name : 'Select Pipeline'}
+                    </div>
                 </Select.Button>
                 {pipelines.map((item, idx) => {
                     return (
@@ -998,11 +1028,11 @@ function NoArtifactsView() {
     )
 }
 
-export const LogsRenderer: React.FC<{ triggerDetails: History; setFullScreenView: (...args) => void, isBlobStorageConfigured: boolean }> = ({
-    triggerDetails,
-    setFullScreenView,
-    isBlobStorageConfigured
-}) => {
+export const LogsRenderer: React.FC<{
+    triggerDetails: History
+    setFullScreenView: (...args) => void
+    isBlobStorageConfigured: boolean
+}> = ({ triggerDetails, setFullScreenView, isBlobStorageConfigured }) => {
     const keys = useKeyDown()
 
     useEffect(() => {
@@ -1031,8 +1061,10 @@ export const LogsRenderer: React.FC<{ triggerDetails: History; setFullScreenView
         }
     }
 
-    return triggerDetails.podStatus !== POD_STATUS.PENDING && logsNotAvailable && (!isBlobStorageConfigured || !triggerDetails.blobStorageEnabled)  ? (
-      renderConfigurationError(isBlobStorageConfigured)
+    return triggerDetails.podStatus !== POD_STATUS.PENDING &&
+        logsNotAvailable &&
+        (!isBlobStorageConfigured || !triggerDetails.blobStorageEnabled) ? (
+        renderConfigurationError(isBlobStorageConfigured)
     ) : (
         <div className="logs__body">
             {logs.map((log, index) => {
@@ -1067,9 +1099,9 @@ export function Scroller({ scrollToTop, scrollToBottom, style }) {
     )
 }
 
-export const Artifacts: React.FC<{ triggerDetails: History; getArtifactPromise?: () => Promise<any>}> = ({
+export const Artifacts: React.FC<{ triggerDetails: History; getArtifactPromise?: () => Promise<any> }> = ({
     triggerDetails,
-    getArtifactPromise
+    getArtifactPromise,
 }) => {
     const { buildId, triggerId } = useParams<{ buildId: string; triggerId: string }>()
     const [downloading, setDownloading] = useState(false)
@@ -1143,12 +1175,11 @@ export const Artifacts: React.FC<{ triggerDetails: History; getArtifactPromise?:
 const MaterialHistory: React.FC<{ gitTrigger: GitTriggers; ciMaterial: CiMaterial }> = ({ gitTrigger, ciMaterial }) => {
     return (
         <>
-            {
-                (gitTrigger?.Commit || (gitTrigger?.WebhookData && gitTrigger?.WebhookData?.Data)) &&
+            {gitTrigger && (gitTrigger.Commit || gitTrigger.WebhookData?.Data) && (
                 <div
                     key={gitTrigger?.Commit}
                     className="bcn-0 pt-12 br-4 en-2 bw-1 pb-12 mb-12"
-                    style={{width: 'min( 100%, 800px )'}}
+                    style={{ width: 'min( 100%, 800px )' }}
                 >
                     <GitCommitInfoGeneric
                         materialUrl={gitTrigger?.GitRepoUrl ? gitTrigger?.GitRepoUrl : ciMaterial?.url}
@@ -1163,9 +1194,8 @@ const MaterialHistory: React.FC<{ gitTrigger: GitTriggers; ciMaterial: CiMateria
                         }
                     />
                 </div>
-            }
+            )}
         </>
-
     )
 }
 

--- a/src/components/app/details/cIDetails/CIDetails.tsx
+++ b/src/components/app/details/cIDetails/CIDetails.tsx
@@ -373,7 +373,7 @@ export const BuildCardPopup: React.FC<{ triggerDetails: History }> = ({ triggerD
                             key={ciMaterial.id}
                             style={{ display: 'grid', gridTemplateColumns: '20px 1fr', gridColumnGap: '8px' }}
                         >
-                            {sourceType != SourceTypeMap.WEBHOOK && (
+                            {sourceType != SourceTypeMap.WEBHOOK && gitDetail?.Commit && (
                                 <>
                                     <div className="dc__git-logo"> </div>
                                     <div className="flex left column">
@@ -1142,24 +1142,30 @@ export const Artifacts: React.FC<{ triggerDetails: History; getArtifactPromise?:
 
 const MaterialHistory: React.FC<{ gitTrigger: GitTriggers; ciMaterial: CiMaterial }> = ({ gitTrigger, ciMaterial }) => {
     return (
-        <div
-            key={gitTrigger?.Commit}
-            className="bcn-0 pt-12 br-4 en-2 bw-1 pb-12 mb-12"
-            style={{ width: 'min( 100%, 800px )' }}
-        >
-            <GitCommitInfoGeneric
-                materialUrl={gitTrigger?.GitRepoUrl ? gitTrigger?.GitRepoUrl : ciMaterial?.url}
-                showMaterialInfo={true}
-                commitInfo={gitTrigger}
-                materialSourceType={
-                    gitTrigger?.CiConfigureSourceType ? gitTrigger?.CiConfigureSourceType : ciMaterial?.type
-                }
-                selectedCommitInfo={''}
-                materialSourceValue={
-                    gitTrigger?.CiConfigureSourceValue ? gitTrigger?.CiConfigureSourceValue : ciMaterial?.value
-                }
-            />
-        </div>
+        <>
+            {
+                (gitTrigger?.Commit || (gitTrigger?.WebhookData && gitTrigger?.WebhookData?.Data)) &&
+                <div
+                    key={gitTrigger?.Commit}
+                    className="bcn-0 pt-12 br-4 en-2 bw-1 pb-12 mb-12"
+                    style={{width: 'min( 100%, 800px )'}}
+                >
+                    <GitCommitInfoGeneric
+                        materialUrl={gitTrigger?.GitRepoUrl ? gitTrigger?.GitRepoUrl : ciMaterial?.url}
+                        showMaterialInfo={true}
+                        commitInfo={gitTrigger}
+                        materialSourceType={
+                            gitTrigger?.CiConfigureSourceType ? gitTrigger?.CiConfigureSourceType : ciMaterial?.type
+                        }
+                        selectedCommitInfo={''}
+                        materialSourceValue={
+                            gitTrigger?.CiConfigureSourceValue ? gitTrigger?.CiConfigureSourceValue : ciMaterial?.value
+                        }
+                    />
+                </div>
+            }
+        </>
+
     )
 }
 

--- a/src/components/app/details/cIDetails/CIDetails.tsx
+++ b/src/components/app/details/cIDetails/CIDetails.tsx
@@ -1174,7 +1174,6 @@ export const Artifacts: React.FC<{ triggerDetails: History; getArtifactPromise?:
 
 const MaterialHistory: React.FC<{ gitTrigger: GitTriggers; ciMaterial: CiMaterial }> = ({ gitTrigger, ciMaterial }) => {
     return (
-        <>
             {gitTrigger && (gitTrigger.Commit || gitTrigger.WebhookData?.Data) && (
                 <div
                     key={gitTrigger?.Commit}

--- a/src/components/app/details/cIDetails/CIDetails.tsx
+++ b/src/components/app/details/cIDetails/CIDetails.tsx
@@ -1195,7 +1195,6 @@ const MaterialHistory: React.FC<{ gitTrigger: GitTriggers; ciMaterial: CiMateria
                     />
                 </div>
             )}
-        </>
     )
 }
 

--- a/src/components/app/details/triggerView/cdMaterial.tsx
+++ b/src/components/app/details/triggerView/cdMaterial.tsx
@@ -152,8 +152,7 @@ export class CDMaterial extends Component<CDMaterialProps, CDMaterialState> {
 
                     return (
                         <>
-                            {
-                                (_gitCommit?.Commit || (_gitCommit?.WebhookData && _gitCommit?.WebhookData?.Data)) &&
+                            {_gitCommit && (_gitCommit.Commit || _gitCommit.WebhookData?.Data) && (
                                 <div className="bcn-0 pt-12 br-4 pb-12 en-2 bw-1 m-12">
                                     <GitCommitInfoGeneric
                                         materialUrl={mat.url}
@@ -164,7 +163,7 @@ export class CDMaterial extends Component<CDMaterialProps, CDMaterialState> {
                                         materialSourceValue={''}
                                     />
                                 </div>
-                            }
+                            )}
                         </>
                     )
                 })}

--- a/src/components/app/details/triggerView/cdMaterial.tsx
+++ b/src/components/app/details/triggerView/cdMaterial.tsx
@@ -151,7 +151,6 @@ export class CDMaterial extends Component<CDMaterialProps, CDMaterialState> {
                     }
 
                     return (
-                        <>
                             {_gitCommit && (_gitCommit.Commit || _gitCommit.WebhookData?.Data) && (
                                 <div className="bcn-0 pt-12 br-4 pb-12 en-2 bw-1 m-12">
                                     <GitCommitInfoGeneric
@@ -164,7 +163,6 @@ export class CDMaterial extends Component<CDMaterialProps, CDMaterialState> {
                                     />
                                 </div>
                             )}
-                        </>
                     )
                 })}
             </>

--- a/src/components/app/details/triggerView/cdMaterial.tsx
+++ b/src/components/app/details/triggerView/cdMaterial.tsx
@@ -151,16 +151,21 @@ export class CDMaterial extends Component<CDMaterialProps, CDMaterialState> {
                     }
 
                     return (
-                        <div className="bcn-0 pt-12 br-4 pb-12 en-2 bw-1 m-12">
-                            <GitCommitInfoGeneric
-                                materialUrl={mat.url}
-                                showMaterialInfo={false}
-                                commitInfo={_gitCommit}
-                                materialSourceType={''}
-                                selectedCommitInfo={''}
-                                materialSourceValue={''}
-                            />
-                        </div>
+                        <>
+                            {
+                                (_gitCommit?.Commit || (_gitCommit?.WebhookData && _gitCommit?.WebhookData?.Data)) &&
+                                <div className="bcn-0 pt-12 br-4 pb-12 en-2 bw-1 m-12">
+                                    <GitCommitInfoGeneric
+                                        materialUrl={mat.url}
+                                        showMaterialInfo={false}
+                                        commitInfo={_gitCommit}
+                                        materialSourceType={''}
+                                        selectedCommitInfo={''}
+                                        materialSourceValue={''}
+                                    />
+                                </div>
+                            }
+                        </>
                     )
                 })}
             </>

--- a/src/components/common/GitCommitInfoGeneric.tsx
+++ b/src/components/common/GitCommitInfoGeneric.tsx
@@ -225,7 +225,6 @@ export default function GitCommitInfoGeneric({
                                     rel="noopener noreferer"
                                     className="dc__no-decor cb-5"
                                 >
-                                    {' '}
                                     View git url
                                 </a>
                             ) : null}

--- a/src/components/common/GitCommitInfoGeneric.tsx
+++ b/src/components/common/GitCommitInfoGeneric.tsx
@@ -81,7 +81,6 @@ export default function GitCommitInfoGeneric({
 
     function renderMoreDataForWebhook(_moreData) {
         return (
-            <>
                 {!showSeeMore ? (
                     <div className="material-history__all-changes">
                         <div className="material-history__body mt-4">
@@ -103,7 +102,6 @@ export default function GitCommitInfoGeneric({
                         </div>
                     </div>
                 ) : null}
-            </>
         )
     }
 

--- a/src/components/common/GitCommitInfoGeneric.tsx
+++ b/src/components/common/GitCommitInfoGeneric.tsx
@@ -1,200 +1,327 @@
 import React, { useState } from 'react'
-import { ReactComponent as Commit } from '../../assets/icons/ic-commit.svg';
-import { ReactComponent as CommitIcon } from '../../assets/icons/ic-code-commit.svg';
-import { ReactComponent as PersonIcon } from '../../assets/icons/ic-person.svg';
-import { ReactComponent as CalendarIcon } from '../../assets/icons/ic-calendar.svg';
-import { ReactComponent as MessageIcon } from '../../assets/icons/ic-message.svg';
-import { ReactComponent as BranchIcon } from '../../assets/icons/ic-branch.svg';
-import { ReactComponent as BranchMain } from '../../assets/icons/ic-branch-main.svg';
-import { ReactComponent as Check } from '../../assets/icons/ic-check-circle.svg';
-import { SourceTypeMap, Moment12HourFormat } from '../../config';
-import { createGitCommitUrl } from '../common/helpers/git';
-import { GitMaterialInfo } from './GitMaterialInfo';
-import moment from 'moment';
+import { ReactComponent as Commit } from '../../assets/icons/ic-commit.svg'
+import { ReactComponent as CommitIcon } from '../../assets/icons/ic-code-commit.svg'
+import { ReactComponent as PersonIcon } from '../../assets/icons/ic-person.svg'
+import { ReactComponent as CalendarIcon } from '../../assets/icons/ic-calendar.svg'
+import { ReactComponent as MessageIcon } from '../../assets/icons/ic-message.svg'
+import { ReactComponent as BranchIcon } from '../../assets/icons/ic-branch.svg'
+import { ReactComponent as BranchMain } from '../../assets/icons/ic-branch-main.svg'
+import { ReactComponent as Check } from '../../assets/icons/ic-check-circle.svg'
+import { SourceTypeMap, Moment12HourFormat } from '../../config'
+import { createGitCommitUrl } from '../common/helpers/git'
+import { GitMaterialInfo } from './GitMaterialInfo'
+import moment from 'moment'
 
-export default function GitCommitInfoGeneric({ materialSourceType, materialSourceValue, commitInfo, selectedCommitInfo, materialUrl, showMaterialInfo, canTriggerBuild = false }) {
-
+export default function GitCommitInfoGeneric({
+    materialSourceType,
+    materialSourceValue,
+    commitInfo,
+    selectedCommitInfo,
+    materialUrl,
+    showMaterialInfo,
+    canTriggerBuild = false,
+}) {
     const [showSeeMore, setShowSeeMore] = useState(true)
-    let _lowerCaseCommitInfo = _lowerCaseObject(commitInfo);
-    let _isWebhook = (materialSourceType === SourceTypeMap.WEBHOOK) || (_lowerCaseCommitInfo && _lowerCaseCommitInfo.webhookdata && _lowerCaseCommitInfo.webhookdata.id !== 0);
-    let _webhookData = _isWebhook ? _lowerCaseCommitInfo.webhookdata : {};
-    let _commitUrl = _isWebhook ? null : (_lowerCaseCommitInfo.commiturl ? _lowerCaseCommitInfo.commiturl : createGitCommitUrl(materialUrl, _lowerCaseCommitInfo.commit));
+    let _lowerCaseCommitInfo = _lowerCaseObject(commitInfo)
+    let _isWebhook =
+        materialSourceType === SourceTypeMap.WEBHOOK ||
+        (_lowerCaseCommitInfo && _lowerCaseCommitInfo.webhookdata && _lowerCaseCommitInfo.webhookdata.id !== 0)
+    let _webhookData = _isWebhook ? _lowerCaseCommitInfo.webhookdata : {}
+    let _commitUrl = _isWebhook
+        ? null
+        : _lowerCaseCommitInfo.commiturl
+        ? _lowerCaseCommitInfo.commiturl
+        : createGitCommitUrl(materialUrl, _lowerCaseCommitInfo.commit)
 
     function _lowerCaseObject(input): any {
-        let _output = {};
+        let _output = {}
         if (!input) {
-            return _output;
+            return _output
         }
         Object.keys(input).forEach((_key) => {
-            let _modifiedKey = _key.toLowerCase();
-            let _value = input[_key];
-            if (_value && (typeof _value === "object")) {
-                _output[_modifiedKey] = _lowerCaseObject(_value);
+            let _modifiedKey = _key.toLowerCase()
+            let _value = input[_key]
+            if (_value && typeof _value === 'object') {
+                _output[_modifiedKey] = _lowerCaseObject(_value)
             } else {
-                _output[_modifiedKey] = _value;
+                _output[_modifiedKey] = _value
             }
         })
-        return _output;
+        return _output
     }
 
     function renderBasicGitCommitInfoForWebhook() {
-        let _date;
+        let _date
         if (_webhookData.data.date) {
-            let _moment = moment(_webhookData.data.date, 'YYYY-MM-DDTHH:mm:ssZ');
-            _date = _moment.isValid() ? _moment.format(Moment12HourFormat) : _webhookData.data.date;
+            let _moment = moment(_webhookData.data.date, 'YYYY-MM-DDTHH:mm:ssZ')
+            _date = _moment.isValid() ? _moment.format(Moment12HourFormat) : _webhookData.data.date
         }
-        return <>
-            { _webhookData.data.author ? <div className="material-history__text flex left"> <PersonIcon className="icon-dim-16 mr-8" /> {_webhookData.data.author}</div> : null}
-            { _date ? <div className="material-history__text flex left">  <CalendarIcon className="icon-dim-16 mr-8" />
-                <time className="cn-7 fs-12">
-                    {_date}
-                </time>
-            </div> : null}
-            { _webhookData.data.message ? <div className="material-history__text flex left material-history-text--padded"><MessageIcon className="icon-dim-16 mr-8" />{_webhookData.data.message}</div> : null}
-        </>
+        return (
+            <>
+                {_webhookData.data.author ? (
+                    <div className="material-history__text flex left">
+                        {' '}
+                        <PersonIcon className="icon-dim-16 mr-8" /> {_webhookData.data.author}
+                    </div>
+                ) : null}
+                {_date ? (
+                    <div className="material-history__text flex left">
+                        {' '}
+                        <CalendarIcon className="icon-dim-16 mr-8" />
+                        <time className="cn-7 fs-12">{_date}</time>
+                    </div>
+                ) : null}
+                {_webhookData.data.message ? (
+                    <div className="material-history__text flex left material-history-text--padded">
+                        <MessageIcon className="icon-dim-16 mr-8" />
+                        {_webhookData.data.message}
+                    </div>
+                ) : null}
+            </>
+        )
     }
 
     function renderMoreDataForWebhook(_moreData) {
-        return <>
-            {!showSeeMore ? <div className="material-history__all-changes">
-                <div className="material-history__body mt-4" >
-                    {Object.keys(_moreData).map((_key, index) => {
-                        let classes
-                        if (index % 2 == 0) {
-                            classes = "bcn-1"
-                        }
-                        return <div key={_key} className={`material-history__text material-history__grid left pt-4 pb-4 ${classes}`}>
-                            <div >{_key}</div><div>{_moreData[_key]}</div>
+        return (
+            <>
+                {!showSeeMore ? (
+                    <div className="material-history__all-changes">
+                        <div className="material-history__body mt-4">
+                            {Object.keys(_moreData).map((_key, index) => {
+                                let classes
+                                if (index % 2 == 0) {
+                                    classes = 'bcn-1'
+                                }
+                                return (
+                                    <div
+                                        key={_key}
+                                        className={`material-history__text material-history__grid left pt-4 pb-4 ${classes}`}
+                                    >
+                                        <div>{_key}</div>
+                                        <div>{_moreData[_key]}</div>
+                                    </div>
+                                )
+                            })}
                         </div>
-                    }
-                    )}
-                </div>
-            </div> : null}</>
+                    </div>
+                ) : null}
+            </>
+        )
     }
 
     function renderSeeMoreButtonForWebhook() {
-        return <button type="button" className="fs-12 fw-6 pt-12 mt-12 pl-12 pr-12 w-100 bcn-0 flex left br-4 dc__box-shadow-top cb-5" style={{ border: "none" }} onClick={(event) => {
-            event.stopPropagation();
-            setShowSeeMore(!showSeeMore)
-        }}>
-            {showSeeMore ? "See More" : "See Less"}
-        </button>
+        return (
+            <button
+                type="button"
+                className="fs-12 fw-6 pt-12 mt-12 pl-12 pr-12 w-100 bcn-0 flex left br-4 dc__box-shadow-top cb-5"
+                style={{ border: 'none' }}
+                onClick={(event) => {
+                    event.stopPropagation()
+                    setShowSeeMore(!showSeeMore)
+                }}
+            >
+                {showSeeMore ? 'See More' : 'See Less'}
+            </button>
+        )
     }
 
     function handleMoreDataForWebhook() {
-        let _moreData = {};
-        if (_webhookData.eventactiontype == "merged") {
+        let _moreData = {}
+        if (_webhookData.eventactiontype == 'merged') {
             Object.keys(_webhookData.data).forEach((_key) => {
-                if (_key != "author" && _key != "date" && _key != "git url" && _key != "source branch name" && _key != "source checkout" && _key != "target branch name" && _key != "target checkout" && _key != "title") {
-                    _moreData[_key] = _webhookData.data[_key];
+                if (
+                    _key != 'author' &&
+                    _key != 'date' &&
+                    _key != 'git url' &&
+                    _key != 'source branch name' &&
+                    _key != 'source checkout' &&
+                    _key != 'target branch name' &&
+                    _key != 'target checkout' &&
+                    _key != 'title'
+                ) {
+                    _moreData[_key] = _webhookData.data[_key]
                 }
             })
-        } else if (_webhookData.eventactiontype == "non-merged") {
+        } else if (_webhookData.eventactiontype == 'non-merged') {
             Object.keys(_webhookData.data).forEach((_key) => {
-                if (_key != "author" && _key != "date" && _key != "target checkout") {
-                    _moreData[_key] = _webhookData.data[_key];
+                if (_key != 'author' && _key != 'date' && _key != 'target checkout') {
+                    _moreData[_key] = _webhookData.data[_key]
                 }
             })
         }
 
-        let _hasMoreData = Object.keys(_moreData).length > 0;
+        let _hasMoreData = Object.keys(_moreData).length > 0
 
-        return <>
-            {_hasMoreData && renderMoreDataForWebhook(_moreData)}
-            {_hasMoreData && renderSeeMoreButtonForWebhook()}
-        </>
+        return (
+            <>
+                {_hasMoreData && renderMoreDataForWebhook(_moreData)}
+                {_hasMoreData && renderSeeMoreButtonForWebhook()}
+            </>
+        )
     }
 
-    return (<>
-        {
-            showMaterialInfo && ((!_isWebhook && _lowerCaseCommitInfo.commit) || _isWebhook) &&
-            <GitMaterialInfo repoUrl={materialUrl} materialType={materialSourceType} materialValue={materialSourceValue} />
-        }
+    return (
+        <>
+            {showMaterialInfo && (_isWebhook || _lowerCaseCommitInfo.commit || _isWebhook) && (
+                <GitMaterialInfo
+                    repoUrl={materialUrl}
+                    materialType={materialSourceType}
+                    materialValue={materialSourceValue}
+                />
+            )}
 
-        {
-            (!_isWebhook) && _lowerCaseCommitInfo.commit &&
-            <>
-                <div className="ml-16 mr-16 flex dc__content-space">
-                    {_commitUrl ? <a href={_commitUrl} target="_blank" rel="noopener" className="commit-hash" onClick={e => e.stopPropagation()}>
-                        <div className="material-history__header"> <Commit className="commit-hash__icon" />{_lowerCaseCommitInfo.commit} </div>
-                    </a> : null}
-                    {selectedCommitInfo ? <div className="material-history__select-text " >
-                        {_lowerCaseCommitInfo.isselected ? <Check className="dc__align-right" /> : "Select"}
-                    </div> : null}
-                </div>
-                { _lowerCaseCommitInfo.author ? <div className="material-history__text flex left"><PersonIcon className="icon-dim-16 mr-8" /> {_lowerCaseCommitInfo.author}</div> : null}
-                { _lowerCaseCommitInfo.date ? <div className="material-history__text flex left"><CalendarIcon className="icon-dim-16 mr-8" /> {_lowerCaseCommitInfo.date}</div> : null}
-                { _lowerCaseCommitInfo.message ? <div className="material-history__text material-history-text--padded flex left"><MessageIcon className="icon-dim-16 mr-8" />{_lowerCaseCommitInfo.message}</div> : null}
-            </>
-        }
-
-        {
-            _isWebhook && _webhookData.eventactiontype == "merged" &&
-            <>
-                <div className="flex dc__content-space pr-16 ">
-                    <div className="ml-16 ">
-                        {_webhookData.data.title ? <div className="flex left cn-9  fs-13">{_webhookData.data.title}</div> : null}
-                        {_webhookData.data["git url"] ? <a href={`${_webhookData.data["git url"]}`} target="_blank" rel="noopener noreferer" className="dc__no-decor cb-5"> View git url</a> : null}
-                    </div>
-                    {selectedCommitInfo ? <div className="material-history__select-text material-history__header">
-                        {_lowerCaseCommitInfo.isselected ? <Check className="dc__align-right" /> : "Select"}
-                    </div> : null}
-                </div>
-
-                <div className="material-history__header ml-6 mt-12 mb-12">
-                    <div className="flex left">
-                        <BranchMain className="icon-dim-32" />
-                        <div>
-                            <div className="flex left mb-8">
-                                {_webhookData.data["source branch name"] ? <div className=" mono cn-7 fs-12 lh-1-5 br-4 bcn-1 pl-6 pr-6">
-                                    <BranchIcon className="icon-dim-12 dc__vertical-align-middle" /> {_webhookData.data["source branch name"]}
-                                </div> : null}
-                                {_webhookData.data["source checkout"] ?
-                                    <div className="flex left cb-5 br-4 pl-8 pr-8">
-                                        <a href={createGitCommitUrl(materialUrl, _webhookData.data["source checkout"])} target="_blank" rel="noopener" className="commit-hash" onClick={e => e.stopPropagation()}>
-                                            <Commit className="commit-hash__icon" />{_webhookData.data["source checkout"]}
-                                        </a>
-                                    </div>
-                                    : null}
-                            </div>
-                            <div className="flex left">
-                                <div className="mono cn-7 fs-12 lh-1-5 br-4 bcn-1 pl-6 pr-6">
-                                    {_webhookData.data["target branch name"] ?
-                                        <><BranchIcon className="icon-dim-12 dc__vertical-align-middle" /> {_webhookData.data["target branch name"]} </>
-                                        : null}
+            {!_isWebhook && _lowerCaseCommitInfo.commit && (
+                <>
+                    <div className="ml-16 mr-16 flex dc__content-space">
+                        {_commitUrl ? (
+                            <a
+                                href={_commitUrl}
+                                target="_blank"
+                                rel="noopener"
+                                className="commit-hash"
+                                onClick={(e) => e.stopPropagation()}
+                            >
+                                <div className="material-history__header">
+                                    {' '}
+                                    <Commit className="commit-hash__icon" />
+                                    {_lowerCaseCommitInfo.commit}{' '}
                                 </div>
-                                <div className="flex left cb-5 br-4 pl-8 pr-8">
-                                    {canTriggerBuild &&
-                                        <div className="flex left bcn-1 br-4 cn-5 pl-8 pr-8">
-                                            <CommitIcon className="commit-hash__icon " />HEAD
+                            </a>
+                        ) : null}
+                        {selectedCommitInfo ? (
+                            <div className="material-history__select-text ">
+                                {_lowerCaseCommitInfo.isselected ? <Check className="dc__align-right" /> : 'Select'}
+                            </div>
+                        ) : null}
+                    </div>
+                    {_lowerCaseCommitInfo.author ? (
+                        <div className="material-history__text flex left">
+                            <PersonIcon className="icon-dim-16 mr-8" /> {_lowerCaseCommitInfo.author}
+                        </div>
+                    ) : null}
+                    {_lowerCaseCommitInfo.date ? (
+                        <div className="material-history__text flex left">
+                            <CalendarIcon className="icon-dim-16 mr-8" /> {_lowerCaseCommitInfo.date}
+                        </div>
+                    ) : null}
+                    {_lowerCaseCommitInfo.message ? (
+                        <div className="material-history__text material-history-text--padded flex left">
+                            <MessageIcon className="icon-dim-16 mr-8" />
+                            {_lowerCaseCommitInfo.message}
+                        </div>
+                    ) : null}
+                </>
+            )}
+
+            {_isWebhook && _webhookData.eventactiontype == 'merged' && (
+                <>
+                    <div className="flex dc__content-space pr-16 ">
+                        <div className="ml-16 ">
+                            {_webhookData.data.title ? (
+                                <div className="flex left cn-9  fs-13">{_webhookData.data.title}</div>
+                            ) : null}
+                            {_webhookData.data['git url'] ? (
+                                <a
+                                    href={`${_webhookData.data['git url']}`}
+                                    target="_blank"
+                                    rel="noopener noreferer"
+                                    className="dc__no-decor cb-5"
+                                >
+                                    {' '}
+                                    View git url
+                                </a>
+                            ) : null}
+                        </div>
+                        {selectedCommitInfo ? (
+                            <div className="material-history__select-text material-history__header">
+                                {_lowerCaseCommitInfo.isselected ? <Check className="dc__align-right" /> : 'Select'}
+                            </div>
+                        ) : null}
+                    </div>
+
+                    <div className="material-history__header ml-6 mt-12 mb-12">
+                        <div className="flex left">
+                            <BranchMain className="icon-dim-32" />
+                            <div>
+                                <div className="flex left mb-8">
+                                    {_webhookData.data['source branch name'] ? (
+                                        <div className=" mono cn-7 fs-12 lh-1-5 br-4 bcn-1 pl-6 pr-6">
+                                            <BranchIcon className="icon-dim-12 dc__vertical-align-middle" />{' '}
+                                            {_webhookData.data['source branch name']}
                                         </div>
-                                    }
-                                    {!canTriggerBuild &&
-                                        <a href={createGitCommitUrl(materialUrl, _webhookData.data["target checkout"])} target="_blank" rel="noopener" className="commit-hash" onClick={e => e.stopPropagation()}>
-                                            <Commit className="commit-hash__icon" />{_webhookData.data["target checkout"]}
-                                        </a>
-                                    }
+                                    ) : null}
+                                    {_webhookData.data['source checkout'] ? (
+                                        <div className="flex left cb-5 br-4 pl-8 pr-8">
+                                            <a
+                                                href={createGitCommitUrl(
+                                                    materialUrl,
+                                                    _webhookData.data['source checkout'],
+                                                )}
+                                                target="_blank"
+                                                rel="noopener"
+                                                className="commit-hash"
+                                                onClick={(e) => e.stopPropagation()}
+                                            >
+                                                <Commit className="commit-hash__icon" />
+                                                {_webhookData.data['source checkout']}
+                                            </a>
+                                        </div>
+                                    ) : null}
+                                </div>
+                                <div className="flex left">
+                                    <div className="mono cn-7 fs-12 lh-1-5 br-4 bcn-1 pl-6 pr-6">
+                                        {_webhookData.data['target branch name'] ? (
+                                            <>
+                                                <BranchIcon className="icon-dim-12 dc__vertical-align-middle" />{' '}
+                                                {_webhookData.data['target branch name']}{' '}
+                                            </>
+                                        ) : null}
+                                    </div>
+                                    <div className="flex left cb-5 br-4 pl-8 pr-8">
+                                        {canTriggerBuild && (
+                                            <div className="flex left bcn-1 br-4 cn-5 pl-8 pr-8">
+                                                <CommitIcon className="commit-hash__icon " />
+                                                HEAD
+                                            </div>
+                                        )}
+                                        {!canTriggerBuild && (
+                                            <a
+                                                href={createGitCommitUrl(
+                                                    materialUrl,
+                                                    _webhookData.data['target checkout'],
+                                                )}
+                                                target="_blank"
+                                                rel="noopener"
+                                                className="commit-hash"
+                                                onClick={(e) => e.stopPropagation()}
+                                            >
+                                                <Commit className="commit-hash__icon" />
+                                                {_webhookData.data['target checkout']}
+                                            </a>
+                                        )}
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                </div>
-                {renderBasicGitCommitInfoForWebhook()}
-                {handleMoreDataForWebhook()}
-            </>
-        }
-        {
-            _isWebhook && _webhookData.eventactiontype == "non-merged" && <>
-                <div className="flex left pr-16 pb-8" style={{ justifyContent: "space-between" }}>
-                    <div className="flex left cn-9 fs-13 ml-16"> {_webhookData.data["target checkout"]}</div>
-                    {selectedCommitInfo ? <div className="material-history__select-text" >
-                        {_lowerCaseCommitInfo.isselected ? <Check className="dc__align-right" /> : "Select"}
-                    </div> : null}
-                </div>
-                {renderBasicGitCommitInfoForWebhook()}
-                {handleMoreDataForWebhook()}
-            </>
-        }
-    </>
+                    {renderBasicGitCommitInfoForWebhook()}
+                    {handleMoreDataForWebhook()}
+                </>
+            )}
+            {_isWebhook && _webhookData.eventactiontype == 'non-merged' && (
+                <>
+                    <div className="flex left pr-16 pb-8" style={{ justifyContent: 'space-between' }}>
+                        <div className="flex left cn-9 fs-13 ml-16"> {_webhookData.data['target checkout']}</div>
+                        {selectedCommitInfo ? (
+                            <div className="material-history__select-text">
+                                {_lowerCaseCommitInfo.isselected ? <Check className="dc__align-right" /> : 'Select'}
+                            </div>
+                        ) : null}
+                    </div>
+                    {renderBasicGitCommitInfoForWebhook()}
+                    {handleMoreDataForWebhook()}
+                </>
+            )}
+        </>
     )
 }

--- a/src/components/common/GitCommitInfoGeneric.tsx
+++ b/src/components/common/GitCommitInfoGeneric.tsx
@@ -107,12 +107,12 @@ export default function GitCommitInfoGeneric({ materialSourceType, materialSourc
 
     return (<>
         {
-            showMaterialInfo &&
+            showMaterialInfo && ((!_isWebhook && _lowerCaseCommitInfo.commit) || _isWebhook) &&
             <GitMaterialInfo repoUrl={materialUrl} materialType={materialSourceType} materialValue={materialSourceValue} />
         }
 
         {
-            (!_isWebhook) &&
+            (!_isWebhook) && _lowerCaseCommitInfo.commit &&
             <>
                 <div className="ml-16 mr-16 flex dc__content-space">
                     {_commitUrl ? <a href={_commitUrl} target="_blank" rel="noopener" className="commit-hash" onClick={e => e.stopPropagation()}>

--- a/src/components/common/GitCommitInfoGeneric.tsx
+++ b/src/components/common/GitCommitInfoGeneric.tsx
@@ -60,13 +60,11 @@ export default function GitCommitInfoGeneric({
             <>
                 {_webhookData.data.author ? (
                     <div className="material-history__text flex left">
-                        {' '}
                         <PersonIcon className="icon-dim-16 mr-8" /> {_webhookData.data.author}
                     </div>
                 ) : null}
                 {_date ? (
                     <div className="material-history__text flex left">
-                        {' '}
                         <CalendarIcon className="icon-dim-16 mr-8" />
                         <time className="cn-7 fs-12">{_date}</time>
                     </div>


### PR DESCRIPTION
# Description

This happens in case an app is using multiple git repositories and if someone deletes a git repository from those, workflow doesn't get updated with the changes. It keeps showing the same git repositories which were before deletion of any one of them.
Even if you add the same repo again, Workflow doesn't update the id for the same. Triggered ci pipeline with multiple git repositories and when one of the git material is deleted, it should have affected multiple places but deletion was not reflecting at all anywhere.
In Ui when the git material is deleted, In ci and cd history the git material card was shown but with empty commit, hence fixes to be done there.
Places where git material deletion should be reflected are:-

1. Workflow editor
Deleted git repository node will be removed
Current Behavior:- Git material deleted in the git repositories section but it still appears in the pipeline.
2. Build & deploy
Deleted git repositoryke node will be removed
Current Behavior:- Git material deleted in the git repositories section but it still appears in the pipeline.
3. WorkFlow Editor> Edit Build Pipeline > Select Source Code
Deleted git repository should not be shown as an option here.
Current Behavior:-Git material deleted in the git repositories section but it still appears in the source code options.
4. CI > Select material
Deleted git repository will not be shown for commit selection
Current Behavior:- Git material deleted in the git repositories section but it still appears as an option in the select material
section.
5. CD > Select image > Source info
Only those “repo + commits” will be shown which were used to build the image
Current Behavior:- Git material deleted in the git repositories section but it still appears in the source info in deployment
card.
6. Build history > Source code
For each triggered build, show the state at that point of time I.e. If 2 repos were connected during the build trigger, 2
repos and the selected commits will be shown. Later if the user removed a repo and triggered a build, only 1 repo will be
shown against that build trigger. 
Current Behavior:- Builds triggered with one git repertory, also shows history of 2nd git
material, which was deleted from the git repositories.
7. Deployment history > Source code
For each triggered deployment, show only those “repo + commits” which were used to build the deployed image.
Current Behavior:- Deployments triggered with one git repertory, also shows history of 2nd git material, which was deleted
from the git repositories.
8. App Details > Commit Info
As this is the current state of a deployed commit(which commits are being deployed from which git material), if
deployment is triggered by 2 git material then 2 git materials should reflect here, else if there is only one then only 1 git
material should reflect here.

Fixes https://github.com/devtron-labs/devtron/issues/1397

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I tested the code locally as well as on personal vm multiple times. Tested all the cases and implications when a git repo is deleted and where it should be reflected.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


