### PR TITLE
fix: change CronJob & Job to Job & CronJob in constants file

### DIFF
--- a/src/components/deploymentConfig/constants.tsx
+++ b/src/components/deploymentConfig/constants.tsx
@@ -91,7 +91,7 @@ export const EDITOR_VIEW = {
 export const CHART_TYPE_TAB_KEYS = { DEVTRON_CHART: 'devtronChart', CUSTOM_CHARTS: 'customCharts' }
 export const CHART_TYPE_TAB = { devtronChart: 'Charts by Devtron', customCharts: 'Custom charts' }
 export const CHART_DOCUMENTATION_LINK = {
-    'CronJob & Job': DOCUMENTATION.JOB_CRONJOB,
+    'Job & CronJob': DOCUMENTATION.JOB_CRONJOB,
     'Rollout Deployment': DOCUMENTATION.ROLLOUT,
 }
 export const RECOMMENDED_CHART_NAME = 'Deployment'


### PR DESCRIPTION
# Description

Changed the chart name from CronJob & Job to Job & CronJob in constants file so that 'Learn More' link is functional. Previously, Learn More link was not showing as CronJob & Job name was changed at the backend to Job & CronJob.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested the code change multiple times locally via port forwarding, with my orchestrator pointing to demo1.

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


