### PR TITLE
fix: Block deletion of default devtron app(devtron-operator chart)

### DIFF
--- a/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
+++ b/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
@@ -1271,7 +1271,7 @@ function ChartValuesView({
                             chartValueId !== '0' &&
                             !(
                                 deployedAppDetail &&
-                                CheckIfDevtronOperatorHelmRelease(deployedAppDetail[2], deployedAppDetail[1], deployedAppDetail[0])
+                                checkIfDevtronOperatorHelmRelease(deployedAppDetail[2], deployedAppDetail[1], deployedAppDetail[0])
                             ) && (
                                 <DeleteApplicationButton
                                     type={isCreateValueView ? 'preset value' : 'Application'}

--- a/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
+++ b/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
@@ -25,7 +25,7 @@ import {
     updateChartValues,
 } from '../../../charts/charts.service'
 import { ServerErrors } from '../../../../modals/commonTypes'
-import { ConfigurationType, SERVER_MODE, URLS } from '../../../../config'
+import { ConfigurationType, SERVER_MODE, URLS, DEVTRON_DEFAULT_CHART_NAME, DEVTRON_DEFAULT_NAMESPACE } from '../../../../config'
 import YAML from 'yaml'
 import {
     ChartEnvironmentSelector,
@@ -1174,6 +1174,7 @@ function ChartValuesView({
     }
 
     const renderData = () => {
+        const deployedAppDetail = isExternalApp && appId.split('|')
         return (
             <div
                 className={`chart-values-view__container bcn-0 ${
@@ -1265,14 +1266,22 @@ function ChartValuesView({
                                 hideCreateNewOption={isCreateValueView}
                             />
                         )}
-                        {!isDeployChartView && chartValueId !== '0' && (
-                            <DeleteApplicationButton
-                                type={isCreateValueView ? 'preset value' : 'Application'}
-                                isUpdateInProgress={commonState.isUpdateInProgress}
-                                isDeleteInProgress={commonState.isDeleteInProgress}
-                                dispatch={dispatch}
-                            />
-                        )}
+
+                        {!isDeployChartView &&
+                            chartValueId !== '0' &&
+                            !(
+                                deployedAppDetail &&
+                                deployedAppDetail[2] === DEVTRON_DEFAULT_CHART_NAME &&
+                                deployedAppDetail[1] === DEVTRON_DEFAULT_NAMESPACE &&
+                                deployedAppDetail[0] === '1'
+                            ) && (
+                                <DeleteApplicationButton
+                                    type={isCreateValueView ? 'preset value' : 'Application'}
+                                    isUpdateInProgress={commonState.isUpdateInProgress}
+                                    isDeleteInProgress={commonState.isDeleteInProgress}
+                                    dispatch={dispatch}
+                                />
+                            )}
                     </div>
                     {commonState.openReadMe && (
                         <ActiveReadmeColumn

--- a/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
+++ b/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
@@ -25,7 +25,7 @@ import {
     updateChartValues,
 } from '../../../charts/charts.service'
 import { ServerErrors } from '../../../../modals/commonTypes'
-import { ConfigurationType, SERVER_MODE, URLS, DEVTRON_DEFAULT_CHART_NAME, DEVTRON_DEFAULT_NAMESPACE } from '../../../../config'
+import { ConfigurationType, SERVER_MODE, URLS, CheckIfDevtronOperatorHelmRelease } from '../../../../config'
 import YAML from 'yaml'
 import {
     ChartEnvironmentSelector,
@@ -1271,9 +1271,7 @@ function ChartValuesView({
                             chartValueId !== '0' &&
                             !(
                                 deployedAppDetail &&
-                                deployedAppDetail[2] === DEVTRON_DEFAULT_CHART_NAME &&
-                                deployedAppDetail[1] === DEVTRON_DEFAULT_NAMESPACE &&
-                                deployedAppDetail[0] === '1'
+                                CheckIfDevtronOperatorHelmRelease(deployedAppDetail[2], deployedAppDetail[1], deployedAppDetail[0])
                             ) && (
                                 <DeleteApplicationButton
                                     type={isCreateValueView ? 'preset value' : 'Application'}

--- a/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
+++ b/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
@@ -25,7 +25,7 @@ import {
     updateChartValues,
 } from '../../../charts/charts.service'
 import { ServerErrors } from '../../../../modals/commonTypes'
-import { ConfigurationType, SERVER_MODE, URLS, CheckIfDevtronOperatorHelmRelease } from '../../../../config'
+import { ConfigurationType, SERVER_MODE, URLS, checkIfDevtronOperatorHelmRelease } from '../../../../config'
 import YAML from 'yaml'
 import {
     ChartEnvironmentSelector,

--- a/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
+++ b/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
@@ -1174,7 +1174,7 @@ function ChartValuesView({
     }
 
     const renderData = () => {
-        const deployedAppDetail = isExternalApp && appId.split('|')
+        const deployedAppDetail = isExternalApp && appId && appId.split('|')
         return (
             <div
                 className={`chart-values-view__container bcn-0 ${

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -3,8 +3,9 @@ export const DEFAULT_STATUS = 'Checking Status...'
 export const Host = process.env.REACT_APP_ORCHESTRATOR_ROOT
 export const DEFAULTK8SVERSION = 'v1.16.0'
 export const TOKEN_COOKIE_NAME = 'argocd.token'
-export const DEVTRON_DEFAULT_CHART_NAME = 'devtron'
+export const DEVTRON_DEFAULT_RELEASE_NAME = 'devtron'
 export const DEVTRON_DEFAULT_NAMESPACE = 'devtroncd'
+export const DEVTRON_DEFAULT_CLUSTER_ID = 1
 
 export const Routes = {
     GET: 'get',

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -5,7 +5,7 @@ export const DEFAULTK8SVERSION = 'v1.16.0'
 export const TOKEN_COOKIE_NAME = 'argocd.token'
 export const DEVTRON_DEFAULT_RELEASE_NAME = 'devtron'
 export const DEVTRON_DEFAULT_NAMESPACE = 'devtroncd'
-export const DEVTRON_DEFAULT_CLUSTER_ID = 1
+export const DEVTRON_DEFAULT_CLUSTER_ID = '1'
 
 export const Routes = {
     GET: 'get',

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -3,6 +3,8 @@ export const DEFAULT_STATUS = 'Checking Status...'
 export const Host = process.env.REACT_APP_ORCHESTRATOR_ROOT
 export const DEFAULTK8SVERSION = 'v1.16.0'
 export const TOKEN_COOKIE_NAME = 'argocd.token'
+export const DEVTRON_DEFAULT_CHART_NAME = 'devtron'
+export const DEVTRON_DEFAULT_NAMESPACE = 'devtroncd'
 
 export const Routes = {
     GET: 'get',

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,2 +1,3 @@
 export * from './constants'
 export * from './routes'
+export * from './utils'

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -1,0 +1,7 @@
+import { DEVTRON_DEFAULT_RELEASE_NAME, DEVTRON_DEFAULT_NAMESPACE, DEVTRON_DEFAULT_CLUSTER_ID } from '../config'
+
+export const CheckIfDevtronOperatorHelmRelease = (releaseName: string, namespace: string, clusterId: string): boolean => {
+    return releaseName === DEVTRON_DEFAULT_RELEASE_NAME &&
+        namespace === DEVTRON_DEFAULT_NAMESPACE &&
+        clusterId === DEVTRON_DEFAULT_CLUSTER_ID.toString()
+}

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -1,7 +1,7 @@
 import { DEVTRON_DEFAULT_RELEASE_NAME, DEVTRON_DEFAULT_NAMESPACE, DEVTRON_DEFAULT_CLUSTER_ID } from '../config'
 
-export const CheckIfDevtronOperatorHelmRelease = (releaseName: string, namespace: string, clusterId: string): boolean => {
+export const checkIfDevtronOperatorHelmRelease = (releaseName: string, namespace: string, clusterId: string): boolean => {
     return releaseName === DEVTRON_DEFAULT_RELEASE_NAME &&
         namespace === DEVTRON_DEFAULT_NAMESPACE &&
-        clusterId === DEVTRON_DEFAULT_CLUSTER_ID.toString()
+        clusterId === DEVTRON_DEFAULT_CLUSTER_ID
 }


### PR DESCRIPTION
# Description

Block deletion of Devtron(devtron-operator chart) helm apps. Deletion of the default app comes with some unwanted behaviour so for default devtron app delete option must not be shown on the UI.

Fixes:- [#2708](https://github.com/devtron-labs/devtron/issues/2708)
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested locally multiple times while port-forwarding.
- [x] Tested by deploying the changes on demo cluster in feature_demo_21_nov branch.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


