### PR TITLE
fix: added check to prevent the warning on linked ci

### DIFF
--- a/src/components/app/details/triggerView/workflow/Workflow.tsx
+++ b/src/components/app/details/triggerView/workflow/Workflow.tsx
@@ -227,7 +227,7 @@ export class Workflow extends Component<WorkflowProps> {
 
     render() {
         const isExternalCiWorkflow = this.props.nodes.some(
-            (node) => node.isExternalCI && node.type === WorkflowNodeType.CI,
+            (node) => node.isExternalCI && !node.isLinkedCI && node.type === WorkflowNodeType.CI,
         )
         return (
             <div className="workflow workflow--trigger mb-20" style={{ minWidth: `${this.props.width}px` }}>

--- a/src/components/workflowEditor/Workflow.tsx
+++ b/src/components/workflowEditor/Workflow.tsx
@@ -236,7 +236,7 @@ export class Workflow extends Component<WorkflowProps, WorkflowState> {
     }
 
     openCIPipeline(node: NodeAttr) {
-        if(node.isExternalCI){
+        if(node.isExternalCI && !node.isLinkedCI){
           return `${this.props.match.url}/deprecated-warning`
         }
         let { appId } = this.props.match.params
@@ -354,7 +354,7 @@ export class Workflow extends Component<WorkflowProps, WorkflowState> {
         ciPipelineId = ciPipeline ? +ciPipeline.id : ciPipelineId
         const configDiffView = this.props.cdWorkflowList?.length > 0
         const isExternalCiWorkflow = this.props.nodes.some(
-            (node) => node.isExternalCI && node.type === WorkflowNodeType.CI,
+            (node) => node.isExternalCI && !node.isLinkedCI && node.type === WorkflowNodeType.CI,
         )
         return (
             <ConditionalWrap


### PR DESCRIPTION
# Description

The deprecated warning should come only in case on old external CI

Fixes # [AB#1356](https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/1356)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Manually tested on external and linked ci


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


