### PR TITLE
fix: clusterName delay in cluster terminal

### DIFF
--- a/src/components/ClusterNodes/NodeList.tsx
+++ b/src/components/ClusterNodes/NodeList.tsx
@@ -68,6 +68,7 @@ export default function NodeList({ imageList, isSuperAdmin, namespaceList }: Clu
     const [nodeListOffset, setNodeListOffset] = useState(0)
     const [showTerminal, setTerminal] = useState<boolean>(false)
     const nodeList = filteredFlattenNodeList.map((node) => node['name'])
+    const clusterName: string = filteredFlattenNodeList[0] ? filteredFlattenNodeList[0]['clusterName'] : ''
     const [selectedNode, setSelectedNode] = useState<string>()
     const pageSize = 15
 
@@ -695,7 +696,7 @@ export default function NodeList({ imageList, isSuperAdmin, namespaceList }: Clu
                     nodeList={nodeList}
                     closeTerminal={closeTerminal}
                     clusterImageList={imageList}
-                    namespaceList={namespaceList[selectedCluster.label]}
+                    namespaceList={namespaceList[clusterName]}
                     node={selectedNode}
                     setSelectedNode={setSelectedNode}
                 />

--- a/src/components/ClusterNodes/NodeList.tsx
+++ b/src/components/ClusterNodes/NodeList.tsx
@@ -68,7 +68,7 @@ export default function NodeList({ imageList, isSuperAdmin, namespaceList }: Clu
     const [nodeListOffset, setNodeListOffset] = useState(0)
     const [showTerminal, setTerminal] = useState<boolean>(false)
     const nodeList = filteredFlattenNodeList.map((node) => node['name'])
-    const clusterName: string = filteredFlattenNodeList[0] ? filteredFlattenNodeList[0]['clusterName'] : ''
+    const clusterName: string = filteredFlattenNodeList[0]?.['clusterName'] || ''
     const [selectedNode, setSelectedNode] = useState<string>()
     const pageSize = 15
 

--- a/src/components/ClusterNodes/clusterNodes.service.tsx
+++ b/src/components/ClusterNodes/clusterNodes.service.tsx
@@ -58,7 +58,7 @@ export const clusterTerminalTypeUpdate = (data): Promise<ResponseType> => {
 }
 
 export const clusterNamespaceList = (): Promise<ResponseType> => {
-    return get(`${Routes.CLUSTER_NAMESPACE}`)
+    return get(Routes.CLUSTER_NAMESPACE)
 }
 
 export const getClusterManifest = (terminalAccessId: number):  Promise<ResponseType> => {

--- a/src/components/ClusterNodes/clusterNodes.service.tsx
+++ b/src/components/ClusterNodes/clusterNodes.service.tsx
@@ -58,7 +58,7 @@ export const clusterTerminalTypeUpdate = (data): Promise<ResponseType> => {
 }
 
 export const clusterNamespaceList = (): Promise<ResponseType> => {
-    return get(`/${Routes.CLUSTER_NAMESPACE}`)
+    return get(`${Routes.CLUSTER_NAMESPACE}`)
 }
 
 export const getClusterManifest = (terminalAccessId: number):  Promise<ResponseType> => {


### PR DESCRIPTION
# Description

Fixed cluster terminal page breaks when list API is pending

fixes #devtron-labs/devtron/issues/2803

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


