### PR TITLE
feat: Cluster node details action buttons

### DIFF
--- a/src/components/ClusterNodes/NodeActions/CordonNodeModal.tsx
+++ b/src/components/ClusterNodes/NodeActions/CordonNodeModal.tsx
@@ -23,7 +23,7 @@ export default function CordonNodeModal({ name, version, kind, unschedulable, cl
                 name: name,
                 version: version,
                 kind: kind,
-                nodeCordonHelper: {
+                nodeCordonOptions: {
                     unschedulableDesired: !unschedulable,
                 },
             }

--- a/src/components/ClusterNodes/NodeActions/DrainNodeModal.tsx
+++ b/src/components/ClusterNodes/NodeActions/DrainNodeModal.tsx
@@ -84,7 +84,7 @@ export default function DrainNodeModal({ name, version, kind, closePopup }: Node
                 name: name,
                 version: version,
                 kind: kind,
-                nodeDrainHelper: {
+                nodeDrainOptions: {
                     gracePeriodSeconds: Number(gracePeriod),
                     deleteEmptyDirData: deleteEmptyDirData,
                     disableEviction: disableEviction,

--- a/src/components/ClusterNodes/NodeActions/EditTaintsModal.tsx
+++ b/src/components/ClusterNodes/NodeActions/EditTaintsModal.tsx
@@ -41,7 +41,7 @@ export default function EditTaintsModal({ name, version, kind, taints, closePopu
     const addNewTaint = (): void => {
         const _taintList = [...taintList, { key: '', value: '', effect: EFFECT_TYPE.PreferNoSchedule }]
         setTaintList(_taintList)
-        validateTaintList(_taintList)
+        validateTaintList(_taintList, true)
     }
 
     const handleInputChange = (e): void => {
@@ -58,7 +58,7 @@ export default function EditTaintsModal({ name, version, kind, taints, closePopu
         setTaintList(_taintList)
     }
 
-    const validateTaintList = (_taintList): TaintErrorObj => {
+    const validateTaintList = (_taintList: TaintType[], ignoreNewlyAdded?: boolean): TaintErrorObj => {
         const _errorObj = { isValid: true, taintErrorList: [] }
         const uniqueTaintMap = new Map<string, boolean>()
         for (let index = 0; index < _taintList.length; index++) {
@@ -67,8 +67,8 @@ export default function EditTaintsModal({ name, version, kind, taints, closePopu
             const validateTaintValue = validationRules.taintValue(element.value)
             if (uniqueTaintMap.get(uniqueKey)) {
                 _errorObj.taintErrorList.push({
-                    key: 'Duplicate taint key',
-                    value: { validateTaintValue },
+                    key: { isValid: false, message: 'Duplicate taint key' },
+                    value: validateTaintValue,
                 })
                 _errorObj.isValid = false
             } else {
@@ -80,6 +80,12 @@ export default function EditTaintsModal({ name, version, kind, taints, closePopu
                 })
                 _errorObj.isValid = _errorObj.isValid && validateTaintKey.isValid && validateTaintValue.isValid
             }
+        }
+        if (ignoreNewlyAdded) {
+            _errorObj.taintErrorList.splice(-1, 1, {
+                key: { isValid: true, message: null },
+                value: { isValid: true, message: null },
+            })
         }
         setErrorObj(_errorObj)
         return _errorObj

--- a/src/components/ClusterNodes/NodeActions/EditTaintsModal.tsx
+++ b/src/components/ClusterNodes/NodeActions/EditTaintsModal.tsx
@@ -144,6 +144,7 @@ export default function EditTaintsModal({ name, version, kind, taints, closePopu
                                         value={taintDetails.key}
                                         className="form__input h-32"
                                         onChange={handleInputChange}
+                                        placeholder="Key"
                                     />
                                     {_errorObj && !_errorObj['key'].isValid && (
                                         <span className="flexbox cr-5 mt-4 fw-5 fs-11 flexbox">
@@ -160,6 +161,7 @@ export default function EditTaintsModal({ name, version, kind, taints, closePopu
                                         value={taintDetails.value}
                                         className="form__input h-32"
                                         onChange={handleInputChange}
+                                        placeholder="Value"
                                     />
                                     {_errorObj && !_errorObj['value'].isValid && (
                                         <span className="flexbox cr-5 mt-4 fw-5 fs-11 flexbox">

--- a/src/components/ClusterNodes/NodeActions/NodeActionsMenu.tsx
+++ b/src/components/ClusterNodes/NodeActions/NodeActionsMenu.tsx
@@ -87,14 +87,14 @@ export default function NodeActionsMenu({ nodeData, openTerminal, getNodeListDat
                             className="flex left h-36 cursor pl-12 pr-12 dc__hover-n50"
                             onClick={handleOpenTerminalAction}
                         >
-                            <TerminalIcon className="mr-8" />
+                            <TerminalIcon className="icon-dim-16 mr-8" />
                             {CLUSTER_NODE_ACTIONS_LABELS.terminal}
                         </span>
                         <span
                             className="flex left h-36 cursor pl-12 pr-12 dc__hover-n50"
                             onClick={showCordonNodeModal}
                         >
-                            <CordonIcon className="mr-8" />
+                            <CordonIcon className="icon-dim-16 mr-8" />
                             {nodeData.unschedulable
                                 ? CLUSTER_NODE_ACTIONS_LABELS.uncordon
                                 : CLUSTER_NODE_ACTIONS_LABELS.cordon}
@@ -103,25 +103,25 @@ export default function NodeActionsMenu({ nodeData, openTerminal, getNodeListDat
                             className="flex left h-36 cursor pl-12 pr-12 dc__hover-n50"
                             onClick={showDrainNodeModal}
                         >
-                            <DrainIcon className="mr-8" />
+                            <DrainIcon className="icon-dim-16 mr-8" />
                             {CLUSTER_NODE_ACTIONS_LABELS.drain}
                         </span>
                         <span className="flex left h-36 cursor pl-12 pr-12 dc__hover-n50" onClick={showEditTaintsModal}>
-                            <EditTaintsIcon className="mr-8" />
+                            <EditTaintsIcon className="icon-dim-16 mr-8" />
                             {CLUSTER_NODE_ACTIONS_LABELS.taints}
                         </span>
                         <span
                             className="flex left h-36 cursor pl-12 pr-12 dc__hover-n50"
                             onClick={handleEditYamlAction}
                         >
-                            <EditFileIcon className="mr-8" />
+                            <EditFileIcon className="icon-dim-16 mr-8" />
                             {CLUSTER_NODE_ACTIONS_LABELS.yaml}
                         </span>
                         <span
                             className="flex left h-36 cursor pl-12 pr-12 cr-5 dc__hover-n50"
                             onClick={showDeleteNodeModal}
                         >
-                            <DeleteIcon className="mr-8 scr-5" />
+                            <DeleteIcon className="icon-dim-16 mr-8 scr-5" />
                             {CLUSTER_NODE_ACTIONS_LABELS.delete}
                         </span>
                     </div>

--- a/src/components/ClusterNodes/NodeDetails.tsx
+++ b/src/components/ClusterNodes/NodeDetails.tsx
@@ -20,7 +20,7 @@ import { ReactComponent as Storage } from '../../assets/icons/ic-storage.svg'
 import { ReactComponent as Edit } from '../../assets/icons/ic-pencil.svg'
 import { ReactComponent as Dropdown } from '../../assets/icons/ic-chevron-down.svg'
 import { ReactComponent as CordonIcon } from '../../assets/icons/ic-cordon.svg'
-import { ReactComponent as PlayIcon } from '../../assets/icons/ic-play.svg';
+import {ReactComponent as UncordonIcon } from '../../assets/icons/ic-play-medium.svg'
 import { ReactComponent as DrainIcon } from '../../assets/icons/ic-clean-brush.svg'
 import { ReactComponent as EditTaintsIcon } from '../../assets/icons/ic-spraycan.svg'
 import { ReactComponent as DeleteIcon } from '../../assets/icons/ic-delete-interactive.svg'
@@ -746,7 +746,7 @@ export default function NodeDetails({ imageList, isSuperAdmin, namespaceList }: 
                             <span className="flexbox fw-6 cb-5 ml-16 fs-13 pointer" onClick={showCordonNodeModal}>
 
                                 {nodeDetail.unschedulable
-                                ? <><PlayIcon className="icon-dim-12 mr-5 scb-5" />{CLUSTER_NODE_ACTIONS_LABELS.uncordon}</>
+                                ? <><UncordonIcon className="icon-dim-14 mt-3 mr-5 scb-5" />{CLUSTER_NODE_ACTIONS_LABELS.uncordon}</>
                                 : <><CordonIcon className="icon-dim-14 mt-3 mr-5 scb-5" />{CLUSTER_NODE_ACTIONS_LABELS.cordon}</>}
                             </span>
                             <span className="flexbox fw-6 cb-5 ml-16 fs-13 pointer" onClick={showDrainNodeModal}>

--- a/src/components/ClusterNodes/types.ts
+++ b/src/components/ClusterNodes/types.ts
@@ -198,15 +198,15 @@ export interface EditTaintsModalType extends NodeActionModalPropType {
     taints: TaintType[]
 }
 
-interface NodeCordonHelper {
+interface NodeCordonOptions {
     unschedulableDesired: boolean
 }
 
 export interface NodeCordonRequest extends NodeActionRequest {
-    nodeCordonHelper: NodeCordonHelper
+    nodeCordonOptions: NodeCordonOptions
 }
 
-interface NodeDrainHelper {
+interface NodeDrainOptions {
     gracePeriodSeconds: number
     deleteEmptyDirData: boolean
     disableEviction: boolean
@@ -215,7 +215,7 @@ interface NodeDrainHelper {
 }
 
 export interface NodeDrainRequest extends NodeActionRequest {
-    nodeDrainHelper: NodeDrainHelper
+  nodeDrainOptions: NodeDrainOptions
 }
 
 export interface EditTaintsRequest extends NodeActionRequest {


### PR DESCRIPTION
# Description

These changes will add an action buttons to the cluster node details which will contain different actions like,
- Cordon node
- Drain node
- Edit taints
- Edit YAML
- Delete node

Fixes - [AB#1613](https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/1613)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been performed manually by visiting `Clusters > Select cluster > Perform node actions`.

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


