### PR TITLE
fix: chart repo selector is not displayed

### DIFF
--- a/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
+++ b/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
@@ -1293,7 +1293,7 @@ function ChartValuesView({
                                 invalidaEnvironment={commonState.invalidaEnvironment}
                             />
                         )}
-                        {!window._env_.HIDE_GITOPS_OR_HELM_OPTION && !isExternalApp &&(
+                        {!window._env_.HIDE_GITOPS_OR_HELM_OPTION && !isExternalApp && (
                             <DeploymentAppSelector
                                 commonState={commonState}
                                 isUpdate={isUpdate}
@@ -1302,18 +1302,19 @@ function ChartValuesView({
                             />
                         )}
                         <div className="chart-values-view__hr-divider bcn-1 mt-16 mb-16" />
-                        {!isDeployChartView && commonState.showRepoSelector && (
-                            <ChartRepoSelector
-                                isExternal={isExternalApp}
-                                isUpdate={!!isUpdate}
-                                installedAppInfo={commonState.installedAppInfo}
-                                handleRepoChartValueChange={handleRepoChartValueChange}
-                                repoChartValue={commonState.repoChartValue}
-                                chartDetails={commonState.repoChartValue}
-                                showConnectToChartTippy={commonState.showConnectToChartTippy}
-                                hideConnectToChartTippy={hideConnectToChartTippy}
-                            />
-                        )}
+                        {!isDeployChartView &&
+                            (!isExternalApp || commonState.installedAppInfo || commonState.showRepoSelector) && (
+                                <ChartRepoSelector
+                                    isExternal={isExternalApp}
+                                    isUpdate={!!isUpdate}
+                                    installedAppInfo={commonState.installedAppInfo}
+                                    handleRepoChartValueChange={handleRepoChartValueChange}
+                                    repoChartValue={commonState.repoChartValue}
+                                    chartDetails={commonState.repoChartValue}
+                                    showConnectToChartTippy={commonState.showConnectToChartTippy}
+                                    hideConnectToChartTippy={hideConnectToChartTippy}
+                                />
+                            )}
                         {!isDeployChartView &&
                             isExternalApp &&
                             !commonState.installedAppInfo &&
@@ -1360,7 +1361,11 @@ function ChartValuesView({
                             chartValueId !== '0' &&
                             !(
                                 deployedAppDetail &&
-                                checkIfDevtronOperatorHelmRelease(deployedAppDetail[2], deployedAppDetail[1], deployedAppDetail[0])
+                                checkIfDevtronOperatorHelmRelease(
+                                    deployedAppDetail[2],
+                                    deployedAppDetail[1],
+                                    deployedAppDetail[0],
+                                )
                             ) && (
                                 <DeleteApplicationButton
                                     type={isCreateValueView ? 'preset value' : 'Application'}


### PR DESCRIPTION
# Description

This change will fix the chart repo selector that is not displayed under the values tab issue.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been performed manually by visiting chart values view & selecting chart repo. 


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


