### PR TITLE
fix: Scroll and autoselect on single item

### DIFF
--- a/src/components/app/details/cIDetails/CIDetails.tsx
+++ b/src/components/app/details/cIDetails/CIDetails.tsx
@@ -69,10 +69,14 @@ export default function CIDetails() {
             return agg
         }, triggerHistory)
         setTriggerHistory(new Map(newTriggerHistory))
-        return () => {
-            setTriggerHistory(new Map())
-        }
     }, [triggerHistoryResult])
+
+    useEffect(() => {
+      return () => {
+          setTriggerHistory(new Map())
+          setHasMoreLoading(false)
+      }
+  }, [pipelineId])
 
     function synchroniseState(triggerId: number, triggerDetails: History) {
         if (triggerId === triggerDetails.id) {
@@ -103,6 +107,9 @@ export default function CIDetails() {
     const pipelines: CIPipeline[] = (initDataResults[0]?.['value']?.['result'] || [])?.filter(
         (pipeline) => pipeline.pipelineType !== 'EXTERNAL',
     ) // external pipelines not visible in dropdown
+    if(pipelines.length ===1 && !pipelineId){
+      replace(generatePath(path, { appId, pipelineId: pipelines[0].id }))
+    }
     const pipelineOptions: CICDSidebarFilterOptionType[] = (pipelines || []).map((item) => {
         return { value: `${item.id}`, label: item.name, pipelineId: item.id }
     })


### PR DESCRIPTION
# Description

This PR has the fix of CI/CD details page 2nd page scroll and autoselection of env/pipeline in case of single option

Fixes # [(AB#1846)](https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/1846)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
- verified by opening the build/deploymnent history when there is only 1 pipeline/env option available
- verified on build/deployment history when there are more than 20 history available and scrolled till bottom so that 2nd page gets loaded


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


