### PR TITLE
fix: Multigit linkedci local git material visible bugfix

### DIFF
--- a/src/components/app/details/triggerView/workflow.service.ts
+++ b/src/components/app/details/triggerView/workflow.service.ts
@@ -62,7 +62,7 @@ function handleSourceNotConfigured(filteredCIPipelines: CiPipeline[], ciResponse
 
     for (const material of gitMaterials) {
         for (const ciPipeline of filteredCIPipelines) {
-            if (configuredMaterialList[ciPipeline.name].has(material.gitMaterialId)) {
+            if (configuredMaterialList[ciPipeline.name].has(material.gitMaterialId) || ciPipeline.parentCiPipeline) {
                 continue
             }
             ciPipeline.ciMaterial.push({

--- a/src/components/app/details/triggerView/workflow.service.ts
+++ b/src/components/app/details/triggerView/workflow.service.ts
@@ -62,6 +62,7 @@ function handleSourceNotConfigured(filteredCIPipelines: CiPipeline[], ciResponse
 
     for (const material of gitMaterials) {
         for (const ciPipeline of filteredCIPipelines) {
+            //if linked pipeline then local git material should not be visible in pipeline.
             if (configuredMaterialList[ciPipeline.name].has(material.gitMaterialId) || ciPipeline.parentCiPipeline) {
                 continue
             }


### PR DESCRIPTION
# Description

In case of linked CI the local git material is also visible which should not be the case in case of linked pipelines, it should only reflect the parent pipeline and parent's git materials. Please see below image.
![image](https://user-images.githubusercontent.com/54064843/215986819-4830ca9b-4719-4fda-98c3-7794a0f0d781.png)


Fixes #723 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested locally as well as by deploying the image in personal cluster. 1. Created an app with git material. 2. Then I created a linked Ci pipeline, now after the fix local git material is not visible in the linked ci-pipeline.
- [ ] Test B


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


