### PR TITLE
feat: show image tag copy icon while hovering over the entire card

### DIFF
--- a/src/components/app/details/cicdHistory/Artifacts.tsx
+++ b/src/components/app/details/cicdHistory/Artifacts.tsx
@@ -94,7 +94,7 @@ const CopyTippyWithText = ({ copyText, copied, setCopied }: CopyTippyWithTextTyp
             >
                 <CopyIcon
                     data-copy-text={copyText}
-                    className="pointer  ml-6 icon-dim-16"
+                    className="pointer ml-6 icon-dim-16"
                     onClick={onClickCopyToClipboard}
                 />
             </Tippy>

--- a/src/components/app/details/cicdHistory/Artifacts.tsx
+++ b/src/components/app/details/cicdHistory/Artifacts.tsx
@@ -44,15 +44,15 @@ export default function Artifacts({ status, artifact, blobStorageEnabled, getArt
         return (
             <div className="flex left column p-16">
                 <CIListItem type="artifact">
-                    <div className="flex column left hover-trigger ">
-                        <div className="cn-9 fs-14 flex left dc__visible-hover dc__visible-hover--parent">
+                    <div className="flex column left hover-trigger">
+                        <div className="cn-9 fs-14 flex left">
                             <CopyTippyWithText
                                 copyText={artifact?.split(':')[1]}
                                 copied={copied}
                                 setCopied={setCopied}
                             />
                         </div>
-                        <div className="cn-7 fs-12 flex left dc__visible-hover dc__visible-hover--parent">
+                        <div className="cn-7 fs-12 flex left">
                             <CopyTippyWithText copyText={artifact} copied={copied} setCopied={setCopied} />
                         </div>
                     </div>
@@ -94,7 +94,7 @@ const CopyTippyWithText = ({ copyText, copied, setCopied }: CopyTippyWithTextTyp
             >
                 <CopyIcon
                     data-copy-text={copyText}
-                    className="pointer dc__visible-hover--child ml-6 icon-dim-16"
+                    className="pointer  ml-6 icon-dim-16"
                     onClick={onClickCopyToClipboard}
                 />
             </Tippy>


### PR DESCRIPTION
# Description

Show image tag copy icon while hovering over the entire card
Build history > Artifacts

Fixes #[AB1910](https://dev.azure.com/DevtronLabs/Devtron/_boards/board/t/CSAT/Stories/?workitem=1910)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
All the test are done manually .
1. By clicking on copy item 

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


