### PR TITLE
fix: Build page duration div width

### DIFF
--- a/src/components/app/details/cIDetails/ciDetails.scss
+++ b/src/components/app/details/cIDetails/ciDetails.scss
@@ -275,6 +275,10 @@
     }
 }
 
+.min-width-align{
+    min-width: fit-content !important;
+}
+
 .ci-details {
     .popup-button {
         max-width: 400px;

--- a/src/components/app/details/cIDetails/ciDetails.scss
+++ b/src/components/app/details/cIDetails/ciDetails.scss
@@ -275,10 +275,6 @@
     }
 }
 
-.min-width-align{
-    min-width: fit-content !important;
-}
-
 .ci-details {
     .popup-button {
         max-width: 400px;

--- a/src/components/app/details/cicdHistory/TriggerDetails.tsx
+++ b/src/components/app/details/cicdHistory/TriggerDetails.tsx
@@ -92,7 +92,7 @@ export const TriggerDetails = React.memo(
 
 const Finished = React.memo(({ status, startedOn, finishedOn, artifact }: FinishedType): JSX.Element => {
     return (
-        <div className="flex column left min-width-align">
+        <div className="flex column left dc__min-width-fit-content">
             <div className={`${status} fs-14 fw-6 ${TERMINAL_STATUS_COLOR_CLASS_MAP[status.toLowerCase()] || 'cn-5'}`}>
                 {status && status.toLowerCase() === 'cancelled' ? 'ABORTED' : status}
             </div>            
@@ -189,7 +189,7 @@ const ProgressingStatus = React.memo(
         return (
             <>
                 <div className="flex left">
-                    <div className="min-width-align">
+                    <div className="dc__min-width-fit-content">
                         <div className={`${status} fs-14 fw-6 flex left inprogress-status-color`}>
                             In progress
                         </div>

--- a/src/components/app/details/cicdHistory/TriggerDetails.tsx
+++ b/src/components/app/details/cicdHistory/TriggerDetails.tsx
@@ -92,7 +92,7 @@ export const TriggerDetails = React.memo(
 
 const Finished = React.memo(({ status, startedOn, finishedOn, artifact }: FinishedType): JSX.Element => {
     return (
-        <div className="flex column left">
+        <div className="flex column left min-width-align">
             <div className={`${status} fs-14 fw-6 ${TERMINAL_STATUS_COLOR_CLASS_MAP[status.toLowerCase()] || 'cn-5'}`}>
                 {status && status.toLowerCase() === 'cancelled' ? 'ABORTED' : status}
             </div>            
@@ -189,7 +189,7 @@ const ProgressingStatus = React.memo(
         return (
             <>
                 <div className="flex left">
-                    <div>
+                    <div className="min-width-align">
                         <div className={`${status} fs-14 fw-6 flex left inprogress-status-color`}>
                             In progress
                         </div>

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -2185,7 +2185,6 @@ textarea,
     width: max-content;
 }
 
-
 .dc_max-width__max-content {
     max-width: max-content !important;
 }

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -2185,6 +2185,7 @@ textarea,
     width: max-content;
 }
 
+
 .dc_max-width__max-content {
     max-width: max-content !important;
 }
@@ -2204,6 +2205,10 @@ textarea,
 
 .dc__height-inherit {
     height: inherit;
+}
+
+.dc__min-width-fit-content{
+    min-width: fit-content!important;
 }
 
 .h-0 {

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -2206,7 +2206,7 @@ textarea,
     height: inherit;
 }
 
-.dc__min-width-fit-content{
+.dc__min-width-fit-content {
     min-width: fit-content!important;
 }
 


### PR DESCRIPTION
# Description

Div in progress state and finished state dis-aligning after the addition of build duration feature
Fixes # [issue](https://github.com/devtron-labs/dashboard/issues/758)
Refrence image: [image](https://cdn.discordapp.com/attachments/819922034363727932/1074574604816879706/Screenshot_2023-02-13_at_11.25.51_AM.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

It has been tested locally by seeing the changes in the localhost.

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


