### PR TITLE
fix: User can't select slack while updating with ses or smtp

### DIFF
--- a/src/components/notifications/ModifyRecipientsModal.tsx
+++ b/src/components/notifications/ModifyRecipientsModal.tsx
@@ -85,9 +85,12 @@ export class ModifyRecipientsModal extends Component<ModifyRecipientsModalProps,
         })
     }
 
-    addRecipient(selectedProviders): void {
+    addRecipient = (selectedProviders): void => {
         let state = { ...this.state }
         state.selectedRecipient = selectedProviders || []
+        state.recipientWithoutEmailAgent = selectedProviders.some(
+            (item) => item.data.dest === 'ses' || item.data.dest === 'smtp',
+        )
         state.selectedRecipient = state.selectedRecipient.map((p) => {
             if (p.__isNew__) return { ...p, data: { dest: '', configId: 0, recipient: p.value } }
             return p
@@ -173,7 +176,11 @@ export class ModifyRecipientsModal extends Component<ModifyRecipientsModalProps,
                 <div className="modal__body modal__body--w-600 modal__body--p-0 dc__no-top-radius mt-0">
                     <div className="modal__header m-24">
                         <h1 className="modal__title">Modify Recipients</h1>
-                        <button type="button" className="dc__transparent" onClick={this.props.closeModifyRecipientsModal}>
+                        <button
+                            type="button"
+                            className="dc__transparent"
+                            onClick={this.props.closeModifyRecipientsModal}
+                        >
                             <Close className="icon-dim-24" />
                         </button>
                     </div>
@@ -201,8 +208,8 @@ export class ModifyRecipientsModal extends Component<ModifyRecipientsModalProps,
                         <div className="form__input form__input--textarea">
                             {this.state.savedRecipients.map((p) => {
                                 return (
-                                    <div className="dc__devtron-tag mr-5">
-                                        {p.dest === 'ses' || p.dest === '' ? (
+                                    <div className="dc__devtron-tag mr-5 mb-5">
+                                        {p.dest === 'ses' || p.dest === 'smtp' ? (
                                             <Email className="icon-dim-20 mr-5" />
                                         ) : null}
                                         {p.dest === 'slack' ? <Slack className="icon-dim-20 mr-5" /> : null}
@@ -232,7 +239,7 @@ export class ModifyRecipientsModal extends Component<ModifyRecipientsModalProps,
                             autoFocus
                             options={this.props.channelList}
                             value={this.state.selectedRecipient}
-                            onChange={(selected) => this.addRecipient(selected)}
+                            onChange={this.addRecipient}
                             tabIndex={2}
                             className="basic-multi-select"
                             classNamePrefix="select"


### PR DESCRIPTION
# Description

The user is unable to save as it is prompting to select either ses or smtp which is not required in the case of slack.

Fixes #[AB2133](https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/2133)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
By selecting mail & slack through the UI & by also saving combination of slack & email data

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


