### PR TITLE
fix: using port 8080 for nginx server

### DIFF
--- a/nginx-default.conf
+++ b/nginx-default.conf
@@ -1,5 +1,5 @@
 server {
-  listen 80;
+  listen 8080;
   root /usr/share/nginx/html;
   index index.html index.htm;
   


### PR DESCRIPTION
We have changed the nginx server port because of Kubernetes privilege port using exception with non-root user 