### PR TITLE
feat: Enabled configuring custom buildpack builder in dropdown

### DIFF
--- a/src/components/ciConfig/CIAdvancedConfig.tsx
+++ b/src/components/ciConfig/CIAdvancedConfig.tsx
@@ -88,7 +88,7 @@ export default function CIAdvancedConfig({
                     </TippyCustomized>
                 </div>
                 {!updateNotAllowed && (
-                    <div className="add-parameter fs-14 mb-8 cb-5 cursor" onClick={addArg}>
+                    <div className="add-parameter fs-14 mb-8 cb-5 cursor dc__w-fit-content" onClick={addArg}>
                         <span className="fa fa-plus mr-8"></span>Add{isDockerArgsSection ? ' parameter' : ' argument'}
                     </div>
                 )}

--- a/src/components/ciConfig/CIBuildpackBuildOptions.tsx
+++ b/src/components/ciConfig/CIBuildpackBuildOptions.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import ReactSelect, { components } from 'react-select'
+import CreatableSelect from 'react-select/creatable'
 import {
     DropdownIndicator,
     getCommonSelectStyle,
@@ -26,6 +27,16 @@ import {
     VersionsOptionType,
 } from './types'
 import TippyCustomized, { TippyTheme } from '../common/TippyCustomized'
+import { DOCUMENTATION } from '../../config'
+import {
+    AUTO_DETECT,
+    BUILDER_SELECT_STYLES,
+    CI_BUILDPACK_OPTION_TEXTS,
+    LANGUAGE_SELECT_STYLES,
+    USE_CUSTOM_BUILDER,
+    VERSION_DETECT_OPTION,
+    VERSION_SELECT_STYLES,
+} from './ciConfigConstant'
 
 export const renderOptionIcon = (option: string) => {
     if (!option) return null
@@ -71,6 +82,15 @@ export const repositoryControls = (props): JSX.Element => {
     )
 }
 
+const menuListComponent = (props): JSX.Element => {
+    return (
+        <components.MenuList {...props}>
+            <div className="fw-4 lh-20 pl-8 pr-8 pt-6 pb-6 cn-7 fs-13 dc__italic-font-style">{USE_CUSTOM_BUILDER}</div>
+            {props.children}
+        </components.MenuList>
+    )
+}
+
 export default function CIBuildpackBuildOptions({
     ciBuildConfig,
     sourceConfig,
@@ -109,11 +129,7 @@ export default function CIBuildpackBuildOptions({
                     label: ver,
                     value: ver,
                 })) || []
-            versionOptions.push({
-                label: 'Autodetect',
-                value: 'Autodetect',
-                infoText: 'Detect version during build time',
-            })
+            versionOptions.push(VERSION_DETECT_OPTION)
             _builderLanguageSupportMap[_languageBuilder.Language] = {
                 LanguageIcon: _languageBuilder.LanguageIcon,
                 Versions: versionOptions,
@@ -141,7 +157,6 @@ export default function CIBuildpackBuildOptions({
             }
         }
         setSupportedLanguagesList(_supportedLanguagesList)
-        setBuilderLanguageSupportMap(_builderLanguageSupportMap)
         updateConfigAndBuildersData(initOption, _builderLanguageSupportMap)
     }
 
@@ -185,6 +200,26 @@ export default function CIBuildpackBuildOptions({
                     builderLangEnvParam: currentBuilderLangEnvParam,
                     currentBuilderLangEnvParam: currentBuilderLangEnvParam,
                 }
+
+                // Update BuilderLanguageMetadata with previously saved custom option
+                const languageBuilderOption = _builderLanguageSupportMap[ciBuildConfig.buildPackConfig.language]
+                if (
+                    languageBuilderOption.BuilderLanguageMetadata.findIndex(
+                        (_metadata) => _metadata.value === _builder.value,
+                    ) === -1
+                ) {
+                    _builderLanguageSupportMap[ciBuildConfig.buildPackConfig.language] = {
+                        ...languageBuilderOption,
+                        BuilderLanguageMetadata: [
+                            ...languageBuilderOption.BuilderLanguageMetadata,
+                            {
+                                label: _builder.value,
+                                value: _builder.value,
+                                BuilderLangEnvParam: currentBuilderLangEnvParam ?? '',
+                            },
+                        ],
+                    }
+                }
             } else {
                 _builder = {
                     label: initOption.builderId,
@@ -209,6 +244,8 @@ export default function CIBuildpackBuildOptions({
                     currentBuilderLangEnvParam: currentBuilderLangEnvParam,
                 }
             }
+
+            setBuilderLanguageSupportMap(_builderLanguageSupportMap)
             setBuildersAndFrameworks({
                 ...buildersAndFrameworks,
                 selectedBuilder: _builder,
@@ -285,6 +322,26 @@ export default function CIBuildpackBuildOptions({
             },
         })
         updateBuildEnvArgs(buildersAndFrameworks.selectedVersion.value, selected)
+        setBuilderLanguageSupportMap((prevState) => {
+            const prevValue = prevState[buildersAndFrameworks.selectedLanguage.value]
+            if (prevValue.BuilderLanguageMetadata.findIndex((_metadata) => _metadata.value === selected.value) === -1) {
+                return {
+                    ...prevState,
+                    [buildersAndFrameworks.selectedLanguage.value]: {
+                        ...prevValue,
+                        BuilderLanguageMetadata: [
+                            ...prevValue.BuilderLanguageMetadata,
+                            {
+                                label: selected.value,
+                                value: selected.value,
+                                BuilderLangEnvParam: '',
+                            },
+                        ],
+                    },
+                }
+            }
+            return prevState
+        })
     }
 
     const updateBuildEnvArgs = (version: string, builder: BuilderIdOptionType, isInitCall?: boolean) => {
@@ -295,7 +352,7 @@ export default function CIBuildpackBuildOptions({
          * - If yes & is init call then push init arg selection to buildEnvArgs array
          * - Else remove empty arg from buildEnvArgs array & proceed
          */
-        if (_buildEnvArgs.length === 1 && !_buildEnvArgs[0].k && version !== 'Autodetect') {
+        if (_buildEnvArgs.length === 1 && !_buildEnvArgs[0].k && version !== AUTO_DETECT) {
             if (isInitCall) {
                 _buildEnvArgs[0].k = builder.BuilderLangEnvParam
                 _buildEnvArgs[0].v = version
@@ -320,14 +377,14 @@ export default function CIBuildpackBuildOptions({
          *          then remove the arg from buildEnvArgs array
          * - Proceed to set the buildEnvArgs state
          */
-        if (version === 'Autodetect' && !isInitCall) {
+        if (version === AUTO_DETECT && !isInitCall) {
             _buildEnvArgs.forEach((arg, idx) => {
                 if (arg.k === builder.BuilderLangEnvParam) {
                     _buildEnvArgs.splice(idx, 1)
                 }
             })
         } else if (
-            version !== 'Autodetect' &&
+            version !== AUTO_DETECT &&
             (currentCIBuildConfig.buildPackConfig.builderId !== builder.value ||
                 currentCIBuildConfig.buildPackConfig.languageVersion !== version)
         ) {
@@ -379,6 +436,21 @@ export default function CIBuildpackBuildOptions({
             </div>
         )
     }
+
+    const additionalBuilderTippyContent = () => {
+        return (
+            <div className="p-12 fs-13 fw-4 lh-20">
+                <span>{CI_BUILDPACK_OPTION_TEXTS.BuilderTippyContent.additionalContent.label}</span>
+                <ol className="dc__list-style-disc m-0 pl-20">
+                    {CI_BUILDPACK_OPTION_TEXTS.BuilderTippyContent.additionalContent.listItems.map((_item) => (
+                        <li key={_item}>{_item}</li>
+                    ))}
+                </ol>
+            </div>
+        )
+    }
+
+    const formatCreateLabel = (inputValue: string) => `Use '${inputValue}'`
 
     const projectPathVal =
         configOverrideView && !allowOverride ? ciBuildConfig.buildPackConfig?.projectPath : projectPath.value
@@ -432,15 +504,15 @@ export default function CIBuildpackBuildOptions({
                 </div>
                 <div className="form__field">
                     <label htmlFor="" className="form__label flexbox-imp flex-align-center">
-                        Project Path (Relative)
+                        {CI_BUILDPACK_OPTION_TEXTS.ProjectPathTippyContent.label}
                         <TippyCustomized
                             theme={TippyTheme.white}
                             className="w-300"
                             placement="top"
                             Icon={HelpIcon}
                             iconClass="fcv-5"
-                            heading="Project Path"
-                            infoText="In case of monorepo, specify the path of the GIT Repo for the deployment of the project."
+                            heading={CI_BUILDPACK_OPTION_TEXTS.ProjectPathTippyContent.heading}
+                            infoText={CI_BUILDPACK_OPTION_TEXTS.ProjectPathTippyContent.infoText}
                             showCloseButton={true}
                             trigger="click"
                             interactive={true}
@@ -473,7 +545,7 @@ export default function CIBuildpackBuildOptions({
             <div className="flex top buildpack-options">
                 <div className="buildpack-language-options">
                     <div className={`form__field ${configOverrideView ? 'mb-0-imp' : ''}`}>
-                        <label className="form__label">Language</label>
+                        <label className="form__label">{CI_BUILDPACK_OPTION_TEXTS.Language}</label>
                         {configOverrideView && !allowOverride ? (
                             <div className="flex left">
                                 {buildersAndFrameworks.selectedLanguage?.icon && (
@@ -494,21 +566,7 @@ export default function CIBuildpackBuildOptions({
                                 options={supportedLanguagesList}
                                 value={buildersAndFrameworks.selectedLanguage}
                                 isSearchable={false}
-                                styles={getCommonSelectStyle({
-                                    control: (base, state) => ({
-                                        ...base,
-                                        minHeight: '36px',
-                                        boxShadow: 'none',
-                                        backgroundColor: 'var(--N50)',
-                                        border: state.isFocused ? '1px solid var(--B500)' : '1px solid var(--N200)',
-                                        cursor: 'pointer',
-                                    }),
-                                    menu: (base) => ({
-                                        ...base,
-                                        marginTop: '0',
-                                        minWidth: '226px',
-                                    }),
-                                })}
+                                styles={getCommonSelectStyle(LANGUAGE_SELECT_STYLES)}
                                 components={{
                                     IndicatorSeparator: null,
                                     DropdownIndicator,
@@ -521,7 +579,7 @@ export default function CIBuildpackBuildOptions({
                         )}
                     </div>
                     <div className={`form__field ${configOverrideView ? 'mb-0-imp' : ''}`}>
-                        <label className="form__label">Version</label>
+                        <label className="form__label">{CI_BUILDPACK_OPTION_TEXTS.Version}</label>
                         {configOverrideView && !allowOverride ? (
                             <span className="fs-14 fw-4 lh-20 cn-9">
                                 {buildersAndFrameworks.selectedVersion?.value}
@@ -537,27 +595,7 @@ export default function CIBuildpackBuildOptions({
                                 value={buildersAndFrameworks.selectedVersion}
                                 formatOptionLabel={formatOptionLabel}
                                 isSearchable={false}
-                                styles={getCommonSelectStyle({
-                                    control: (base, state) => ({
-                                        ...base,
-                                        minHeight: '36px',
-                                        boxShadow: 'none',
-                                        backgroundColor: 'var(--N50)',
-                                        border: state.isFocused ? '1px solid var(--B500)' : '1px solid var(--N200)',
-                                        cursor: 'pointer',
-                                    }),
-                                    valueContainer: (base) => ({
-                                        ...base,
-                                        small: {
-                                            display: 'none',
-                                        },
-                                    }),
-                                    menu: (base) => ({
-                                        ...base,
-                                        marginTop: '0',
-                                        minWidth: '226px',
-                                    }),
-                                })}
+                                styles={getCommonSelectStyle(VERSION_SELECT_STYLES)}
                                 components={{
                                     IndicatorSeparator: null,
                                     DropdownIndicator,
@@ -571,15 +609,20 @@ export default function CIBuildpackBuildOptions({
                 </div>
                 <div className={`form__field ${configOverrideView ? 'mb-0-imp' : ''}`}>
                     <label className="form__label flexbox-imp flex-align-center">
-                        {configOverrideView && !allowOverride ? 'Builder' : 'Select a Builder'}
+                        {configOverrideView && !allowOverride
+                            ? CI_BUILDPACK_OPTION_TEXTS.BuilderTippyContent.heading
+                            : CI_BUILDPACK_OPTION_TEXTS.BuilderTippyContent.selectBuilder}
                         <TippyCustomized
                             theme={TippyTheme.white}
                             className="w-300"
                             placement="top"
                             Icon={HelpIcon}
                             iconClass="fcv-5"
-                            heading="Builder"
-                            infoText="A builder is an image that contains a set of buildpacks which provide your app's dependencies, a stack, and the OS layer for your app image."
+                            heading={CI_BUILDPACK_OPTION_TEXTS.BuilderTippyContent.heading}
+                            infoText={CI_BUILDPACK_OPTION_TEXTS.BuilderTippyContent.infoText}
+                            additionalContent={additionalBuilderTippyContent()}
+                            documentationLinkText={CI_BUILDPACK_OPTION_TEXTS.BuilderTippyContent.documentationLinkText}
+                            documentationLink={DOCUMENTATION.APP_CI_CONFIG_BUILD_WITHOUT_DOCKER}
                             showCloseButton={true}
                             trigger="click"
                             interactive={true}
@@ -590,7 +633,8 @@ export default function CIBuildpackBuildOptions({
                     {configOverrideView && !allowOverride ? (
                         <span className="fs-14 fw-4 lh-20 cn-9">{buildersAndFrameworks.selectedBuilder?.label}</span>
                     ) : (
-                        <ReactSelect
+                        <CreatableSelect
+                            placeholder={CI_BUILDPACK_OPTION_TEXTS.BuilderTippyContent.selectBuilder}
                             className="m-0"
                             tabIndex={3}
                             isLoading={!builderLanguageSupportMap?.[buildersAndFrameworks.selectedLanguage?.value]}
@@ -599,26 +643,13 @@ export default function CIBuildpackBuildOptions({
                                     ?.BuilderLanguageMetadata
                             }
                             value={buildersAndFrameworks.selectedBuilder}
-                            isSearchable={false}
-                            styles={getCommonSelectStyle({
-                                control: (base, state) => ({
-                                    ...base,
-                                    minHeight: '36px',
-                                    boxShadow: 'none',
-                                    backgroundColor: 'var(--N50)',
-                                    border: state.isFocused ? '1px solid var(--B500)' : '1px solid var(--N200)',
-                                    cursor: 'pointer',
-                                }),
-                                menu: (base) => ({
-                                    ...base,
-                                    marginTop: '0',
-                                    minWidth: '226px',
-                                }),
-                            })}
+                            formatCreateLabel={formatCreateLabel}
+                            styles={getCommonSelectStyle(BUILDER_SELECT_STYLES)}
                             components={{
                                 IndicatorSeparator: null,
                                 DropdownIndicator,
                                 Option,
+                                MenuList: menuListComponent,
                             }}
                             onChange={handleBuilderSelection}
                             isDisabled={configOverrideView && !allowOverride}

--- a/src/components/ciConfig/CIContainerRegistryConfig.tsx
+++ b/src/components/ciConfig/CIContainerRegistryConfig.tsx
@@ -182,7 +182,7 @@ export default function CIContainerRegistryConfig({
                                     : repository_name.value
                             }
                             onChange={handleOnChangeConfig}
-                            autoFocus
+                            autoFocus={!configOverrideView}
                             autoComplete={'off'}
                             disabled={configOverrideView && !allowOverride}
                         />

--- a/src/components/ciConfig/ciConfigConstant.ts
+++ b/src/components/ciConfig/ciConfigConstant.ts
@@ -1,7 +1,94 @@
 export const SelectorMessaging = {
-     WARNING_WITH_NO_TARGET: 'You have entered a custom target platform, please ensure it is valid.',
-     WARNING_WITH_USING_NO_TARGET:'You are using a custom target platform, please ensure it is valid.',
-     PALTFORM_DESCRIPTION: 'If target platform is not set, Devtron will build image for architecture and operating system of the k8s node on which CI is running',
-     PALTFORM_DESCRIPTION_WITH_NO_TARGET: 'Target platform is not set',
-     TARGET_SELECTOR_MENU: 'Type to enter a target platform. Press Enter to accept.'
+    WARNING_WITH_NO_TARGET: 'You have entered a custom target platform, please ensure it is valid.',
+    WARNING_WITH_USING_NO_TARGET: 'You are using a custom target platform, please ensure it is valid.',
+    PALTFORM_DESCRIPTION:
+        'If target platform is not set, Devtron will build image for architecture and operating system of the k8s node on which CI is running',
+    PALTFORM_DESCRIPTION_WITH_NO_TARGET: 'Target platform is not set',
+    TARGET_SELECTOR_MENU: 'Type to enter a target platform. Press Enter to accept.',
+}
+
+export const AUTO_DETECT = 'Autodetect'
+export const VERSION_DETECT_OPTION = {
+    label: AUTO_DETECT,
+    value: AUTO_DETECT,
+    infoText: 'Detect version during build time',
+}
+export const USE_CUSTOM_BUILDER = 'Use custom builder: Enter builder image tag'
+export const CI_BUILDPACK_OPTION_TEXTS = {
+    BuilderTippyContent: {
+        heading: 'Builder',
+        infoText:
+            "A builder is an image that contains a set of buildpacks which provide your app's dependencies, a stack, and the OS layer for your app image.",
+        documentationLinkText: 'View documentation',
+        selectBuilder: 'Select a Builder',
+        additionalContent: {
+            label: 'If using custom builder, builder image should be:',
+            listItems: [
+                'publicly available OR',
+                'available in selected container registry OR',
+                'accessible from the build node',
+            ],
+        },
+    },
+    ProjectPathTippyContent: {
+        label: 'Project Path (Relative)',
+        heading: 'Project Path',
+        infoText: 'In case of monorepo, specify the path of the GIT Repo for the deployment of the project.',
+    },
+    Language: 'Language',
+    Version: 'Version',
+}
+
+export const LANGUAGE_SELECT_STYLES = {
+    control: (base, state) => ({
+        ...base,
+        minHeight: '36px',
+        boxShadow: 'none',
+        backgroundColor: 'var(--N50)',
+        border: state.isFocused ? '1px solid var(--B500)' : '1px solid var(--N200)',
+        cursor: 'pointer',
+    }),
+    menu: (base) => ({
+        ...base,
+        marginTop: '0',
+        minWidth: '226px',
+    }),
+}
+
+export const VERSION_SELECT_STYLES = {
+    control: (base, state) => ({
+        ...base,
+        minHeight: '36px',
+        boxShadow: 'none',
+        backgroundColor: 'var(--N50)',
+        border: state.isFocused ? '1px solid var(--B500)' : '1px solid var(--N200)',
+        cursor: 'pointer',
+    }),
+    valueContainer: (base) => ({
+        ...base,
+        small: {
+            display: 'none',
+        },
+    }),
+    menu: (base) => ({
+        ...base,
+        marginTop: '0',
+        minWidth: '226px',
+    }),
+}
+
+export const BUILDER_SELECT_STYLES = {
+    control: (base, state) => ({
+        ...base,
+        minHeight: '36px',
+        boxShadow: 'none',
+        backgroundColor: 'var(--N50)',
+        border: state.isFocused ? '1px solid var(--B500)' : '1px solid var(--N200)',
+        cursor: 'pointer',
+    }),
+    menu: (base) => ({
+        ...base,
+        marginTop: '0',
+        minWidth: '226px',
+    }),
 }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -317,6 +317,7 @@ export const DOCUMENTATION = {
     APP_TAGS: `${DOCUMENTATION_HOME_PAGE}/v/v0.6/usage/applications/create-application#tags`,
     APP_OVERVIEW_TAGS: `${DOCUMENTATION_HOME_PAGE}/v/v0.6/usage/applications/overview#manage-tags`,
     K8S_RESOURCES_PERMISSIONS: `${DOCUMENTATION_HOME_PAGE}/v/v0.6/global-configurations/authorization/user-access#kubernetes-resources-permissions`,
+    APP_CI_CONFIG_BUILD_WITHOUT_DOCKER: `${DOCUMENTATION_HOME_PAGE}/v/v0.6/usage/applications/creating-application/docker-build-configuration#build-docker-image-without-dockerfile`,
 }
 
 export const DEVTRON_NODE_DEPLOY_VIDEO = 'https://www.youtube.com/watch?v=9u-pKiWV-tM&t=1s'

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -2696,3 +2696,7 @@ textarea::placeholder {
 .dc__outline-none-imp {
     outline: none !important;
 }
+
+.dc__list-style-disc {
+    list-style-type: disc;
+}


### PR DESCRIPTION
# Description

These changes will enable user configuring a custom buildpack builder from select a builder dropdown.

<img width="500" alt="Screenshot 2023-03-06 at 11 04 04 PM" src="https://user-images.githubusercontent.com/96225587/223186634-da4299c1-7d58-4227-bfaa-d86f3c8848f8.png">


Fixes https://github.com/devtron-labs/devtron/issues/3075
AB issue - [AB#2268](https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/2268)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been performed manually by visiting App Configuration & saving custom builder option.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


