### PR TITLE
fix: Add Check to editor for onDidFocusEditorWidget and onDidBlurEditorWidget

### DIFF
--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -172,13 +172,13 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
 
         if (editor) {
             if (typeof editor.onDidFocusEditorWidget === 'function' && typeof onFocus === 'function') {
-           editor.onDidFocusEditorWidget(onFocus)
-          }
-       
-          if(typeof editor.onDidBlurEditorWidget ===   'function' &&  typeof onBlur === 'function') {
-            editor.onDidBlurEditorWidget(onBlur)
-          }
-       }
+                editor.onDidFocusEditorWidget(onFocus)
+            }
+
+            if (typeof editor.onDidBlurEditorWidget === 'function' && typeof onBlur === 'function') {
+                editor.onDidBlurEditorWidget(onBlur)
+            }
+        }
 
         editorRef.current = editor
         monacoRef.current = monaco

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -170,14 +170,22 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
             editor.getModel().updateOptions({ tabSize: 2 });
         }
 
+        if (
+            editor &&
+            typeof editor.onDidFocusEditorWidget === 'function' &&
+            typeof editor.onDidBlurEditorWidget === 'function'
+        ) {
+            editor.onDidFocusEditorWidget(() => {
+                onFocus && onFocus()
+            })
+            editor.onDidBlurEditorWidget(() => {
+                onBlur && onBlur()
+            })
+        }
+
         editorRef.current = editor
         monacoRef.current = monaco
-        editor.onDidFocusEditorWidget(() => {
-            onFocus && onFocus()
-        })
-        editor.onDidBlurEditorWidget(() => {
-            onBlur && onBlur()
-        })
+        
     }
 
     useEffect(() => {

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -170,18 +170,15 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
             editor.getModel().updateOptions({ tabSize: 2 });
         }
 
-        if (
-            editor &&
-            typeof editor.onDidFocusEditorWidget === 'function' &&
-            typeof editor.onDidBlurEditorWidget === 'function'
-        ) {
-            editor.onDidFocusEditorWidget(() => {
-                onFocus && onFocus()
-            })
-            editor.onDidBlurEditorWidget(() => {
-                onBlur && onBlur()
-            })
-        }
+        if (editor) {
+            if (typeof editor.onDidFocusEditorWidget === 'function' && typeof onFocus === 'function') {
+           editor.onDidFocusEditorWidget(onFocus)
+          }
+       
+          if(typeof editor.onDidBlurEditorWidget ===   'function' &&  typeof onBlur === 'function') {
+            editor.onDidBlurEditorWidget(onBlur)
+          }
+       }
 
         editorRef.current = editor
         monacoRef.current = monaco


### PR DESCRIPTION
# Description

This error is coming on deployment history as onDidFocusEditorWidget is not available in editor instance whereas it's present in other multiple places like deploy chart, app config, etc. as I had a quick look.

Fixes - [AB#2343](https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/2343)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Tested locally


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


