### PR TITLE
fix: Gitops validate and update with empty token

### DIFF
--- a/src/components/gitOps/GitOpsConfiguration.tsx
+++ b/src/components/gitOps/GitOpsConfiguration.tsx
@@ -11,7 +11,7 @@ import {
 import { ReactComponent as GitLab } from '../../assets/icons/git/gitlab.svg'
 import { ReactComponent as GitHub } from '../../assets/icons/git/github.svg'
 import { ReactComponent as Azure } from '../../assets/icons/git/azure.svg'
-import { CustomInput, ErrorScreenManager, handleOnBlur, handleOnFocus, Progressing, showError } from '../common'
+import { CustomInput, ErrorScreenManager, handleOnBlur, handleOnFocus, parsePassword, Progressing, showError } from '../common'
 import Check from '../../assets/icons/ic-outline-check.svg'
 import { ReactComponent as Info } from '../../assets/icons/ic-info-filled-purple.svg'
 import { ReactComponent as InfoFill } from '../../assets/icons/appstatus/info-filled.svg'
@@ -294,7 +294,7 @@ class GitOpsConfiguration extends Component<GitOpsProps, GitOpsState> {
             provider: this.state.form.provider,
             username: this.state.form.username.replace(/\s/g, ''),
             host: this.state.form.host.replace(/\s/g, ''),
-            token: this.state.form.token.replace(/\s/g, ''),
+            token: parsePassword(this.state.form.token.replace(/\s/g, '')),
             gitLabGroupId: this.state.form.gitLabGroupId.replace(/\s/g, ''),
             gitHubOrgId: this.state.form.gitHubOrgId.replace(/\s/g, ''),
             azureProjectName: this.state.form.azureProjectName.replace(/\s/g, ''),


### PR DESCRIPTION
# Description

We should send the empty token when token is Default Secret Placeholder for updating or validating

Fixes #https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/2518

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[x] Tested the code by deploying on cluster


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


