### PR TITLE
feat: differentiate config map secret in deployment stage

### DIFF
--- a/src/components/cdPipeline/CDPipeline.tsx
+++ b/src/components/cdPipeline/CDPipeline.tsx
@@ -32,6 +32,8 @@ import {
 import { CDPipelineProps, CDPipelineState, CD_PATCH_ACTION, Environment } from './cdPipeline.types'
 import { ValidationRules } from './validationRules'
 import { getEnvironmentListMinPublic } from '../../services/service'
+import { ReactComponent as Key } from '../../assets/icons/ic-key-bulb.svg'
+import { ReactComponent as File } from '../../assets/icons/ic-file-text.svg'
 import { ReactComponent as Add } from '../../assets/icons/ic-add.svg'
 import { ReactComponent as Close } from '../../assets/icons/ic-close.svg'
 import { ReactComponent as PrePostCD } from '../../assets/icons/ic-cd-stage.svg'
@@ -879,6 +881,19 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
             key === 'preStage'
                 ? this.state.pipelineConfig.runPreStageInEnv
                 : this.state.pipelineConfig.runPostStageInEnv
+        function getOptionLabel(option:any) {
+            if (option.type === 'configmaps') {
+                return (<div style={{ display: 'flex', alignItems: 'center', marginLeft: '0px'}}>
+                    <File className='icon-dim-16' />
+                    <span style={{ marginLeft: 8, alignItems: 'center', fontSize: '12px' }}>{option.name}</span>
+                </div>)
+            } else {
+                return (<div style={{ display: 'flex', alignItems: 'center' }}>
+                    <Key className='icon-dim-16' />
+                    <span style={{ marginLeft: 8, alignItems: 'center', fontSize: '12px'}}>{option.name}</span>
+                </div>)
+            }
+        }        
         return (
             <div className="cd-stage mt-12">
                 <div className="form__row">
@@ -912,8 +927,8 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
                         isClearable={true}
                         value={selections}
                         options={this.configMapAndSecrets}
-                        getOptionLabel={(option) => `${option.name}`}
-                        getOptionValue={(option) => `${option.name}`}
+                        formatOptionLabel={getOptionLabel}
+                        getOptionValue={(option) => `${option.name}${option.type}`}
                         onChange={(selected) => {
                             this.handleConfigmapAndSecretsChange(selected, configmapKey)
                         }}

--- a/src/components/cdPipeline/CDPipeline.tsx
+++ b/src/components/cdPipeline/CDPipeline.tsx
@@ -884,14 +884,14 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
                 : this.state.pipelineConfig.runPostStageInEnv
         function getOptionLabel(option) {
             if (option.type === CONFIGMAPS_SECRETS.configmaps) {
-                return (<div className='dropdown__option'>
-                    <File className='icon-dim-16' />
-                    <span  className='ml-8 fs-12 dc__align-center'>{option.name}</span>
+                return (<div className="dropdown__option">
+                    <File className="icon-dim-16" />
+                    <span  className="ml-8 fs-12 dc__align-center">{option.name}</span>
                 </div>)
             } else {
-                return (<div className='dropdown__option'>
-                    <Key className='icon-dim-16' />
-                    <span className='ml-8 fs-12 dc__align-center'>{option.name}</span>
+                return (<div className="dropdown__option">
+                    <Key className="icon-dim-16" />
+                    <span className="ml-8 fs-12 dc__align-center">{option.name}</span>
                 </div>)
             }
         }

--- a/src/components/cdPipeline/CDPipeline.tsx
+++ b/src/components/cdPipeline/CDPipeline.tsx
@@ -65,6 +65,7 @@ import {
     CREATE_DEPLOYMENT_PIPELINE,
     MULTI_REQUIRED_FIELDS_MSG,
     TOAST_INFO,
+    CONFIGMAPS_SECRETS,
 } from '../../config/constantMessaging'
 
 export const SwitchItemValues = {
@@ -882,15 +883,15 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
                 ? this.state.pipelineConfig.runPreStageInEnv
                 : this.state.pipelineConfig.runPostStageInEnv
         function getOptionLabel(option) {
-            if (option.type === 'configmaps') {
+            if (option.type === CONFIGMAPS_SECRETS.configmaps) {
                 return (<div className='dropdown__option'>
                     <File className='icon-dim-16' />
-                    <span style={{ marginLeft: 8, alignItems: 'center', fontSize: '12px' }}>{option.name}</span>
+                    <span  className='ml-8 fs-12 dc__align-center'>{option.name}</span>
                 </div>)
             } else {
                 return (<div className='dropdown__option'>
                     <Key className='icon-dim-16' />
-                    <span style={{ marginLeft: 8, alignItems: 'center', fontSize: '12px' }}>{option.name}</span>
+                    <span className='ml-8 fs-12 dc__align-center'>{option.name}</span>
                 </div>)
             }
         }

--- a/src/components/cdPipeline/CDPipeline.tsx
+++ b/src/components/cdPipeline/CDPipeline.tsx
@@ -87,8 +87,8 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
         const parentPipelineType = parentPipelineTypeFromURL
             ? parentPipelineTypeFromURL.toLocaleUpperCase().replace('-', '_')
             : this.isWebhookCD
-            ? SourceTypeMap.WEBHOOK
-            : ''
+                ? SourceTypeMap.WEBHOOK
+                : ''
         const parentPipelineId = urlParams.get('parentPipelineId')
         this.state = {
             view: ViewType.LOADING,
@@ -196,7 +196,7 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
                                         },
                                     })
                                 })
-                                .catch((error) => {})
+                                .catch((error) => { })
                             getEnvironmentListMinPublic()
                                 .then((response) => {
                                     let list = response.result || []
@@ -532,13 +532,13 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
             try {
                 json = JSON.parse(jsonStr)
                 yamlStr = yamlJsParser.stringify(json, { indent: 2 })
-            } catch (error) {}
+            } catch (error) { }
         } else {
             yamlStr = event.target.value
             try {
                 json = yamlJsParser.parse(yamlStr)
                 jsonStr = JSON.stringify(json, undefined, 2)
-            } catch (error) {}
+            } catch (error) { }
         }
         let state = { ...this.state }
         let strategies = this.state.pipelineConfig.strategies.map((strategy) => {
@@ -595,7 +595,7 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
             deploymentTemplate:
                 this.state.pipelineConfig.strategies.length > 0
                     ? this.state.pipelineConfig.strategies.find((savedStrategy) => savedStrategy.default)
-                          .deploymentTemplate
+                        .deploymentTemplate
                     : null,
             strategies: this.state.pipelineConfig.strategies.map((savedStrategy) => {
                 return {
@@ -762,8 +762,8 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
             this.isWebhookCD && this.props.match.params.workflowId === '0'
                 ? DEPLOY_IMAGE_EXTERNALSOURCE
                 : this.props.match.params.cdPipelineId
-                ? EDIT_DEPLOYMENT_PIPELINE
-                : CREATE_DEPLOYMENT_PIPELINE
+                    ? EDIT_DEPLOYMENT_PIPELINE
+                    : CREATE_DEPLOYMENT_PIPELINE
         return (
             <>
                 <div className="p-20 flex flex-align-center flex-justify">
@@ -883,18 +883,18 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
                 : this.state.pipelineConfig.runPostStageInEnv
         function getOptionLabel(option) {
             if (option.type === 'configmaps') {
-                return (<div className= 'dropdown__option'>
+                return (<div className='dropdown__option'>
                     <File className='icon-dim-16' />
                     <span style={{ marginLeft: 8, alignItems: 'center', fontSize: '12px' }}>{option.name}</span>
                 </div>)
             } else {
-                return (<div className= 'dropdown__option'>
+                return (<div className='dropdown__option'>
                     <Key className='icon-dim-16' />
-                    <span style={{ marginLeft: 8, alignItems: 'center', fontSize: '12px'}}>{option.name}</span>
+                    <span style={{ marginLeft: 8, alignItems: 'center', fontSize: '12px' }}>{option.name}</span>
                 </div>)
             }
-        }   
-        
+        }
+
         function getOptionValue(option) {
             return (`${option.name}${option.type}`)
         }
@@ -955,8 +955,8 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
                         onChange={
                             this.state.pipelineConfig[key].switch === SwitchItemValues.Config
                                 ? (resp) => {
-                                      this.handleStageConfigChange(resp, key, 'config')
-                                  }
+                                    this.handleStageConfigChange(resp, key, 'config')
+                                }
                                 : null
                         }
                     >
@@ -1210,9 +1210,8 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
                 <p className="fs-14 fw-6 cn-9 mb-8">When do you want to deploy</p>
                 <div className="flex mb-20">
                     <div
-                        className={`flex dc__content-start pointer w-50 pt-8 pr-16 pb-8 pl-16 br-4 mr-8 bw-1${
-                            this.state.pipelineConfig.triggerType === TriggerType.Auto ? ' bcb-1 eb-2' : ' bcn-0 en-2'
-                        }`}
+                        className={`flex dc__content-start pointer w-50 pt-8 pr-16 pb-8 pl-16 br-4 mr-8 bw-1${this.state.pipelineConfig.triggerType === TriggerType.Auto ? ' bcb-1 eb-2' : ' bcn-0 en-2'
+                            }`}
                         onClick={() => this.handleTriggerTypeChange(TriggerType.Auto)}
                     >
                         <BotIcon className="icon-dim-20 mr-12" />
@@ -1222,9 +1221,8 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
                         </div>
                     </div>
                     <div
-                        className={`flex dc__content-start pointer w-50 pt-8 pr-16 pb-8 pl-16 br-4 ml-8 bw-1${
-                            this.state.pipelineConfig.triggerType === TriggerType.Manual ? ' bcb-1 eb-2' : ' bcn-0 en-2'
-                        }`}
+                        className={`flex dc__content-start pointer w-50 pt-8 pr-16 pb-8 pl-16 br-4 ml-8 bw-1${this.state.pipelineConfig.triggerType === TriggerType.Manual ? ' bcb-1 eb-2' : ' bcn-0 en-2'
+                            }`}
                         onClick={() => this.handleTriggerTypeChange(TriggerType.Manual)}
                     >
                         <PersonIcon className="icon-dim-20 mr-12" />
@@ -1372,9 +1370,9 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
         })
         let strategy = this.state.pipelineConfig.strategies[0]
             ? {
-                  label: this.state.pipelineConfig.strategies[0]?.deploymentTemplate,
-                  value: this.state.pipelineConfig.strategies[0]?.deploymentTemplate,
-              }
+                label: this.state.pipelineConfig.strategies[0]?.deploymentTemplate,
+                value: this.state.pipelineConfig.strategies[0]?.deploymentTemplate,
+            }
             : undefined
         return (
             <>
@@ -1453,9 +1451,8 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
                     </div>
 
                     <div
-                        className={`ci-button-container bcn-0 pt-12 pb-12 pl-20 pr-20 flex bottom-border-radius ${
-                            this.isWebhookCD && !this.props.match.params.cdPipelineId ? 'right' : 'flex-justify'
-                        }`}
+                        className={`ci-button-container bcn-0 pt-12 pb-12 pl-20 pr-20 flex bottom-border-radius ${this.isWebhookCD && !this.props.match.params.cdPipelineId ? 'right' : 'flex-justify'
+                            }`}
                     >
                         {this.renderSecondaryButton()}
                         <ButtonWithLoader

--- a/src/components/cdPipeline/CDPipeline.tsx
+++ b/src/components/cdPipeline/CDPipeline.tsx
@@ -881,19 +881,27 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
             key === 'preStage'
                 ? this.state.pipelineConfig.runPreStageInEnv
                 : this.state.pipelineConfig.runPostStageInEnv
-        function getOptionLabel(option:any) {
+        function getOptionLabel(option) {
             if (option.type === 'configmaps') {
-                return (<div style={{ display: 'flex', alignItems: 'center', marginLeft: '0px'}}>
+                return (<div className= 'dropdown__option'>
                     <File className='icon-dim-16' />
                     <span style={{ marginLeft: 8, alignItems: 'center', fontSize: '12px' }}>{option.name}</span>
                 </div>)
             } else {
-                return (<div style={{ display: 'flex', alignItems: 'center' }}>
+                return (<div className= 'dropdown__option'>
                     <Key className='icon-dim-16' />
                     <span style={{ marginLeft: 8, alignItems: 'center', fontSize: '12px'}}>{option.name}</span>
                 </div>)
             }
-        }        
+        }   
+        
+        function getOptionValue(option) {
+            return (`${option.name}${option.type}`)
+        }
+
+        const onChangeOption = (selected) => {
+            this.handleConfigmapAndSecretsChange(selected, configmapKey)
+        }
         return (
             <div className="cd-stage mt-12">
                 <div className="form__row">
@@ -928,10 +936,8 @@ export default class CDPipeline extends Component<CDPipelineProps, CDPipelineSta
                         value={selections}
                         options={this.configMapAndSecrets}
                         formatOptionLabel={getOptionLabel}
-                        getOptionValue={(option) => `${option.name}${option.type}`}
-                        onChange={(selected) => {
-                            this.handleConfigmapAndSecretsChange(selected, configmapKey)
-                        }}
+                        getOptionValue={getOptionValue}
+                        onChange={onChangeOption}
                         components={{
                             IndicatorSeparator: null,
                             DropdownIndicator,

--- a/src/components/cdPipeline/cdPipeline.css
+++ b/src/components/cdPipeline/cdPipeline.css
@@ -141,3 +141,9 @@
     border-radius: 4px;
     overflow: hidden;
 }
+
+.dropdown__option {
+    display: flex;
+    align-items: center;
+    margin-left: 0px;
+}

--- a/src/components/cdPipeline/cdpipeline.util.tsx
+++ b/src/components/cdPipeline/cdpipeline.util.tsx
@@ -22,22 +22,31 @@ export const styles = {
             color: 'var(--N900)'
         })
     },
+    multiValue: (base ,state) => {
+        return({
+            ...base,
+            backgroundColor: 'var(--N0)',
+            border: '1px solid var(--N200)',
+            borderRadius: '4px'
+        })
+    },
     option: (base, state) => {
         return ({
             ...base,
             color: 'var(--N900)',
             backgroundColor: state.isFocused ? 'var(--N100)' : 'white',
+            paddingLeft: '8px',
         })
     }
 }
 
 export function Option(props) {
     const { selectOption, data } = props;
-    const style = { height: '16px', width: '16px', flex: '0 0 16px' }
+    const style = { flex: '0 0' , alignText: 'left' }
     const onClick = (e) => selectOption(data);
-    return <div className="flex left pl-12" style={{ background: props.isFocused ? 'var(--N100)' : 'transparent' }}>
-        {props.isSelected ? <Check onClick={onClick} className="mr-8 icon-dim-16" style={style} />
-            : <span onClick={onClick} className="mr-8" style={style} />}
+    return <div className="flex left" style={{ background: props.isFocused ? 'var(--N100)' : 'transparent' }}>
+        {props.isSelected ? <Check onClick={onClick} className="icon-dim-16" style={style} />
+            : <span onClick={onClick} style={style} />}
         <components.Option {...props} />
     </div>
 };

--- a/src/config/constantMessaging.ts
+++ b/src/config/constantMessaging.ts
@@ -165,3 +165,8 @@ export const APP_GROUP_CI_DETAILS = {
 export const DEPLOYMENT_HISTORY_TABS = {
   SOURCE : 0,
 }
+
+export const CONFIGMAPS_SECRETS = {
+    configmaps: "configmaps",
+    secrets: "secrets"
+}

--- a/src/css/forms.scss
+++ b/src/css/forms.scss
@@ -600,9 +600,3 @@ p.sentence-case:first-letter {
     margin: 0px;
     margin-bottom: 4px;
 }
-
-.dropdown__option {
-    display: flex;
-    align-items: center;
-    margin-left: 0px;
-}

--- a/src/css/forms.scss
+++ b/src/css/forms.scss
@@ -600,3 +600,9 @@ p.sentence-case:first-letter {
     margin: 0px;
     margin-bottom: 4px;
 }
+
+.dropdown__option {
+    display: flex;
+    align-items: center;
+    margin-left: 0px;
+}


### PR DESCRIPTION
# Description

Create a differentiating label to differentiate config maps and secrets in both edit deployment and new deployment workflow ( in both pre and post deployment stage ) , on selecting a config name or a secret having same name as the other type both are disappearing.

Fixes # [2532](https://dev.azure.com/DevtronLabs/Devtron/_boards/board/t/OSS%20adoption/Stories/?workitem=2532)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
1: To start with the , created label to differentiate config maps and secrets in the deployment stage.
2: On selecting the config map with secret , the latter does not disappear and vice versa.
3: The value of both config maps and secrets are passed correctly in the payload.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


