### PR TITLE
fix: App-group config back button

### DIFF
--- a/src/components/ApplicationGroup/Details/EnvironmentConfig/EnvConfig.tsx
+++ b/src/components/ApplicationGroup/Details/EnvironmentConfig/EnvConfig.tsx
@@ -25,7 +25,7 @@ export default function EnvConfig({ filteredApps }: AppGroupDetailDefaultType) {
                 .sort((a, b) => a.name.localeCompare(b.name))
             setEnvAppList(_envAppList)
             if (!appId) {
-                history.push(`${url}/${_envAppList[0].id}`)
+                history.replace(`${url}/${_envAppList[0].id}`)
             } else if (!_filteredAppMap.get(+appId)) {
                 const oldUrlSubstring = `/edit/${appId}`
                 const newUrlSubstring = `/edit/${_envAppList[0].id}`


### PR DESCRIPTION
# Description

App-group > config page break when the user clicks on the back button

Fixes [#AB2547](https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/2547)

<img width="1436" alt="Screenshot 2023-03-24 at 1 20 15 PM" src="https://user-images.githubusercontent.com/98738644/227457822-7d2016c8-9bd6-4b44-b957-85550d6fd3a4.png">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Select any app from the app group list 
2. Click on config 
3. Click on the back button 
4. Check if page breaks or not 
5. Tried with app filtered


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


