### PR TITLE
fix:incorrect env name on toast message when deleting

### DIFF
--- a/src/components/cluster/Cluster.tsx
+++ b/src/components/cluster/Cluster.tsx
@@ -531,23 +531,21 @@ function Cluster({
                                                             )}
                                                         </div>
                                                     </div>
-                                                    {confirmation && (
-                                                        <DeleteComponent
-                                                            setDeleting={clusterDelete}
-                                                            deleteComponent={deleteEnvironment}
-                                                            payload={getEnvironmentPayload()}
-                                                            title={environment_name}
-                                                            toggleConfirmation={toggleConfirmation}
-                                                            component={DeleteComponentsName.Environment}
-                                                            confirmationDialogDescription={
-                                                                DC_ENVIRONMENT_CONFIRMATION_MESSAGE
-                                                            }
-                                                            reload={reload}
-                                                        />
-                                                    )}
                                                 </div>
                                             ) : null,
                                     )}
+                                {confirmation && (
+                                    <DeleteComponent
+                                        setDeleting={clusterDelete}
+                                        deleteComponent={deleteEnvironment}
+                                        payload={getEnvironmentPayload()}
+                                        title={environment.environment_name}
+                                        toggleConfirmation={toggleConfirmation}
+                                        component={DeleteComponentsName.Environment}
+                                        confirmationDialogDescription={DC_ENVIRONMENT_CONFIRMATION_MESSAGE}
+                                        reload={reload}
+                                    />
+                                )}
                             </div>
                         ) : (
                             clusterId && renderNoEnvironmentTab()


### PR DESCRIPTION
# Description

on deleting any environment from cluster and environments page it was showing incorrect name .it got set to last environment name as delete component was inside map

Fixes #[3005](https://github.com/devtron-labs/devtron/issues/3005)
<img width="1440" alt="milind test22" src="https://user-images.githubusercontent.com/123984701/231954250-97ad01c7-762b-48f5-9aea-be3f31e3b5c5.png">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested on Local setup
- [ ] Test B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


