### PR TITLE
fix: shows commit details only on currently deployed image on deployment history

### DIFF
--- a/src/components/app/details/cdDetails/CDDetails.tsx
+++ b/src/components/app/details/cdDetails/CDDetails.tsx
@@ -6,7 +6,7 @@ import { ModuleNameMap, URLS } from '../../../../config'
 import { AppNotConfigured } from '../appDetails/AppDetails'
 import { useHistory, useRouteMatch, useParams, generatePath } from 'react-router'
 import { NavLink, Switch, Route, Redirect } from 'react-router-dom'
-import { getTriggerHistory, getTriggerDetails, getCDBuildReport } from './service'
+import { getTriggerHistory, getCDBuildReport } from './service'
 import DeploymentHistoryConfigList from './deploymentHistoryDiff/DeploymentHistoryConfigList.component'
 import './cdDetail.scss'
 import DeploymentHistoryDetailedView from './deploymentHistoryDiff/DeploymentHistoryDetailedView'
@@ -247,16 +247,6 @@ export const TriggerOutput: React.FC<{
         pipelineId: string
     }>()
     const triggerDetails = triggerHistory.get(+triggerId)
-    const [triggerDetailsLoading, triggerDetailsResult, triggerDetailsError, reloadTriggerDetails] = useAsync(
-        () => getTriggerDetails({ appId, envId, pipelineId, triggerId }),
-        [triggerId, appId, envId],
-        !!triggerId && !!pipelineId,
-    )
-    useEffect(() => {
-        if (triggerDetailsLoading || triggerDetailsError) return
-
-        if (triggerDetailsResult?.result) syncState(+triggerId, triggerDetailsResult?.result)
-    }, [triggerDetailsLoading, triggerDetailsResult, triggerDetailsError])
 
     const timeout = useMemo(() => {
         if (
@@ -271,10 +261,7 @@ export const TriggerOutput: React.FC<{
         return 30000 // 30s for normal
     }, [triggerDetails])
 
-    useInterval(reloadTriggerDetails, timeout)
-
-    if (triggerDetailsLoading && !triggerDetails) return <Progressing pageLoader />
-    if (!triggerDetailsLoading && !triggerDetails) return <Reload />
+    if (!triggerDetails) return <Reload />
     if (triggerDetails?.id !== +triggerId) {
         return null
     }
@@ -364,7 +351,7 @@ export const TriggerOutput: React.FC<{
             <HistoryLogs
                 key={triggerDetails.id}
                 triggerDetails={triggerDetails}
-                loading={triggerDetailsLoading && !triggerDetailsResult}
+                loading={false}
                 setFullScreenView={setFullScreenView}
                 setDeploymentHistoryList={setDeploymentHistoryList}
                 deploymentHistoryList={deploymentHistoryList}


### PR DESCRIPTION
# Description
Currently, shows commit details only on currently deployed image on deployment history.
Expected, Should show the commit details for all the images deployed.

Fixes #https://github.com/devtron-labs/devtron/issues/3091


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested by Deploying image multiple times for both Helm and GitOps


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


