### PR TITLE
fix: Search Option in clusters, preset values and chart store should not be case sensitive

### DIFF
--- a/src/components/ClusterNodes/ClusterList.tsx
+++ b/src/components/ClusterNodes/ClusterList.tsx
@@ -113,7 +113,7 @@ export default function ClusterList({ imageList, isSuperAdmin, namespaceList }: 
     }
 
     const handleFilterChanges = (_searchText: string): void => {
-        const _filteredData = clusterList.filter((cluster) => cluster.name.indexOf(_searchText) >= 0)
+        const _filteredData = clusterList.filter((cluster) => cluster.name.indexOf(_searchText.toLowerCase()) >= 0)
         setFilteredClusterList(_filteredData)
         setNoResults(_filteredData.length === 0)
     }

--- a/src/components/charts/SavedValues/SavedValuesList.tsx
+++ b/src/components/charts/SavedValues/SavedValuesList.tsx
@@ -105,7 +105,7 @@ export default function SavedValuesList() {
     }
 
     const handleFilterChanges = (_searchText: string): void => {
-        const _filteredData = savedValueList.filter((cluster) => cluster.name.indexOf(_searchText) >= 0)
+        const _filteredData = savedValueList.filter((cluster) => cluster.name.indexOf(_searchText.toLowerCase()) >= 0)
         setFilteredSavedValueList(_filteredData)
     }
 


### PR DESCRIPTION
# Description
 when ever we search for something in clusters,preset values and chart store using capital letters ,the result shows an empty set.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


