### PR TITLE
fix: Added fix for namespace  shows undefined for empty

### DIFF
--- a/src/components/app/list-new/AppListService.ts
+++ b/src/components/app/list-new/AppListService.ts
@@ -242,7 +242,7 @@ const _buildNamespaces = (namespaceListRes : EnvironmentListHelmResponse, cluste
         namespaceObj.environments.forEach((environment : EnvironmentHelmResult) => {
             let _namespace = environment.namespace;
             // avoid pushing same namespace for same cluster multiple times (can be data bug in backend)
-            if(!_namespaces.some(_ns => (_ns.clusterId == _clusterId && _ns.actualName == _namespace))){
+            if(_namespace && !_namespaces.some(_ns => (_ns.clusterId == _clusterId && _ns.actualName == _namespace))){
                 _namespaces.push({
                     key: _clusterId + "_" + _namespace,
                     label: '<div><div class="dc__truncate-text">'+_namespace+'</div><div class="cn-6 fs-11 fw-n dc__truncate-text"> cluster: '+_clusterName+'</div></div>',


### PR DESCRIPTION
# Description

Now namespaces are optional when it comes to virtual clusters. So, added a check for an empty namespace for the filter list

Fixes [#AB3592](https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/3592)

<img width="785" alt="Screenshot 2023-06-06 at 11 39 48 AM" src="https://github.com/devtron-labs/dashboard/assets/98738644/91f19701-bf66-44ff-b267-adf09a79f4bf">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Create a Virtual cluster & then an environment without a namespace
- Select the virtual cluster in the app list & then open the namespace


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


