### PR TITLE
fix: Hide image card for CD artifact

### DIFF
--- a/src/components/app/details/cicdHistory/Artifacts.tsx
+++ b/src/components/app/details/cicdHistory/Artifacts.tsx
@@ -95,7 +95,7 @@ export default function Artifacts({
     } else {
         return (
             <div className="flex left column p-16">
-                {!isJobView && (
+                {!isJobView && type !== HistoryComponentType.CD && (
                     <CIListItem type="artifact">
                         <div className="flex column left hover-trigger">
                             <div className="cn-9 fs-14 flex left" data-testid="artifact-text-visibility">


### PR DESCRIPTION
# Description

 Hide image card for CD artifact in PRE/POST CD
<img width="874" alt="Screenshot 2023-06-09 at 3 48 08 PM" src="https://github.com/devtron-labs/dashboard/assets/61836271/49ff4f12-9eaf-4d13-a16c-8c762e5b4590">

Fixes [#AB3642](https://dev.azure.com/DevtronLabs/Devtron/_boards/board/t/OSS%20adoption/Stories/?workitem=3642)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


