### PR TITLE
fix: Update with empty string for GCR an GCP container registry

### DIFF
--- a/src/components/dockerRegistry/Docker.tsx
+++ b/src/components/dockerRegistry/Docker.tsx
@@ -420,7 +420,7 @@ function DockerForm({
             ...(selectedDockerRegistryType.value === 'artifact-registry' || selectedDockerRegistryType.value === 'gcr'
                 ? {
                       username: trimmedUsername,
-                      password: `'${parsePassword(customState.password.value)}'`,
+                      password: parsePassword(customState.password.value),
                   }
                 : {}),
             ...(selectedDockerRegistryType.value === 'docker-hub' ||
@@ -822,6 +822,8 @@ function DockerForm({
                                     value={customState.password.value}
                                     className="w-100 p-10"
                                     rows={3}
+                                    onBlur={id && handleOnBlur}
+                                    onFocus={handleOnFocus}
                                     onChange={customHandleChange}
                                     placeholder={selectedDockerRegistryType.password.placeholder}
                                 />


### PR DESCRIPTION
# Description

while updating the container registry token, after saving the token isnt being saved in DB when passed empty

Fixes #https://github.com/devtron-labs/devtron/issues/3516

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update




# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


