### PR TITLE
fix: Promethes showing in toggled state 

### DIFF
--- a/src/components/cluster/Cluster.tsx
+++ b/src/components/cluster/Cluster.tsx
@@ -240,6 +240,7 @@ export default class ClusterList extends Component<ClusterListProps, any> {
                                     toggleCheckTlsConnection={this.toggleCheckTlsConnection}
                                     setTlsConnectionFalse={this.setTlsConnectionFalse}
                                     isTlsConnection={this.state.isTlsConnection}
+                                    prometheus_url={cluster.prometheus_url}
                                 />
                             ),
                     )}
@@ -751,8 +752,8 @@ function Cluster({
                                 active={true}
                                 config={{}}
                                 reload={reload}
-                                prometheus_url=""
-                                prometheusAuth={state.prometheus}
+                                prometheus_url={prometheus_url}
+                                prometheusAuth={state.prometheus} 
                                 defaultClusterComponent={state.defaultClusterComponent}
                                 isTlsConnection={isTlsConnection}
                                 isClusterDetails={state.isClusterDetails}


### PR DESCRIPTION
# Description

It bugs out when you go to clusters and environments section in global configurations and edit any cluster.
It will show as prometheus not configured even if you have configured.

Before Fix
Clusters and Environments section should have shown as prometheus configured along with the endpoint and Authentication Type.

After Fix
Clusters and Environments section showing as prometheus not configured.
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (https://github.com/devtron-labs/devtron/issues/3520)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested locally


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


