### PR TITLE
Fix: redirecting url of Pod in cluster Section

### DIFF
--- a/src/components/ClusterNodes/NodeDetails.tsx
+++ b/src/components/ClusterNodes/NodeDetails.tsx
@@ -7,6 +7,7 @@ import {
     useBreadcrumb,
     toastAccessDenied,
     ServerErrors,
+    URLS,
 } from '@devtron-labs/devtron-fe-common-lib'
 import { ReactComponent as Info } from '../../assets/icons/ic-info-filled.svg'
 import { ReactComponent as Error } from '../../assets/icons/ic-error-exclamation.svg'
@@ -637,7 +638,7 @@ export default function NodeDetails({ imageList, isSuperAdmin, namespaceList }: 
     const handleResourceClick=(e)=>{
         const {name}=e.currentTarget.dataset
         const _url=`/resource-browser/${clusterId}/all/pod/${K8S_EMPTY_GROUP}/${name}`
-        push(_url)
+        window.open(_url,'_blank')
     }
     const renderPodHeaderCell = (
         columnName: string,
@@ -706,7 +707,7 @@ export default function NodeDetails({ imageList, isSuperAdmin, namespaceList }: 
                                                 interactive={true}
                                             >
                                                 <a
-                                                    className="dc__inline-block dc__ellipsis-right lh-20"
+                                                    className="dc__inline-block dc__ellipsis-right lh-20 cursor"
                                                     style={{ maxWidth: 'calc(100% - 20px)' }}
                                                     data-name={pod.name}
                                                     onClick={handleResourceClick}

--- a/src/components/ClusterNodes/NodeDetails.tsx
+++ b/src/components/ClusterNodes/NodeDetails.tsx
@@ -55,7 +55,7 @@ import DrainNodeModal from './NodeActions/DrainNodeModal'
 import DeleteNodeModal from './NodeActions/DeleteNodeModal'
 import { createTaintsList } from '../cluster/cluster.util'
 import { K8S_EMPTY_GROUP } from '../ResourceBrowser/Constants'
-
+import { URLS } from '../../config'
 
 
 export default function NodeDetails({ imageList, isSuperAdmin, namespaceList }: ClusterListType) {
@@ -636,7 +636,7 @@ export default function NodeDetails({ imageList, isSuperAdmin, namespaceList }: 
     }
     const handleResourceClick=(e)=>{
         const {name}=e.currentTarget.dataset
-        const _url=`/resource-browser/${clusterId}/all/pod/${K8S_EMPTY_GROUP}/${name}`
+        const _url=`${URLS.RESOURCE_BROWSER}/${clusterId}/all/pod/${K8S_EMPTY_GROUP}/${name}`
         window.open(_url,'_blank')
     }
     const renderPodHeaderCell = (
@@ -705,14 +705,14 @@ export default function NodeDetails({ imageList, isSuperAdmin, namespaceList }: 
                                                 content={pod.name}
                                                 interactive={true}
                                             >
-                                                <a
-                                                    className="dc__inline-block dc__ellipsis-right lh-20 cursor"
+                                                <span
+                                                    className="dc__inline-block dc__ellipsis-right lh-20 cb-5 cursor"
                                                     style={{ maxWidth: 'calc(100% - 20px)' }}
                                                     data-name={pod.name}
                                                     onClick={handleResourceClick}
                                                 >
                                                     {pod.name}
-                                                </a>
+                                                </span>
                                             </Tippy>
                                             <Tippy
                                                 className="default-tt"

--- a/src/components/ClusterNodes/NodeDetails.tsx
+++ b/src/components/ClusterNodes/NodeDetails.tsx
@@ -54,6 +54,8 @@ import CordonNodeModal from './NodeActions/CordonNodeModal'
 import DrainNodeModal from './NodeActions/DrainNodeModal'
 import DeleteNodeModal from './NodeActions/DeleteNodeModal'
 import { createTaintsList } from '../cluster/cluster.util'
+import { K8S_EMPTY_GROUP, K8S_RESOURCE_LIST } from '../ResourceBrowser/Constants'
+
 
 
 export default function NodeDetails({ imageList, isSuperAdmin, namespaceList }: ClusterListType) {
@@ -632,7 +634,11 @@ export default function NodeDetails({ imageList, isSuperAdmin, namespaceList }: 
                   }
         setSortedPodList([...nodeDetail.pods].sort(comparatorMethod))
     }
-
+    const handleResourceClick=(e)=>{
+        const {name}=e.currentTarget.dataset
+        const _url=`/resource-browser/${clusterId}/all/pod/${K8S_EMPTY_GROUP}/${name}`
+        push(_url)
+    }
     const renderPodHeaderCell = (
         columnName: string,
         sortingFieldName: string,
@@ -699,12 +705,14 @@ export default function NodeDetails({ imageList, isSuperAdmin, namespaceList }: 
                                                 content={pod.name}
                                                 interactive={true}
                                             >
-                                                <span
+                                                <a
                                                     className="dc__inline-block dc__ellipsis-right lh-20"
                                                     style={{ maxWidth: 'calc(100% - 20px)' }}
+                                                    data-name={pod.name}
+                                                    onClick={handleResourceClick}
                                                 >
                                                     {pod.name}
-                                                </span>
+                                                </a>
                                             </Tippy>
                                             <Tippy
                                                 className="default-tt"

--- a/src/components/ClusterNodes/NodeDetails.tsx
+++ b/src/components/ClusterNodes/NodeDetails.tsx
@@ -7,7 +7,6 @@ import {
     useBreadcrumb,
     toastAccessDenied,
     ServerErrors,
-    URLS,
 } from '@devtron-labs/devtron-fe-common-lib'
 import { ReactComponent as Info } from '../../assets/icons/ic-info-filled.svg'
 import { ReactComponent as Error } from '../../assets/icons/ic-error-exclamation.svg'

--- a/src/components/ClusterNodes/NodeDetails.tsx
+++ b/src/components/ClusterNodes/NodeDetails.tsx
@@ -55,7 +55,7 @@ import CordonNodeModal from './NodeActions/CordonNodeModal'
 import DrainNodeModal from './NodeActions/DrainNodeModal'
 import DeleteNodeModal from './NodeActions/DeleteNodeModal'
 import { createTaintsList } from '../cluster/cluster.util'
-import { K8S_EMPTY_GROUP, K8S_RESOURCE_LIST } from '../ResourceBrowser/Constants'
+import { K8S_EMPTY_GROUP } from '../ResourceBrowser/Constants'
 
 
 

--- a/src/components/ClusterNodes/NodeDetails.tsx
+++ b/src/components/ClusterNodes/NodeDetails.tsx
@@ -635,8 +635,7 @@ export default function NodeDetails({ imageList, isSuperAdmin, namespaceList }: 
         setSortedPodList([...nodeDetail.pods].sort(comparatorMethod))
     }
     const handleResourceClick=(e)=>{
-        const {name}=e.currentTarget.dataset
-        const _url=`${URLS.RESOURCE_BROWSER}/${clusterId}/all/pod/${K8S_EMPTY_GROUP}/${name}`
+        const _url=`${URLS.RESOURCE_BROWSER}/${clusterId}/all/pod/${K8S_EMPTY_GROUP}/${e.currentTarget.dataset.name}`
         window.open(_url,'_blank')
     }
     const renderPodHeaderCell = (


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
For the pod resources in Clusters section ,on clicking the resource we should be able to reach the manifest,logs ,terminal page of the resource.

Fixes # [#4288](https://dev.azure.com/DevtronLabs/Devtron/_boards/board/t/OSS%20adoption/Stories/?workitem=4288)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
1.After making the changes in the code ,i have tested it on the local host


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


