### PR TITLE
fix: Removed move task option in jobs

### DIFF
--- a/src/components/CIPipelineN/TaskList.tsx
+++ b/src/components/CIPipelineN/TaskList.tsx
@@ -348,7 +348,7 @@ export function TaskList({
                                         <Trash className="icon-dim-16 mr-10" />
                                         Remove
                                     </div>
-                                    {taskDetail.stepType && (
+                                    {!isJobView && taskDetail.stepType && (
                                         <div
                                             className="flex left p-8 pointer dc__hover-n50"
                                             data-index={index}


### PR DESCRIPTION
# Description

we shouldn’t give option to move plugin in job for post build because no any uses for that feature on that place

Fixes # [AB4393](https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/4393/)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


