### PR TITLE
fix: Page not redirecting from dashboard to app

### DIFF
--- a/src/components/common/navigation/NavigationRoutes.tsx
+++ b/src/components/common/navigation/NavigationRoutes.tsx
@@ -385,11 +385,11 @@ export default function NavigationRoutes() {
                                             </Route>,
                                         ]}
                                         {isSuperAdmin && !window._env_.K8S_CLIENT && (
-                                            <AppContext.Provider value={contextValue}>
-                                                <Route path={URLS.JOB}>
+                                            <Route path={URLS.JOB}>
+                                                <AppContext.Provider value={contextValue}>
                                                     <Jobs />
-                                                </Route>
-                                            </AppContext.Provider>
+                                                </AppContext.Provider>
+                                            </Route>
                                         )}
                                         <Route>
                                             <RedirectUserWithSentry


### PR DESCRIPTION
# Description

If user opening the dashboard with "/dashboard" URL app list page unable to open on same URL but it should be redirect on App list page.

Fixes [#AB4417](https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/4417)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


