### PR TITLE
fix: Build & deploy page break on old data

### DIFF
--- a/src/components/app/details/triggerView/workflow.service.ts
+++ b/src/components/app/details/triggerView/workflow.service.ts
@@ -533,7 +533,7 @@ function cdPipelineToNode(cdPipeline: CdPipeline, dimensions: WorkflowDimensions
         stageIndex++
     }
     let cdDownstreams = []
-    if (dimensions.type === WorkflowDimensionType.TRIGGER && !isEmpty(cdPipeline.postDeployStage?.steps || cdPipeline.preStage?.config)) {
+    if (dimensions.type === WorkflowDimensionType.TRIGGER && !isEmpty(cdPipeline.postDeployStage?.steps || cdPipeline.postStage?.config)) {
         cdDownstreams = [`${WorkflowNodeType.POST_CD}-${cdPipeline.id}`]
     }
 

--- a/src/components/app/details/triggerView/workflow/Workflow.tsx
+++ b/src/components/app/details/triggerView/workflow/Workflow.tsx
@@ -248,10 +248,12 @@ export class Workflow extends Component<WorkflowProps> {
         return this.props.nodes.reduce((edgeList, node) => {
             node.downstreams.forEach((downStreamNodeId) => {
                 let endNode = this.props.nodes.find((val) => val.type + '-' + val.id == downStreamNodeId)
-                edgeList.push({
-                    startNode: node,
-                    endNode: endNode,
-                })
+                if(endNode){
+                    edgeList.push({
+                        startNode: node,
+                        endNode: endNode,
+                    })
+                }
             })
             return edgeList
         }, [])

--- a/src/components/app/details/triggerView/workflow/Workflow.tsx
+++ b/src/components/app/details/triggerView/workflow/Workflow.tsx
@@ -248,12 +248,10 @@ export class Workflow extends Component<WorkflowProps> {
         return this.props.nodes.reduce((edgeList, node) => {
             node.downstreams.forEach((downStreamNodeId) => {
                 let endNode = this.props.nodes.find((val) => val.type + '-' + val.id == downStreamNodeId)
-                if(endNode){
                     edgeList.push({
                         startNode: node,
                         endNode: endNode,
                     })
-                }
             })
             return edgeList
         }, [])


### PR DESCRIPTION
# Description

Build and deploy page break when pre & post is added from old api

Fixes #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Create pre-post cd and open build and deploy page


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


