### PR TITLE
Hp bugs of chart store & container registry

### DIFF
--- a/src/components/chartRepo/ChartRepo.tsx
+++ b/src/components/chartRepo/ChartRepo.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useForm, useAsync } from '../common'
+import { useForm, useAsync, getNonEditableChartRepoText } from '../common'
 import {
     showError,
     Progressing,
@@ -45,22 +45,6 @@ export default function ChartRepo({ isSuperAdmin }: ChartRepoType) {
         const maxRange = 4294967296
         const num = randomBytes[0] / maxRange
         return Math.floor(num * range) + min
-    }
-
-    function refetchCharts(e) {
-        if (fetching) {
-            return
-        }
-        setFetching(true)
-        toast.success(TOAST_INFO.RE_SYNC)
-         reSyncChartRepo()
-            .then((response) => {
-                setFetching(false)
-            })
-            .catch((error) => {
-                showError(error)
-                setFetching(false)
-            })
     }
 
     if (!isSuperAdmin) {
@@ -148,7 +132,7 @@ function CollapsedList({ id, name, active, url, authMode, isEditable, accessToke
             toggleCollapse((t) => !t)
         } else {
             toast.info(
-                `Cannot edit chart repo "${name}". Some charts from this repository are being used by helm apps.`,
+                getNonEditableChartRepoText(name),
             )
         }
     }

--- a/src/components/chartRepo/ChartRepo.tsx
+++ b/src/components/chartRepo/ChartRepo.tsx
@@ -16,16 +16,16 @@ import { saveChartProviderConfig, updateChartProviderConfig, validateChartRepoCo
 import { getChartRepoList } from '../../services/service'
 import { ReactComponent as Add } from '../../assets/icons/ic-add.svg'
 import { ReactComponent as Helm } from '../../assets/icons/ic-helmchart.svg'
-import { DOCUMENTATION, PATTERNS, CHART_REPO_TYPE, CHART_REPO_AUTH_TYPE, CHART_REPO_LABEL } from '../../config'
+import { DOCUMENTATION, PATTERNS, CHART_REPO_TYPE, CHART_REPO_AUTH_TYPE, CHART_REPO_LABEL, URLS } from '../../config'
 import { ValidateForm, VALIDATION_STATUS } from '../common/ValidateForm/ValidateForm'
 import './chartRepo.scss'
 import DeleteComponent from '../../util/DeleteComponent'
 import {DC_CHART_REPO_CONFIRMATION_MESSAGE, DeleteComponentsName, TOAST_INFO} from '../../config/constantMessaging'
 import { RadioGroup, RadioGroupItem } from '@devtron-labs/devtron-fe-common-lib'
-import TippyCustomized from '@devtron-labs/devtron-fe-common-lib'
-import { ReactComponent as SyncIcon } from '../../assets/icons/ic-arrows_clockwise.svg'
 import { ChartFormFields } from './ChartRepoType'
 import {ChartRepoType} from "./chartRepo.types";
+import { NavLink } from 'react-router-dom'
+import { ReactComponent as Question } from '../../assets/icons/ic-help-outline.svg'
 
 export default function ChartRepo({ isSuperAdmin }: ChartRepoType) {
     const [loading, result, error, reload] = useAsync(getChartRepoList, [], isSuperAdmin)
@@ -409,6 +409,7 @@ function ChartForm({
                 name={isNameField ? 'name' : 'url'}
                 error={isNameField ? state.name.error : state.url.error}
                 label={isNameField ? 'Name*' : 'URL*'}
+                placeholder={isNameField ? 'Enter Repository name' : 'Enter repo URL'}
                 disabled={!isEditable}
             />
         )
@@ -458,9 +459,9 @@ function ChartForm({
                 configName="chart repo"
             />
 
-            <div className="form__row form__row--two-third">
-                { renderModifiedChartInputElement(ChartFormFields.NAME, isEditable)}
-                { renderModifiedChartInputElement(ChartFormFields.URL, isEditable)}
+            <div className="form__row--two-third mb-16">
+                {renderModifiedChartInputElement(ChartFormFields.NAME, isEditable)}
+                {renderModifiedChartInputElement(ChartFormFields.URL, isEditable)}
                 {(chartRepoType !== CHART_REPO_TYPE.PUBLIC ||
                     (id && authMode === CHART_REPO_AUTH_TYPE.USERNAME_PASSWORD)) && (
                     <>
@@ -494,29 +495,43 @@ function ChartForm({
                     </>
                 )}
             </div>
-
-            <div className="form__row form__buttons">
-                {id && (
-                    <button
-                        data-testid="chart-repo-delete-button"
-                        className="cta delete dc__m-auto chart_repo__delete-button"
-                        type="button"
-                        onClick={handleDeleteClick}
-                    >
-                        {deleting ? <Progressing /> : 'Delete'}
-                    </button>
+            <div className={`${!id ? 'form__row--one-third' : ''} pb-16 pt-16 dc__border-top`}>
+                {!id && (
+                    <div className="form-row flex left">
+                         <Question className="icon-dim-16 mr-8" />
+                        Looking to add OCI-based registry?
+                        <NavLink
+                            className="dc__no-decor pl-8 pr-8 flex left cb-5"
+                            to={`${URLS.GLOBAL_CONFIG_DOCKER}/0`}
+                        >
+                            Add OCI Registries
+                        </NavLink>
+                    </div>
                 )}
-                <button
-                    data-testid="chart-repo-cancel-button"
-                    className="cta cancel"
-                    type="button"
-                    onClick={handleCancelClick}
-                >
-                    Cancel
-                </button>
-                <button data-testid="chart-repo-save-button" className="cta" type="submit" disabled={loading}>
-                    {loading ? <Progressing /> : id ? 'Update' : 'Save'}
-                </button>
+
+                <div className=" form__buttons">
+                    {id && (
+                        <button
+                            data-testid="chart-repo-delete-button"
+                            className="cta delete dc__m-auto chart_repo__delete-button"
+                            type="button"
+                            onClick={handleDeleteClick}
+                        >
+                            {deleting ? <Progressing /> : 'Delete'}
+                        </button>
+                    )}
+                    <button
+                        data-testid="chart-repo-cancel-button"
+                        className="cta cancel"
+                        type="button"
+                        onClick={handleCancelClick}
+                    >
+                        Cancel
+                    </button>
+                    <button data-testid="chart-repo-save-button" className="cta" type="submit" disabled={loading}>
+                        {loading ? <Progressing /> : id ? 'Update' : 'Save'}
+                    </button>
+                </div>
             </div>
             {confirmation && (
                 <DeleteComponent

--- a/src/components/charts/charts.service.ts
+++ b/src/components/charts/charts.service.ts
@@ -249,14 +249,14 @@ export function updateHelmAppProject(payload: HelmProjectUpdatePayload): Promise
     return put(Routes.UPDATE_HELM_APP_META_INFO, payload)
 }
 
-export function getChartProviderList(){
+export function getChartProviderList(): Promise<ResponseType>{
     return get('app-store/chart-provider/list')
 }
 
-export function postChartProviderList(payload){
+export function updateChartProviderList(payload){
     return post('app-store/chart-provider/update', payload)
 }
 
-export function postSyncSpecificChart(payload){
+export function updateSyncSpecificChart(payload){
     return post('app-store/chart-provider/sync-chart ', payload)
 }

--- a/src/components/charts/charts.types.tsx
+++ b/src/components/charts/charts.types.tsx
@@ -351,11 +351,12 @@ export interface HelmProjectUpdatePayload {
 }
 
 export interface ChartListPopUpType{
-  onClose:() => void
+  onClose:(e) => void
   chartList: ChartListType[]
   filteredChartList: ChartListType[]
   isLoading: boolean
   setFilteredChartList: React.Dispatch<React.SetStateAction<ChartListType[]>>
+  setShowSourcePopoUp: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export interface ChartListType {

--- a/src/components/charts/list/AddChartSource.tsx
+++ b/src/components/charts/list/AddChartSource.tsx
@@ -1,17 +1,25 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { NavLink } from 'react-router-dom'
-import { URLS } from '../../../config'
+import { SERVER_MODE, URLS } from '../../../config'
+import { mainContext } from '../../common/navigation/NavigationRoutes'
 
 function AddChartSource() {
+    const { serverMode } = useContext(mainContext)
+
     return (
         <div className="chart-list__add w-200 en-2 bw-1 br-4 bcn-0 fw-4 fs-13 cn-9 mt-8">
             <NavLink className="add-repo-row dc__no-decor pl-8 pr-8 flex left cn-9" to={URLS.GLOBAL_CONFIG_CHART}>
                 Add Chart repositories
             </NavLink>
 
-            <NavLink className="add-repo-row dc__no-decor pl-8 pr-8 flex left cn-9" to={`${URLS.GLOBAL_CONFIG_DOCKER}/0`}>
-                Add OCI Registries
-            </NavLink>
+            {serverMode !== SERVER_MODE.EA_ONLY && (
+                <NavLink
+                    className="add-repo-row dc__no-decor pl-8 pr-8 flex left cn-9"
+                    to={`${URLS.GLOBAL_CONFIG_DOCKER}/0`}
+                >
+                    Add OCI Registries
+                </NavLink>
+            )}
         </div>
     )
 }

--- a/src/components/charts/list/ChartListPopUpRow.tsx
+++ b/src/components/charts/list/ChartListPopUpRow.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react'
+import { List } from '../../globalConfigurations/GlobalConfiguration'
+import Tippy from '@tippyjs/react'
+import { Progressing, showError } from '@devtron-labs/devtron-fe-common-lib'
+import { updateChartProviderList, updateSyncSpecificChart } from '../charts.service'
+import { ReactComponent as SyncIcon } from '../../../assets/icons/ic-arrows_clockwise.svg'
+import { ChartListType } from '../charts.types'
+import { toast } from 'react-toastify'
+import { getNonEditableChartRepoText } from '../../common'
+import { TOAST_INFO } from '../../../config/constantMessaging'
+
+function ChartListPopUpRow({ index, list }: { index: number; list: ChartListType; }) {
+    const [isSpecificChartRefetchLoading, setSpecificChartRefetchLoading] = useState(false)
+    const [isToggleLoading, setToggleLoading] = useState(false)
+    const [enabled, toggleEnabled] = useState<boolean>(list.active)
+
+    function refetchSpecificChart(id: number, isOCIRegistry: boolean) {
+        let payload = {
+            id: id,
+            isOCIRegistry: isOCIRegistry,
+        }
+        setSpecificChartRefetchLoading(true)
+
+        try {
+            updateSyncSpecificChart(payload).then((response) => {
+                setSpecificChartRefetchLoading(false)
+                toast.success(TOAST_INFO.RE_SYNC)
+            })
+        } catch (error) {
+            showError(error)
+            setSpecificChartRefetchLoading(false)
+        }
+    }
+
+    const onSelectToggle = async () => {
+        if (list.isEditable) {
+            const _toggleEnabled = !enabled
+            let payload = {
+                id: list.id, //eg: OCI registry: “test-registry” ; for chart repo: “1”
+                isOCIRegistry: list.isOCIRegistry, // for chart-repo: false
+                active: _toggleEnabled,
+            }
+            setToggleLoading(true)
+
+            await updateChartProviderList(payload)
+                .then((response) => {
+                    toggleEnabled(_toggleEnabled)
+                    setToggleLoading(false)
+                })
+                .catch((error) => {
+                    setToggleLoading(false)
+                    showError(error)
+                })
+        }else{
+            toast.info(
+                getNonEditableChartRepoText(list.name),
+            )
+        }
+    }
+
+    return (
+        <div className="chart-list__row">
+            <List key={`chart-row-${index}`}>
+                <List.Logo>
+                    <div className={'dc__registry-icon ' + list.registryProvider}></div>
+                </List.Logo>
+                <div>{list.name}</div>
+                <Tippy className="default-tt" arrow={false} placement="top" content="Refetch charts">
+                    <a
+                        rel="noreferrer noopener"
+                        target="_blank"
+                        className={`dc__link ${!isSpecificChartRefetchLoading ? 'cursor' : ''} ${
+                            !enabled ? 'cursor-not-allowed' : ''
+                        }`}
+                        onClick={() => enabled && refetchSpecificChart(list.id, list.isOCIRegistry)}
+                    >
+                        {isSpecificChartRefetchLoading ? (
+                            <Progressing size={16} fillColor="var(--N500)"/>
+                        ) : (
+                            <span>
+                                <SyncIcon className={`${enabled ? "scn-5" : "scn-2"}`} />
+                            </span>
+                        )}
+                    </a>
+                </Tippy>
+
+                <Tippy
+                    className="default-tt"
+                    arrow={false}
+                    placement="bottom"
+                    content={enabled ? 'Disable chart repository' : 'Enable chart repository'}
+                >
+                    
+                    <span data-testid={`${'name'}-chart-repo-toggle-button`} style={{ marginLeft: 'auto' }} className={`${list.isEditable ? "cursor-not-allowed" : ""}`}>
+                        {isToggleLoading ? (
+                            <Progressing size={16} />
+                        ) : (
+                            <List.Toggle onSelect={onSelectToggle} enabled={enabled} />
+                        )}
+                    </span>
+                </Tippy>
+            </List>
+        </div>
+    )
+}
+
+export default ChartListPopUpRow

--- a/src/components/charts/list/DiscoverCharts.tsx
+++ b/src/components/charts/list/DiscoverCharts.tsx
@@ -127,10 +127,14 @@ function DiscoverChartList({isSuperAdmin} : {isSuperAdmin: boolean}) {
         }
     }, [location.search, state.loading])
 
+    const getInitChartList = async()  => {
+     return  getChartProviderList()
+    }
+
     const getChartFilter = async () => {
         setIsLoading(true)
         try {
-            let chartRepos = (await getChartProviderList()).result || []
+            let chartRepos = (await getInitChartList()).result || []
             chartRepos.sort((a, b) => a['name'].localeCompare(b['name']))
             setChartLists(chartRepos)
             setFilteredChartList(chartRepos)
@@ -299,7 +303,8 @@ function DiscoverChartList({isSuperAdmin} : {isSuperAdmin: boolean}) {
         setShowSourcePopoUp(true)
     }
 
-    const toggleChartListPopUp = (): void => {
+    const toggleChartListPopUp = (e: React.MouseEvent): void => {
+        e.stopPropagation()
         setShowSourcePopoUp(!setShowSourcePopoUp)
     }
 
@@ -341,6 +346,7 @@ function DiscoverChartList({isSuperAdmin} : {isSuperAdmin: boolean}) {
                             filteredChartList={filteredChartList}
                             setFilteredChartList={setFilteredChartList}
                             isLoading={isLoading}
+                            setShowSourcePopoUp={setShowSourcePopoUp}
                         />
                     )}
                 </div>

--- a/src/components/common/helpers/Helpers.tsx
+++ b/src/components/common/helpers/Helpers.tsx
@@ -1212,3 +1212,7 @@ export const getDeploymentAppType = (
   }
   return allowedDeploymentTypes[0]
 }
+
+export const getNonEditableChartRepoText = (name: string): string => {
+   return `Cannot edit chart repo "${name}". Some charts from this repository are being used by helm apps.`
+}

--- a/src/components/dockerRegistry/Docker.tsx
+++ b/src/components/dockerRegistry/Docker.tsx
@@ -423,10 +423,7 @@ function DockerForm({
     const [validationStatus, setValidationStatus] = useState(
         VALIDATION_STATUS.DRY_RUN || VALIDATION_STATUS.FAILURE || VALIDATION_STATUS.LOADER || VALIDATION_STATUS.SUCCESS,
     )
-    const isGCROrGCP =
-        selectedDockerRegistryType.value === RegistryType.ARTIFACT_REGISTRY ||
-        selectedDockerRegistryType.value === RegistryType.GCR
-        
+         
     function customHandleChange(e) {
         setCustomState((st) => ({ ...st, [e.target.name]: { value: e.target.value, error: '' } }))
     }
@@ -1173,12 +1170,13 @@ function DockerForm({
         </div>
     </div>
     }
-
+    const isGCROrGCP =
+    selectedDockerRegistryType.value === RegistryType.ARTIFACT_REGISTRY ||
+    selectedDockerRegistryType.value === RegistryType.GCR
+  
     const renderAuthentication = () => {
-        if( registryStorageType === RegistryStorageType.OCI_PRIVATE){
-            if (
-                selectedDockerRegistryType.value === RegistryType.ECR
-            ) {
+        if (registryStorageType !== RegistryStorageType.OCI_PUBLIC) {
+            if (selectedDockerRegistryType.value === RegistryType.ECR) {
                 return (
                     <>
                         <div className="form__row mb-0-imp">
@@ -1232,6 +1230,82 @@ function DockerForm({
                                     />
                                 </div>
                             </>
+                        )}
+                    </>
+                )
+            } else {
+                return (
+                    <>
+                        <div className={`${isGCROrGCP ? '' : 'form__row--two-third'}`}>
+                            <div className="form__row">
+                                <CustomInput
+                                    dataTestid="container-registry-username-textbox"
+                                    name="username"
+                                    labelClassName="dc__required-field"
+                                    tabIndex={5}
+                                    value={customState.username.value || selectedDockerRegistryType.id.defaultValue}
+                                    autoComplete="off"
+                                    error={customState.username.error}
+                                    onChange={customHandleChange}
+                                    label={selectedDockerRegistryType.id.label}
+                                    disabled={!!selectedDockerRegistryType.id.defaultValue}
+                                    placeholder={
+                                        selectedDockerRegistryType.id.placeholder
+                                            ? selectedDockerRegistryType.id.placeholder
+                                            : 'Enter username'
+                                    }
+                                />
+                            </div>
+                            <div className="form__row">
+                                {(selectedDockerRegistryType.value === RegistryType.DOCKER_HUB ||
+                                    selectedDockerRegistryType.value === RegistryType.ACR ||
+                                    selectedDockerRegistryType.value === RegistryType.QUAY ||
+                                    selectedDockerRegistryType.value === RegistryType.OTHER) && (
+                                    <CustomInput
+                                        dataTestid="container-registry-password-textbox"
+                                        name="password"
+                                        labelClassName="dc__required-field"
+                                        tabIndex={6}
+                                        value={customState.password.value}
+                                        error={customState.password.error}
+                                        onChange={customHandleChange}
+                                        onBlur={id && handleOnBlur}
+                                        onFocus={handleOnFocus}
+                                        label={selectedDockerRegistryType.password.label}
+                                        placeholder={
+                                            selectedDockerRegistryType.password.placeholder
+                                                ? selectedDockerRegistryType.password.placeholder
+                                                : 'Enter password/token'
+                                        }
+                                        autoComplete="off"
+                                    />
+                                )}
+                            </div>
+                        </div>
+                        {isGCROrGCP && (
+                            <div className="form__row">
+                                <label htmlFor="" className="form__label w-100 dc__required-field">
+                                    {selectedDockerRegistryType.password.label}
+                                </label>
+                                <textarea
+                                    name="password"
+                                    tabIndex={6}
+                                    data-testid="artifact-service-account-textbox"
+                                    value={customState.password.value}
+                                    className="w-100 p-10"
+                                    rows={3}
+                                    onBlur={id && handleOnBlur}
+                                    onFocus={handleOnFocus}
+                                    onChange={customHandleChange}
+                                    placeholder={selectedDockerRegistryType.password.placeholder}
+                                />
+                                {customState.password?.error && (
+                                    <div className="form__error">
+                                        <Error className="form__icon form__icon--error" />
+                                        {customState.password?.error}
+                                    </div>
+                                )}
+                            </div>
                         )}
                     </>
                 )
@@ -1360,34 +1434,7 @@ function DockerForm({
                     </div>
                 </div>
                 {renderAuthentication()}
-                {(isGCROrGCP || registryStorageType === RegistryStorageType.OCI_PRIVATE)  && (
-                    <>
-                        {renderUserNamePassword()}
-                        <div className="form__row">
-                            <label htmlFor="" className="form__label w-100 dc__required-field">
-                                {selectedDockerRegistryType.password.label}
-                            </label>
-                            <textarea
-                                name="password"
-                                tabIndex={6}
-                                data-testid="artifact-service-account-textbox"
-                                value={customState.password.value}
-                                className="w-100 p-10"
-                                rows={3}
-                                onBlur={id && handleOnBlur}
-                                onFocus={handleOnFocus}
-                                onChange={customHandleChange}
-                                placeholder={selectedDockerRegistryType.password.placeholder}
-                            />
-                            {customState.password?.error && (
-                                <div className="form__error">
-                                    <Error className="form__icon form__icon--error" />
-                                    {customState.password?.error}
-                                </div>
-                            )}
-                        </div>
-                    </>
-                )}
+               
                 {selectedDockerRegistryType.value === RegistryType.OTHER && (
                     <>
                         <div className={`form__buttons flex left ${toggleCollapsedAdvancedRegistry ? '' : 'mb-16'}`}>

--- a/src/components/v2/values/chartValuesDiff/ChartValuesView.component.tsx
+++ b/src/components/v2/values/chartValuesDiff/ChartValuesView.component.tsx
@@ -48,7 +48,7 @@ import { ReactComponent as Helm } from '../../../../assets/icons/helm-app.svg'
 import { envGroupStyle } from './ChartValuesView.utils'
 import { DELETE_ACTION } from '../../../../config'
 import Tippy from '@tippyjs/react'
-import { ReactComponent as InfoIcon } from '../../../../assets/icons/info-filled.svg'
+import { ReactComponent as InfoIcon } from '../../../../assets/icons/appstatus/info-filled.svg'
 
 const VirtualEnvSelectionInfoText = importComponentFromFELibrary('VirtualEnvSelectionInfoText')
 const VirtualEnvHelpTippy = importComponentFromFELibrary('VirtualEnvHelpTippy')
@@ -77,11 +77,13 @@ export const ChartEnvironmentSelector = ({
     }
 
     const renderOCIContainerRegistryText = () => {
-       if (isOCICompliantChart){
-        return <div className="cn-7 fs-12 pt-16">
-             <InfoIcon className="icon-dim-16 fcn-9"/>
-           <span>Charts from container registries can be deployed via helm only.</span> 
-        </div>
+       if (isOCICompliantChart) {
+           return (
+               <div className="cn-7 fs-12 pt-16 flexbox">
+                   <InfoIcon className="icon-dim-20 mr-4" />
+                   Charts from container registries can be deployed via helm only.
+               </div>
+           )
        }
     }
 

--- a/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
+++ b/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
@@ -1488,7 +1488,7 @@ function ChartValuesView({
                             !isCreateValueView &&
                             !isVirtualEnvironmentOnSelector &&
                             (!isDeployChartView || allowedDeploymentTypes.length > 0) &&
-                            !appDetails?.isVirtualEnvironment && (
+                            !appDetails?.isVirtualEnvironment && !commonState.installedConfig.isOCICompliantChart &&(
                                 <DeploymentAppSelector
                                     commonState={commonState}
                                     isUpdate={isUpdate}

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -396,6 +396,12 @@ a:focus {
   grid-column-gap: 16px;
 }
 
+.form__row--one-third {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    grid-column-gap: 16px;
+  }
+
 // ClassName of text area
 .dc__code-textarea {
     min-width: 100%;


### PR DESCRIPTION
Bug fixes:


1.  Chart Providers List: can also disable helm chart repositories with active deployments
2.  Chart Providers List: chart sync API is called for disabled chart provider
3. Chart Providers List: Toast chart sync API response
4. Duplicate pass/Token box showing in (Docker,quay,other,Azure) config while adding new container registry
5.  Chart deployed from OCI and visible in chart store as well but while deploying , Helm and gitops option should be not visible
6.  Chart Store: For empty chart list in chart store, the empty state hides the side bar on page refresh
7.  Chart Store EA Mode: Add chart source should redirect to chart repository only, currently can visit add registry page as well. Chart Store: Chart providers filter list is not visible for sub users
8. Chart version should be same in helm chart if pre-post deployed
9.  On changing the Registry type of any Registry Provider we are not maintaining the Registry Provider
10.  On saving any type of "Registry Provider"  which is already saved we have an issue with old registries

