### PR TITLE
fix: DATA VALIDATION ERROR and disabled toggle button for deployed apps in chart repo

### DIFF
--- a/src/components/chartRepo/ChartRepo.tsx
+++ b/src/components/chartRepo/ChartRepo.tsx
@@ -11,7 +11,7 @@ import {
 } from '@devtron-labs/devtron-fe-common-lib'
 import { toast } from 'react-toastify'
 import { List, CustomInput, ProtectedInput } from '../globalConfigurations/GlobalConfiguration'
-import Tippy, { tippy } from '@tippyjs/react';
+import Tippy from '@tippyjs/react';
 import { saveChartProviderConfig, updateChartProviderConfig, validateChartRepoConfiguration, reSyncChartRepo, deleteChartRepo } from './chartRepo.service';
 import { getChartRepoList } from '../../services/service'
 import { ReactComponent as Add } from '../../assets/icons/ic-add.svg'

--- a/src/components/chartRepo/ChartRepo.tsx
+++ b/src/components/chartRepo/ChartRepo.tsx
@@ -130,10 +130,10 @@ function CollapsedList({ id, name, active, url, authMode, isEditable, accessToke
     const [loading, setLoading] = useState(false);
 
     useEffectAfterMount(() => {
-        if (!collapsed) return
         async function update() {
             let payload = {
-                id: id || 0, name, url, authMode, active: enabled,
+                id: id || 0, name, url, active: enabled,
+                authMode: authMode || 'ANONYMOUS', 
                 ...(authMode === CHART_REPO_AUTH_TYPE.USERNAME_PASSWORD ? { username: userName, password } : {}),
                 ...(authMode === CHART_REPO_AUTH_TYPE.ACCESS_TOKEN ? { accessToken } : {})
             }
@@ -198,13 +198,13 @@ function CollapsedList({ id, name, active, url, authMode, isEditable, accessToke
                             className="default-tt"
                             arrow={false}
                             placement="bottom"
-                            content={enabled ? 'Disable chart repository' : 'Enable chart repository'}
+                            content={!isEditable ? "Can't disable repository" : enabled ? 'Disable chart repository' : 'Enable chart repository'}
                         >
                             <span data-testid={`${name}-chart-repo-toggle-button`} style={{ marginLeft: 'auto' }}>
                                 {loading ? (
                                     <Progressing />
                                 ) : (
-                                    <List.Toggle onSelect={(en) => toggleEnabled(en)} enabled={enabled} />
+                                    <List.Toggle onSelect={isEditable && toggleEnabled} enabled={enabled} isButtonDisabled={!isEditable} />
                                 )}
                             </span>
                         </Tippy>

--- a/src/components/chartRepo/ChartRepo.tsx
+++ b/src/components/chartRepo/ChartRepo.tsx
@@ -11,7 +11,7 @@ import {
 } from '@devtron-labs/devtron-fe-common-lib'
 import { toast } from 'react-toastify'
 import { List, CustomInput, ProtectedInput } from '../globalConfigurations/GlobalConfiguration'
-import Tippy from '@tippyjs/react';
+import Tippy, { tippy } from '@tippyjs/react';
 import { saveChartProviderConfig, updateChartProviderConfig, validateChartRepoConfiguration, reSyncChartRepo, deleteChartRepo } from './chartRepo.service';
 import { getChartRepoList } from '../../services/service'
 import { ReactComponent as Add } from '../../assets/icons/ic-add.svg'
@@ -167,6 +167,15 @@ function CollapsedList({ id, name, active, url, authMode, isEditable, accessToke
             )
         }
     }
+
+    let tippyContent
+
+    if (!isEditable) {
+        tippyContent = "Can't disable repository"
+    } else {
+        tippyContent = enabled ? 'Disable chart repository' : 'Enable chart repository'
+    }
+
     return (
         <article
             className={`collapsed-list dc__clear-both ${
@@ -198,7 +207,7 @@ function CollapsedList({ id, name, active, url, authMode, isEditable, accessToke
                             className="default-tt"
                             arrow={false}
                             placement="bottom"
-                            content={!isEditable ? "Can't disable repository" : enabled ? 'Disable chart repository' : 'Enable chart repository'}
+                            content={tippyContent}
                         >
                             <span data-testid={`${name}-chart-repo-toggle-button`} style={{ marginLeft: 'auto' }}>
                                 {loading ? (

--- a/src/components/globalConfigurations/GlobalConfiguration.tsx
+++ b/src/components/globalConfigurations/GlobalConfiguration.tsx
@@ -576,8 +576,13 @@ function Title({ title = '', subtitle = '', style = {}, className = '', tag = ''
     )
 }
 
-function ListToggle({ onSelect, enabled = false, ...props }) {
-    return <Toggle dataTestId="toggle-button" {...props} onSelect={onSelect} selected={enabled} />
+function ListToggle({ onSelect, enabled = false, isButtonDisabled = false, ...props }) {
+    const handleToggle = () => {
+        if (!isButtonDisabled) {
+            onSelect(!enabled);
+        }
+    };
+    return <Toggle dataTestId="toggle-button" {...props} onSelect={handleToggle} selected={enabled} disabled={isButtonDisabled} />
 }
 
 function DropDown({ className = '', dataTestid = '', style = {}, src = null, ...props }) {


### PR DESCRIPTION
# Description

These changes fixed the "data validation error" when we enable/disable a chart repo and also fixed the issue where we can enable/disable a chart even when the chart is being used in a deployed helm app.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
All tests have been performed manually by visiting Chart Repository and performing different actions.

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


