### PR TITLE
fix: AppGroup image selection 

### DIFF
--- a/src/components/ApplicationGroup/Details/TriggerView/EnvTriggerView.tsx
+++ b/src/components/ApplicationGroup/Details/TriggerView/EnvTriggerView.tsx
@@ -1072,7 +1072,9 @@ export default function EnvTriggerView({ filteredAppIds, isVirtualEnv }: AppGrou
                             isSelected: i === index,
                         }
                     })
-                    setFilterMaterials(artifacts)
+                    if (filterMaterials.length > 0) {
+                        setFilterMaterials(artifacts)
+                    }
                     node[materialType] = artifacts
                 }
                 return node

--- a/src/components/ApplicationGroup/Details/TriggerView/EnvTriggerView.tsx
+++ b/src/components/ApplicationGroup/Details/TriggerView/EnvTriggerView.tsx
@@ -1060,7 +1060,7 @@ export default function EnvTriggerView({ filteredAppIds, isVirtualEnv }: AppGrou
             const nodes = workflow.nodes.map((node) => {
                 if (
                     (selectedCDDetail && selectedCDDetail.id === +node.id && selectedCDDetail.type === node.type) ||
-                    (selectedCDNode && selectedCDNode.id == +node.id && node.type === selectedCDNode.type)
+                    (!showBulkCDModal && selectedCDNode && selectedCDNode.id == +node.id && node.type === selectedCDNode.type)
                 ) {
                     const artifacts = node[materialType].map((artifact, i) => {
                         return {

--- a/src/components/ApplicationGroup/Details/TriggerView/EnvTriggerView.tsx
+++ b/src/components/ApplicationGroup/Details/TriggerView/EnvTriggerView.tsx
@@ -133,12 +133,10 @@ export default function EnvTriggerView({ filteredAppIds, isVirtualEnv }: AppGrou
     const abortControllerRef = useRef(new AbortController())
     const [appReleaseTags, setAppReleaseTags] = useState<string[]>([])
     const [tagsEditableVal, setTagsEditable] = useState<boolean>(false)
-    const [fliteredWorkflowDataUpdated, setfliteredWorkflowDataUpdated] = useState<boolean>(false)
     const [hideImageTaggingHardDelete,setHideImageTaggingHardDelete] = useState<boolean>(false)
     const { queryParams } = useSearchString()
     const [isConfigPresent, setConfigPresent] = useState<boolean>(false)
     const [isDefaultConfigPresent, setDefaultConfig] = useState<boolean>(false)
-    const [filterMaterials, setFilterMaterials] = useState<any[]>([])
 
     const setAppReleaseTagsNames = (appReleaseTags: string[]) => {
         setAppReleaseTags(appReleaseTags)
@@ -166,7 +164,7 @@ export default function EnvTriggerView({ filteredAppIds, isVirtualEnv }: AppGrou
             onClickCDMaterial(queryParams.get('approval-node'), DeploymentNodeType.CD, true)
             getConfigs()
         }
-    }, [location.search, fliteredWorkflowDataUpdated])
+    }, [location.search])
 
     const getConfigs = () => {
         getDefaultConfig()
@@ -243,7 +241,6 @@ export default function EnvTriggerView({ filteredAppIds, isVirtualEnv }: AppGrou
         )
         _filteredWorkflows.sort((a, b) => sortCallback('name', a, b))
         setFilteredWorkflows(_filteredWorkflows)
-        setfliteredWorkflowDataUpdated(true)
     }
 
     const pollWorkflowStatus = (_processedWorkflowsData: ProcessWorkFlowStatusType) => {
@@ -1065,16 +1062,12 @@ export default function EnvTriggerView({ filteredAppIds, isVirtualEnv }: AppGrou
                     (selectedCDDetail && selectedCDDetail.id === +node.id && selectedCDDetail.type === node.type) ||
                     (selectedCDNode && selectedCDNode.id == +node.id && node.type === selectedCDNode.type)
                 ) {
-                    let materials = filterMaterials.length > 0 ? filterMaterials : node[materialType]
-                    const artifacts = materials.map((artifact, i) => {
+                    const artifacts = node[materialType].map((artifact, i) => {
                         return {
                             ...artifact,
                             isSelected: i === index,
                         }
                     })
-                    if (filterMaterials.length > 0) {
-                        setFilterMaterials(artifacts)
-                    }
                     node[materialType] = artifacts
                 }
                 return node
@@ -1868,35 +1861,6 @@ export default function EnvTriggerView({ filteredAppIds, isVirtualEnv }: AppGrou
         )
     }
 
-    const getSearchedItem = (searchedItems?: any[])  => {
-        let node: NodeAttr, _appID
-            if (selectedCDNode?.id) {
-                for (const _wf of filteredWorkflows) {
-                    node = _wf.nodes.find((el) => {
-                        return +el.id == selectedCDNode.id && el.type == selectedCDNode.type
-                    })
-                    if (node) {
-                        _appID = _wf.appId
-                        break
-                    }
-                }
-            }
-        const material = node?.[materialType] || []
-        let resultMaterials = []
-        material.forEach((mat) => {
-            if (((!mat.userApprovalMetadata || mat.userApprovalMetadata.approvalRuntimeState !== 2)) || !(searchedItems)) {
-                mat.isSelected = false
-                resultMaterials.push(mat)
-            }
-        })
-        searchedItems.forEach((mat) => {
-            if (!((!mat.userApprovalMetadata || mat.userApprovalMetadata.approvalRuntimeState !== 2)) || !(searchedItems)) {
-                resultMaterials.push(mat)
-            }
-        })
-        setFilterMaterials(resultMaterials)
-    }
-
     const renderCDMaterial = (): JSX.Element | null => {
         if (showCDModal) {
             let node: NodeAttr, _appID
@@ -1911,7 +1875,7 @@ export default function EnvTriggerView({ filteredAppIds, isVirtualEnv }: AppGrou
                     }
                 }
             }
-            const material = ( filterMaterials.length > 0 ? filterMaterials : node?.[materialType] ) || []
+            const material = node?.[materialType] || []
             return (
                 <VisibleModal className="" parentClassName="dc__overflow-hidden" close={closeCDModal}>
                     <div
@@ -1962,7 +1926,6 @@ export default function EnvTriggerView({ filteredAppIds, isVirtualEnv }: AppGrou
                                 history={history}
                                 location={location}
                                 match={match}
-                                getSearchedItem={getSearchedItem}
                                 isApplicationGroupTrigger={true}
                             />
                         )}

--- a/src/components/app/details/triggerView/TriggerView.tsx
+++ b/src/components/app/details/triggerView/TriggerView.tsx
@@ -102,7 +102,6 @@ class TriggerView extends Component<TriggerViewProps, TriggerViewState> {
             tagsEditable:false,
             configs: false,
             isDefaultConfigPresent: false,
-            filterMaterials: []
         }
         this.refreshMaterial = this.refreshMaterial.bind(this)
         this.onClickCIMaterial = this.onClickCIMaterial.bind(this)
@@ -638,7 +637,6 @@ class TriggerView extends Component<TriggerViewProps, TriggerViewState> {
             isApprovalNode ? DeploymentNodeType.APPROVAL : nodeType,
             this.abortController.signal,
             isApprovalNode,
-            imageTag
         )
             .then((data) => {
                 const workflows = [...this.state.workflows].map((workflow) => {
@@ -1040,14 +1038,12 @@ class TriggerView extends Component<TriggerViewProps, TriggerViewState> {
         const workflows = [...this.state.workflows].map((workflow) => {
             const nodes = workflow.nodes.map((node) => {
                 if (this.state.cdNodeId == +node.id && node.type === this.state.nodeType) {
-                    let materials = this.state.filterMaterials.length > 0 ? this.state.filterMaterials : node[materialType]
-                    const artifacts = materials.map((artifact, i) => {
+                    const artifacts = node[materialType].map((artifact, i) => {
                         return {
                             ...artifact,
                             isSelected: i === index,
                         }
                     })
-                    this.setState({filterMaterials: artifacts})
                     node[materialType] = artifacts
                 }
                 return node
@@ -1341,30 +1337,11 @@ class TriggerView extends Component<TriggerViewProps, TriggerViewState> {
         return node ?? ({} as NodeAttr)
     }
 
-    getSearchedItem = (searchedItems?: any[])  => {
-        const node: NodeAttr = this.getCDNode()
-        const material = node[this.state.materialType] || []
-        let resultMaterials = []
-        material.forEach((mat) => {
-            if (((!mat.userApprovalMetadata || mat.userApprovalMetadata.approvalRuntimeState !== 2)) || !(searchedItems)) {
-                mat.isSelected = false
-                resultMaterials.push(mat)
-            }
-        })
-        searchedItems.forEach((mat) => {
-            if (!((!mat.userApprovalMetadata || mat.userApprovalMetadata.approvalRuntimeState !== 2)) || !(searchedItems)) {
-                resultMaterials.push(mat)
-            }
-        })
-        this.setState({
-            filterMaterials: resultMaterials
-        })
-    }
-
     renderCDMaterial() {
         if (this.state.showCDModal) {
             const node: NodeAttr = this.getCDNode()
-            const material = ( this.state.filterMaterials.length > 0 ? this.state.filterMaterials : node[this.state.materialType] ) || [] 
+            const material = node[this.state.materialType] || []
+
             return (
                 <VisibleModal className="" parentClassName="dc__overflow-hidden" close={this.closeCDModal}>
                     <div
@@ -1416,7 +1393,6 @@ class TriggerView extends Component<TriggerViewProps, TriggerViewState> {
                                 history={this.props.history}
                                 location={this.props.location}
                                 match={this.props.match}
-                                getSearchedItem={this.getSearchedItem}
                                 isApplicationGroupTrigger={false}
                             />
                         )}

--- a/src/components/app/details/triggerView/cdMaterial.tsx
+++ b/src/components/app/details/triggerView/cdMaterial.tsx
@@ -42,7 +42,6 @@ import {
     ImageTagButton,
     ImageTagsContainer,
     GenericEmptyState,
-    getCDMaterials,
 } from '@devtron-labs/devtron-fe-common-lib'
 import { CDButtonLabelMap, getCommonConfigSelectStyles, TriggerViewContext } from './config'
 import { getLatestDeploymentConfig, getRecentDeploymentConfig, getSpecificDeploymentConfig } from '../../service'
@@ -78,7 +77,6 @@ export class CDMaterial extends Component<CDMaterialProps, CDMaterialState> {
     constructor(props: CDMaterialProps) {
         super(props)
         this.state = {
-            loadingSearchedImage: false,
             isSecurityModuleInstalled: false,
             checkingDiff: false,
             diffFound: false,
@@ -97,10 +95,7 @@ export class CDMaterial extends Component<CDMaterialProps, CDMaterialState> {
             latestDeploymentConfig: null,
             specificDeploymentConfig: null,
             isSelectImageTrigger: props.materialType === MATERIAL_TYPE.inputMaterialList,
-            materialInEditModeMap: new Map<number,boolean>(),
-            searchString: '',
-            searchApplied: false,
-            searchExpanded: false,
+            materialInEditModeMap: new Map<number, boolean>(),
         }
         this.handleConfigSelection = this.handleConfigSelection.bind(this)
         this.deployTrigger = this.deployTrigger.bind(this)
@@ -111,7 +106,7 @@ export class CDMaterial extends Component<CDMaterialProps, CDMaterialState> {
     }
 
     static getDerivedStateFromProps(props, state) {
-        return { ...state, selectedMaterial: props.material.find((_mat) => _mat.isSelected)}
+        return { ...state, selectedMaterial: props.material.find((_mat) => _mat.isSelected) }
     }
 
     componentDidMount() {
@@ -797,11 +792,11 @@ export class CDMaterial extends Component<CDMaterialProps, CDMaterialState> {
 
     viewAllImages = (e) => {
         e.stopPropagation()
-        if(!this.props.isApplicationGroupTrigger) {
+        if (!this.props.isApplicationGroupTrigger) {
             this.context.onClickCDMaterial(this.props.pipelineId, DeploymentNodeType.CD, true)
         }
         this.props.history.push({
-            search: `approval-node=${this.props.pipelineId}`
+            search: `approval-node=${this.props.pipelineId}`,
         })
     }
 
@@ -850,109 +845,24 @@ export class CDMaterial extends Component<CDMaterialProps, CDMaterialState> {
         }
     }
 
-    onChangeSearchString = (event) => {
-        let str = event.target.value || ''
-        str = str.toLowerCase()
-        this.setState({searchString: str})
-        if(str === ''){
-            this.clearSearch()
-        }
-    }
-
-    searchImageTag = (event) => {
-        const theKeyCode = event.key
-        if (theKeyCode === 'Enter' && event.target.value !== "") {
-            this.setState({ searchApplied: true })
-            let abortController = new AbortController()
-            this.setState({loadingSearchedImage: true})
-            getCDMaterials(this.props.pipelineId, DeploymentNodeType.CD, abortController.signal,  true, event.target.value)
-                .then((res) => {
-                    this.setState({loadingSearchedImage: false})
-                    this.props.getSearchedItem(res.materials)
-                })
-        }
-    }
-
-    clearSearch = () => {
-        this.setState({ searchApplied: false })
-        this.setState({ searchString: '' })
-        let abortController = new AbortController()
-        this.setState({loadingSearchedImage: true})
-        getCDMaterials(this.props.pipelineId, DeploymentNodeType.CD, abortController.signal, true, '')
-            .then((res) => {
-                this.setState({ loadingSearchedImage: false })
-                this.props.getSearchedItem(res.materials)
-            })
-    }
-
-    refreshData = () => {
-        if(this.state.searchApplied){
-            this.clearSearch()
-        }
-        let abortController = new AbortController()
-        this.setState({loadingSearchedImage: true})
-        getCDMaterials(this.props.pipelineId, DeploymentNodeType.CD, abortController.signal, true, '')
-            .then((res) => {
-                this.setState({loadingSearchedImage: false})
-                this.props.getSearchedItem(res.materials)
-            })
-    }
-
-    expandSearch = () => {
-        this.setState({searchExpanded : true})
-    }
-
     renderMaterialList = (isApprovalConfigured: boolean) => {
         const { consumedImage, materialList } = this.getConsumedAndAvailableMaterialList(isApprovalConfigured)
         const selectImageTitle = this.state.isRollbackTrigger
             ? 'Select from previously deployed images'
             : 'Select Image'
         const titleText = isApprovalConfigured ? 'Approved images' : selectImageTitle
-        console.log(this.state.searchExpanded)
 
         return (
             <>
                 {isApprovalConfigured && this.renderMaterial(consumedImage, true, isApprovalConfigured)}
-                {(!this.props.isFromBulkCD ) && (
+                {!this.props.isFromBulkCD && (
                     <div className="material-list__title pb-16 flex dc__align-center dc__content-space">
-                        <span className="flex dc__align-start">
-                            {titleText}
-                        </span>
-                        {isApprovalConfigured && <div className="h-32 flex dc__content-end dc__align-center dc__column-gap-8">
-                            <div className={`flex dc__align-center dc__position-rel margin-right-0 ${this.state.searchExpanded ? "w-250 bw-1 br-4 en-2" : "w-28 mt-4"} h-32 cursor-text mr-8`}>
-                                <span className="cursor" onClick={this.expandSearch}><Search className={`search__icon icon-dim-18 ${!this.state.searchExpanded ? "icon-color-n6" : ""}`} /></span>
-                                {this.state.searchExpanded && (<input
-                                    autoFocus
-                                    data-testid="Search-by-approver-name"
-                                    type="text"
-                                    name="app_search_input"
-                                    autoComplete="off"
-                                    value={this.state.searchString}
-                                    placeholder="Search image tag"
-                                    className="search__input bcn-1 fw-4"
-                                    onChange={this.onChangeSearchString}
-                                    onKeyDown={this.searchImageTag}
-                                />)}
-                                {this.state.searchApplied && (
-                                    <button className="search__clear-button flex" type="button" onClick={this.clearSearch}>
-                                        <Clear className="icon-dim-18 icon-n4 vertical-align-middle" />
-                                    </button>)}
-                            </div>
-                            <div className="pt-8 dc__content-end dc__align-center">
-                                <RefreshIcon
-                                    className="icon-dim-16 scn-6 cursor"
-                                    onClick={this.refreshData}
-                                />
-                            </div>
-                        </div>}
+                        <span className="flex dc__align-start">{titleText}</span>
                     </div>
                 )}
-                {this.state.loadingSearchedImage ? (
-                    <Progressing />
-                ) :
-                    isApprovalConfigured && materialList.length <= 0
-                        ? this.renderEmptyState(isApprovalConfigured, consumedImage.length > 0)
-                        : this.renderMaterial(materialList, false, isApprovalConfigured)}
+                {isApprovalConfigured && materialList.length <= 0
+                    ? this.renderEmptyState(isApprovalConfigured, consumedImage.length > 0)
+                    : this.renderMaterial(materialList, false, isApprovalConfigured)}
             </>
         )
     }
@@ -1371,20 +1281,18 @@ export class CDMaterial extends Component<CDMaterialProps, CDMaterialState> {
                 ) : (
                     <>
                         {this.renderMaterialList(isApprovalConfigured)}
-                        {this.state.isRollbackTrigger &&
-                            !this.state.noMoreImages &&
-                            this.props.material.length !== 1 && (
-                                <button
-                                    className="show-older-images-cta cta ghosted flex h-32"
-                                    onClick={this.loadOlderImages}
-                                >
-                                    {this.state.loadingMore ? (
-                                        <Progressing styles={{ height: '32px' }} />
-                                    ) : (
-                                        'Show older images'
-                                    )}
-                                </button>
-                            )}
+                        {this.state.isRollbackTrigger && !this.state.noMoreImages && this.props.material.length !== 1 && (
+                            <button
+                                className="show-older-images-cta cta ghosted flex h-32"
+                                onClick={this.loadOlderImages}
+                            >
+                                {this.state.loadingMore ? (
+                                    <Progressing styles={{ height: '32px' }} />
+                                ) : (
+                                    'Show older images'
+                                )}
+                            </button>
+                        )}
                     </>
                 )}
             </div>
@@ -1436,28 +1344,7 @@ export class CDMaterial extends Component<CDMaterialProps, CDMaterialState> {
         )
     }
 
-    renderClearSearchButton = () => {
-        return (
-            <button onClick={this.clearSearch} className="add-link cta flex">
-                Clear search
-            </button>
-        )
-    }
-
     renderEmptyState = (isApprovalConfigured: boolean, consumedImagePresent?: boolean) => {
-        if (this.state.searchApplied) {
-            return (
-                <GenericEmptyState
-                    image={noapprovedimages}
-                    title={EMPTY_STATE.title}
-                    subTitle={EMPTY_STATE.subtitle}
-                    isButtonAvailable={true}
-                    renderButton={this.renderClearSearchButton}
-                    classname='dc__position-rel-imp'
-                />
-            )
-        }
-
         if (isApprovalConfigured && ApprovalEmptyState) {
             return (
                 <ApprovalEmptyState
@@ -1478,7 +1365,8 @@ export class CDMaterial extends Component<CDMaterialProps, CDMaterialState> {
                 subTitle={
                     this.props.materialType == MATERIAL_TYPE.rollbackMaterialList
                         ? 'Previously deployed images will be available here for rollback.'
-                        : 'Please Trigger CI Pipeline and find the image here for deployment.'}
+                        : 'Please Trigger CI Pipeline and find the image here for deployment.'
+                }
             />
         )
     }

--- a/src/components/app/details/triggerView/types.ts
+++ b/src/components/app/details/triggerView/types.ts
@@ -70,7 +70,6 @@ export interface CDMaterialProps extends RouteComponentProps<{}> {
     hideImageTaggingHardDelete?: boolean
     setTagsEditable?: (tagsEditable: boolean) => void
     updateCurrentAppMaterial? : (matId:number, releaseTags?:ReleaseTag[], imageComment?:ImageComment) => void
-    getSearchedItem?: (searchedItems?: any[]) => void
     isApplicationGroupTrigger?: boolean
 }
 
@@ -103,10 +102,6 @@ export interface CDMaterialState {
     selectedMaterial: CDMaterialType
     isSelectImageTrigger: boolean
     materialInEditModeMap: Map<number,boolean>
-    searchString?: string
-    searchApplied?: boolean
-    loadingSearchedImage?: boolean
-    searchExpanded?: boolean
 }
 
 export interface MaterialInfo {
@@ -361,7 +356,6 @@ export interface TriggerViewState {
     hideImageTaggingHardDelete?: boolean
     configs?: boolean
     isDefaultConfigPresent?: boolean
-    filterMaterials?: any[]
 }
 
 //-- begining of response type objects for trigger view

--- a/src/components/app/service.ts
+++ b/src/components/app/service.ts
@@ -273,13 +273,10 @@ export function getCDMaterialList(
     stageType: DeploymentNodeType,
     abortSignal: AbortSignal,
     isApprovalNode?: boolean,
-    imageTag?: string
 ): Promise<CDMaterialResponseType> {
-    const URL = (!imageTag) ? `${Routes.CD_MATERIAL_GET}/${cdMaterialId}/material?stage=${
+    const URL = `${Routes.CD_MATERIAL_GET}/${cdMaterialId}/material?stage=${
         isApprovalNode ? stageMap.APPROVAL : stageMap[stageType]
-    }` : `${Routes.CD_MATERIAL_GET}/${cdMaterialId}/material?stage=${
-        isApprovalNode ? stageMap.APPROVAL : stageMap[stageType]
-    }&search=${imageTag}`
+    }`
     return get(URL, {
         signal: abortSignal,
     }).then((response) => {


### PR DESCRIPTION
# Description

It bugs out when you go to application groups to deploy multiple applications.
It happens in a certain scenario when your active image is older than latest image. When you select the active image the topmost application from app group's image list gets populated.

👟 Reproduction steps
create 2 applications in same env.
make sure the 2nd application that appears in application groups is having active image older than latest image.
Select active image while trying to deploy both applications via application groups and deploy.
The 2nd application will pick a wrong image in this scenario.
👍 Expected behavior
It should have picked the correct image.

Fixes # [3718](https://github.com/devtron-labs/devtron/issues/3781#)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test Locally
- [x] Test By deploying it to VM


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


