### PR TITLE
fix: Unable to edit description in chart group [prod*]

### DIFF
--- a/src/components/app/details/appDetails/AppDetails.tsx
+++ b/src/components/app/details/appDetails/AppDetails.tsx
@@ -215,6 +215,8 @@ export const Details: React.FC<DetailsType> = ({
     const [rotateModal, setRotateModal] = useState<boolean>(false)
     const [hibernating, setHibernating] = useState<boolean>(false)
     const [showScanDetailsModal, toggleScanDetailsModal] = useState(false)
+    const [isAppDeployed, setIsAppDeployed] = useState<boolean>(false)
+    const [resourcePollingStarted, setResourcePollingStarted] = useState<boolean>(false)
     const [lastExecutionDetail, setLastExecutionDetail] = useState({
         imageScanDeployInfoId: 0,
         severityCount: { critical: 0, moderate: 0, low: 0 },
@@ -332,6 +334,12 @@ export const Details: React.FC<DetailsType> = ({
     async function callAppDetailsAPI(fetchExternalLinks?: boolean) {
         appDetailsAPI(params.appId, params.envId, 25000)
             .then((response) => {
+                if (!response.result.appName && !response.result.environmentName) {
+                    setResourceTreeFetchTimeOut(false)
+                    setLoadingResourceTree(false)
+                    setAppDetails(null)
+                    return
+                }
                 appDetailsRef.current = {
                     ...appDetailsRef.current,
                     ...response.result,
@@ -344,11 +352,15 @@ export const Details: React.FC<DetailsType> = ({
                 if (fetchExternalLinks && response.result?.clusterId) {
                     getExternalLinksAndTools(response.result.clusterId)
                 }
+                setIsAppDeployed(true)
             })
             .catch(handleAppDetailsCallError)
             .finally(() => {
                 setLoadingDetails(false)
             })
+    }
+
+    async function callResourceTreeAPI() {
         fetchResourceTreeInTime(params.appId, params.envId, 25000)
             .then((response) => {
                 if (
@@ -478,6 +490,14 @@ export const Details: React.FC<DetailsType> = ({
         }
     }, [pollingIntervalID])
 
+    useEffect(() => {
+        if (isAppDeployed && !resourcePollingStarted) {
+            callResourceTreeAPI()
+            setInterval(callResourceTreeAPI, interval)
+            setResourcePollingStarted(true)
+        }
+    }, [isAppDeployed, resourcePollingStarted])
+
     async function handleHibernate(e) {
         try {
             setHibernating(true)
@@ -486,6 +506,7 @@ export const Details: React.FC<DetailsType> = ({
             )
             await stopStartApp(Number(params.appId), Number(params.envId), isUnHibernateReq ? 'START' : 'STOP')
             await callAppDetailsAPI()
+            await callResourceTreeAPI()
             toast.success(isUnHibernateReq ? 'Pods restore initiated' : 'Pods scale down initiated')
             setHibernateConfirmationModal('')
         } catch (err) {
@@ -712,7 +733,7 @@ export const Details: React.FC<DetailsType> = ({
                 </ConfirmationDialog>
             )}
             {rotateModal && (
-                <RotatePodsModal onClose={() => setRotateModal(false)} callAppDetailsAPI={callAppDetailsAPI} />
+                <RotatePodsModal onClose={() => setRotateModal(false)} callAppDetailsAPI={callAppDetailsAPI} callResourceTreeAPI={callAppDetailsAPI} />
             )}
         </React.Fragment>
     )

--- a/src/components/charts/modal/CreateChartGroup.tsx
+++ b/src/components/charts/modal/CreateChartGroup.tsx
@@ -74,7 +74,7 @@ export default class CreateChartGroup extends Component<CreateChartGroupProps, C
             return false
         }
 
-        const isNameUsed = this.state.charts.some((chart) => chart.name === this.state.name.value)
+        const isNameUsed = this.state.charts.some((chart) => chart.name === this.state.name.value && chart.id !== this.props.chartGroupId)
         if (isNameUsed) {
             toast.error(`A chart group with name ${this.state.name.value} already exists!`)
             return false

--- a/src/components/v2/appDetails/sourceInfo/rotatePods/RotatePodsModal.component.tsx
+++ b/src/components/v2/appDetails/sourceInfo/rotatePods/RotatePodsModal.component.tsx
@@ -19,7 +19,7 @@ import { toast } from 'react-toastify'
 import RotateResponseModal from './RotateResponseModal'
 import { POD_ROTATION_INITIATED, RequiredKinds } from '../../../../../config'
 
-export default function RotatePodsModal({ onClose, callAppDetailsAPI }: RotatePodsModalProps) {
+export default function RotatePodsModal({ onClose, callAppDetailsAPI, callResourceTreeAPI }: RotatePodsModalProps) {
     const [nameSelection, setNameSelection] = useState<Record<string, WorkloadCheckType>>({
         rotate: {
             isChecked: false,
@@ -177,6 +177,7 @@ export default function RotatePodsModal({ onClose, callAppDetailsAPI }: RotatePo
 
             const { result } = await RotatePods(requestPayload)
             callAppDetailsAPI()
+            callResourceTreeAPI()
             if (!result.containsError) {
                 toast.success(POD_ROTATION_INITIATED)
                 onClose()
@@ -283,7 +284,7 @@ export default function RotatePodsModal({ onClose, callAppDetailsAPI }: RotatePo
 
     const renderRotateModal = (): JSX.Element => {
         if (result) {
-            return <RotateResponseModal onClose={onClose} response={result.responses} setResult={setResult} callAppDetailsAPI={callAppDetailsAPI} />
+            return <RotateResponseModal onClose={onClose} response={result.responses} setResult={setResult} callAppDetailsAPI={callAppDetailsAPI} callResourceTreeAPI={callResourceTreeAPI} />
         } else {
             return (
                 <>

--- a/src/components/v2/appDetails/sourceInfo/rotatePods/RotateResponseModal.tsx
+++ b/src/components/v2/appDetails/sourceInfo/rotatePods/RotateResponseModal.tsx
@@ -19,7 +19,7 @@ import { RotatePods } from './rotatePodsModal.service'
 import { toast } from 'react-toastify'
 import { POD_ROTATION_INITIATED } from '../../../../../config'
 import { ReactComponent as BackIcon } from '../../../../../assets/icons/ic-arrow-backward.svg'
-export default function RotateResponseModal({ onClose, response, setResult, callAppDetailsAPI}: RotateResponseModalProps) {
+export default function RotateResponseModal({ onClose, response, setResult, callAppDetailsAPI, callResourceTreeAPI}: RotateResponseModalProps) {
     const [isLoading, setIsLoading] = useState(false)
     const [appDetails] = useSharedState(IndexStore.getAppDetails(), IndexStore.getAppDetailsObservable())
 
@@ -116,6 +116,7 @@ export default function RotateResponseModal({ onClose, response, setResult, call
 
             const { result } = await RotatePods(requestPayload)
             callAppDetailsAPI()
+            callResourceTreeAPI()
             if (!result.containsError) {
                 onClose()
                 toast.success(POD_ROTATION_INITIATED)

--- a/src/components/v2/appDetails/sourceInfo/rotatePods/rotatePodsModal.type.ts
+++ b/src/components/v2/appDetails/sourceInfo/rotatePods/rotatePodsModal.type.ts
@@ -24,6 +24,7 @@ export interface HibernateTargetObject {
 export interface RotatePodsModalProps {
     onClose: () => void
     callAppDetailsAPI: () => void
+    callResourceTreeAPI: () => void
 }
 
 export interface RotateResponseModalProps {
@@ -31,6 +32,7 @@ export interface RotateResponseModalProps {
     response: RotatePodsResponseTargetObject[]
     setResult: Dispatch<SetStateAction<RotatePodsStatus>>
     callAppDetailsAPI: () => void
+    callResourceTreeAPI: () => void
 }
 
 export interface RotatePodsTargetObject {


### PR DESCRIPTION
# Description

These changes fix the issue where, once the user creates a new chart group, he/she can't edit the chart description.

Fixes #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
All tests have been performed manually by visiting Chart Store page and performing different actions.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


