### PR TITLE
fix: Unable to edit description in chart group [prod*]

### DIFF
--- a/src/components/charts/modal/CreateChartGroup.tsx
+++ b/src/components/charts/modal/CreateChartGroup.tsx
@@ -74,7 +74,7 @@ export default class CreateChartGroup extends Component<CreateChartGroupProps, C
             return false
         }
 
-        const isNameUsed = this.state.charts.some((chart) => chart.name === this.state.name.value)
+        const isNameUsed = this.state.charts.some((chart) => chart.name === this.state.name.value && chart.id !== this.props.chartGroupId)
         if (isNameUsed) {
             toast.error(`A chart group with name ${this.state.name.value} already exists!`)
             return false


### PR DESCRIPTION
# Description

These changes fix the issue where, once the user creates a new chart group, he/she can't edit the chart description.

Fixes #
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
All tests have been performed manually by visiting Chart Store page and performing different actions.

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


