### PR TITLE
fix: aws cred and docker password space trim

### DIFF
--- a/src/components/dockerRegistry/Docker.tsx
+++ b/src/components/dockerRegistry/Docker.tsx
@@ -463,8 +463,8 @@ function DockerForm({
             registryUrl: customState.registryUrl.value,
             ...(selectedDockerRegistryType.value === 'ecr'
                 ? {
-                      awsAccessKeyId: customState.awsAccessKeyId.value,
-                      awsSecretAccessKey: parsePassword(customState.awsSecretAccessKey.value),
+                      awsAccessKeyId: customState.awsAccessKeyId.value.trim(),
+                      awsSecretAccessKey: parsePassword(customState.awsSecretAccessKey.value).trim(),
                       awsRegion: awsRegion,
                   }
                 : {}),
@@ -473,8 +473,8 @@ function DockerForm({
                       username: trimmedUsername,
                       password:
                           customState.password.value === DEFAULT_SECRET_PLACEHOLDER
-                              ? parsePassword(customState.password.value)
-                              : `'${parsePassword(customState.password.value)}'`,
+                              ? parsePassword(customState.password.value).trim()
+                              : `'${parsePassword(customState.password.value).trim()}'`,
                   }
                 : {}),
             ...(selectedDockerRegistryType.value === 'docker-hub' ||
@@ -482,13 +482,13 @@ function DockerForm({
             selectedDockerRegistryType.value === 'quay'
                 ? {
                       username: trimmedUsername,
-                      password: parsePassword(customState.password.value),
+                      password: parsePassword(customState.password.value).trim(),
                   }
                 : {}),
             ...(selectedDockerRegistryType.value === 'other'
                 ? {
                       username: trimmedUsername,
-                      password: parsePassword(customState.password.value),
+                      password: parsePassword(customState.password.value).trim(),
                       connection: state.advanceSelect.value,
                       cert: state.advanceSelect.value !== CERTTYPE.SECURE_WITH_CERT ? '' : state.certInput.value,
                   }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
When saving or updating a OCI registery when the password, or aws access keys are provided with leading or trailing spaces, it persists and is treated as wrong password, so this pr aims to trim those leading or trailing spaces.
Fixes # (https://github.com/devtron-labs/devtron/issues/3846#)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] on localhost while trying to save a new registory and also while updating the pre-saved oci registory  
- [ ] Test B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


