### PR TITLE
fix: security scan page break fix

### DIFF
--- a/src/components/security/SecurityPolicyEdit.tsx
+++ b/src/components/security/SecurityPolicyEdit.tsx
@@ -124,7 +124,6 @@ export class SecurityPolicyEdit extends Component<FetchPolicyQueryParams, GetVul
             }
         }).catch(error => {
             showError(error);
-            // this.setState({ view: ViewType.ERROR });
         })
     }
 

--- a/src/components/security/SecurityPolicyEdit.tsx
+++ b/src/components/security/SecurityPolicyEdit.tsx
@@ -124,7 +124,7 @@ export class SecurityPolicyEdit extends Component<FetchPolicyQueryParams, GetVul
             }
         }).catch(error => {
             showError(error);
-            this.setState({ view: ViewType.ERROR });
+            // this.setState({ view: ViewType.ERROR });
         })
     }
 


### PR DESCRIPTION
# Description

Page breaks while changing cve policy if user does not have permissions
repo steps -
1) Give user view only permission 
2) Go to security scan tab
3) Change CVE policy

- Page breaks

Fixes [#511](https://github.com/devtron-labs/devtron/issues/511)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test Locally
- [x] Test By deploying in VM


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


