### PR TITLE
fix: Host URL and and SSO URL column should be autofill

### DIFF
--- a/src/components/hostURL/HostURL.tsx
+++ b/src/components/hostURL/HostURL.tsx
@@ -195,7 +195,7 @@ export default class HostURLConfiguration extends Component<HostURLConfigProps, 
                                 <div className="gitops__id fw-5 fs-13 mb-8 dc__required-field">Host URL</div>
                                 <input
                                     id="host"
-                                    value={this.state.form.value.length === 0 ? window.location.origin : this.state.form.value}
+                                    value={this.state.form.value || window.location.origin}
                                     autoFocus
                                     tabIndex={1}
                                     type="text"

--- a/src/components/hostURL/HostURL.tsx
+++ b/src/components/hostURL/HostURL.tsx
@@ -195,7 +195,7 @@ export default class HostURLConfiguration extends Component<HostURLConfigProps, 
                                 <div className="gitops__id fw-5 fs-13 mb-8 dc__required-field">Host URL</div>
                                 <input
                                     id="host"
-                                    value={this.state.form.value}
+                                    value={this.state.form.value.length === 0 ? window.location.origin : this.state.form.value}
                                     autoFocus
                                     tabIndex={1}
                                     type="text"

--- a/src/components/login/SSOLogin.tsx
+++ b/src/components/login/SSOLogin.tsx
@@ -538,7 +538,7 @@ export default class SSOLogin extends Component<SSOLoginProps, SSOLoginState> {
                         <input
                             type="text"
                             className="form__input"
-                            value={this.state.ssoConfig.url}
+                            value={this.state.ssoConfig.url.length === 0 ? `${window.location.origin}/orchestrator` : this.state.ssoConfig.url}
                             onChange={this.handleURLChange}
                             data-testid="sso-url-input"
                         />

--- a/src/components/login/SSOLogin.tsx
+++ b/src/components/login/SSOLogin.tsx
@@ -538,7 +538,7 @@ export default class SSOLogin extends Component<SSOLoginProps, SSOLoginState> {
                         <input
                             type="text"
                             className="form__input"
-                            value={this.state.ssoConfig.url.length === 0 ? `${window.location.origin}/orchestrator` : this.state.ssoConfig.url}
+                            value={this.state.ssoConfig.url || `${window.location.origin}/${process.env.REACT_APP_ORCHESTRATOR_ROOT}`}
                             onChange={this.handleURLChange}
                             data-testid="sso-url-input"
                         />

--- a/src/components/login/SSOLogin.tsx
+++ b/src/components/login/SSOLogin.tsx
@@ -538,7 +538,7 @@ export default class SSOLogin extends Component<SSOLoginProps, SSOLoginState> {
                         <input
                             type="text"
                             className="form__input"
-                            value={this.state.ssoConfig.url || `${window.location.origin}/${process.env.REACT_APP_ORCHESTRATOR_ROOT}`}
+                            value={this.state.ssoConfig.url || `${process.env.REACT_APP_ORCHESTRATOR_ROOT}`}
                             onChange={this.handleURLChange}
                             data-testid="sso-url-input"
                         />

--- a/src/components/login/SSOLogin.tsx
+++ b/src/components/login/SSOLogin.tsx
@@ -538,7 +538,7 @@ export default class SSOLogin extends Component<SSOLoginProps, SSOLoginState> {
                         <input
                             type="text"
                             className="form__input"
-                            value={this.state.ssoConfig.url || `${process.env.REACT_APP_ORCHESTRATOR_ROOT}`}
+                            value={this.state.ssoConfig.url || process.env.REACT_APP_ORCHESTRATOR_ROOT}
                             onChange={this.handleURLChange}
                             data-testid="sso-url-input"
                         />


### PR DESCRIPTION
# Description

1- Create a new cluster
1.1- open SSO login page
1.2- Verify SSO url login column
2- Open cluster with New host domain
2.1- then verify the Host YRL column 
Aspected
-Host URL and and SSO URL column should be autofill

Fixes (https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/5407

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] By creating a new cluster and visiting the Host URL and SSO Config page.


# Checklist:

* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have performed a self-review of my own code
* [X] I have commented my code, particularly in hard-to-understand areas


