### PR TITLE
fix: Schema.json redirect wrong path in deployment template

### DIFF
--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -221,14 +221,13 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
                 format: true,
                 schemas:[
                     {
-                        uri: `https://github.com/devtron-labs/devtron/tree/main/scripts/devtron-reference-helm-charts/reference-chart_${chartVersion}`, // id of the first schema
+                        uri: `https://github.com/devtron-labs/devtron/tree/main/scripts/devtron-reference-helm-charts/reference-chart_${chartVersion}/schema.json`, // id of the first schema
                         fileMatch: ['*'], // associate with our model
                         schema: validatorSchema,
                     }]
             });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [validatorSchema, chartVersion]);
-
     useEffect(() => {
         if (!editorRef.current) return
         editorRef.current.updateOptions({ readOnly })

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -66,6 +66,7 @@ interface CodeEditorInterface {
     validatorSchema?: any;
     isKubernetes?: boolean;
     cleanData?: boolean;
+    chartVersion?: any; 
 }
 
 interface CodeEditorHeaderInterface {
@@ -115,7 +116,7 @@ interface CodeEditorState {
     code: string;
     noParsing: boolean;
 }
-const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.memo(function Editor({ value, mode = "json", noParsing = false, defaultValue = "", children, tabSize = 2, lineDecorationsWidth = 0, height = 450, inline = false, shebang = "", minHeight, maxHeight, onChange, readOnly, diffView, theme="", loading, customLoader, focus, validatorSchema ,isKubernetes = true, cleanData = false, onBlur, onFocus}) {
+const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.memo(function Editor({ value, mode = "json", noParsing = false, defaultValue = "", children, tabSize = 2, lineDecorationsWidth = 0, height = 450, inline = false, shebang = "", minHeight, maxHeight, onChange, readOnly, diffView, theme="", loading, customLoader, focus, validatorSchema, chartVersion ,isKubernetes = true, cleanData = false, onBlur, onFocus}) {
     if (cleanData) {
         value = cleanKubeManifest(value);
         defaultValue = cleanKubeManifest(defaultValue);
@@ -220,13 +221,13 @@ const CodeEditor: React.FC<CodeEditorInterface> & CodeEditorComposition = React.
                 format: true,
                 schemas:[
                     {
-                        uri: 'https://devtron.ai/schema.json', // id of the first schema
+                        uri: `https://github.com/devtron-labs/devtron/tree/main/scripts/devtron-reference-helm-charts/reference-chart_${chartVersion}`, // id of the first schema
                         fileMatch: ['*'], // associate with our model
                         schema: validatorSchema,
                     }]
             });
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [validatorSchema]);
+    }, [validatorSchema, chartVersion]);
 
     useEffect(() => {
         if (!editorRef.current) return

--- a/src/components/deploymentConfig/DeploymentTemplateView/DeploymentTemplateEditorView.tsx
+++ b/src/components/deploymentConfig/DeploymentTemplateView/DeploymentTemplateEditorView.tsx
@@ -184,7 +184,7 @@ export default function DeploymentTemplateEditorView({
                             : state.fetchedValues[state.selectedCompareOption?.id]) || ''
                     }
                     value={value}
-                    chartVersion={state.selectedChart?.version.split('.').join('-')}
+                    chartVersion={state.selectedChart?.version.replace(',', '-')}
                     onChange={editorOnChange}
                     mode={MODES.YAML}
                     validatorSchema={state.schema}

--- a/src/components/deploymentConfig/DeploymentTemplateView/DeploymentTemplateEditorView.tsx
+++ b/src/components/deploymentConfig/DeploymentTemplateView/DeploymentTemplateEditorView.tsx
@@ -184,6 +184,7 @@ export default function DeploymentTemplateEditorView({
                             : state.fetchedValues[state.selectedCompareOption?.id]) || ''
                     }
                     value={value}
+                    chartVersion={state.selectedChart?.version.split('.').join('-')}
                     onChange={editorOnChange}
                     mode={MODES.YAML}
                     validatorSchema={state.schema}
@@ -217,6 +218,7 @@ export default function DeploymentTemplateEditorView({
                     )}
                     {state.openComparison && (
                         <CodeEditor.Header className="w-100 p-0-imp" hideDefaultSplitHeader={true}>
+
                             <div className="flex column">
                                 <div className="code-editor__header flex left w-100 p-0-imp">
                                     <div className="flex left fs-12 fw-6 cn-9 dc__border-right h-32 pl-12 pr-12">

--- a/src/components/deploymentConfig/DeploymentTemplateView/DeploymentTemplateEditorView.tsx
+++ b/src/components/deploymentConfig/DeploymentTemplateView/DeploymentTemplateEditorView.tsx
@@ -184,7 +184,7 @@ export default function DeploymentTemplateEditorView({
                             : state.fetchedValues[state.selectedCompareOption?.id]) || ''
                     }
                     value={value}
-                    chartVersion={state.selectedChart?.version.replace(',', '-')}
+                    chartVersion={state.selectedChart?.version.replace(/\./g, '-')}
                     onChange={editorOnChange}
                     mode={MODES.YAML}
                     validatorSchema={state.schema}


### PR DESCRIPTION
# Description

Every reference chart have their own schema.json file . but here we are redirecting on wrong path.

Fixes https://github.com/devtron-labs/devtron/issues/3535

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] By visiting on the deployment chart page and clicking cmd+click to get the Schem.json uri path


# Checklist:

* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have performed a self-review of my own code
* [X] I have commented my code, particularly in hard-to-understand areas


