### PR TITLE
fix: Commit hash search box breaks on double enter or incorrect query 

### DIFF
--- a/src/components/app/details/triggerView/TriggerView.tsx
+++ b/src/components/app/details/triggerView/TriggerView.tsx
@@ -289,7 +289,7 @@ class TriggerView extends Component<TriggerViewProps, TriggerViewState> {
             workflow.nodes.map((node) => {
                 if (node.type === 'CI' && +node.id == this.state.ciNodeId) {
                     node.inputMaterialList = node.inputMaterialList.map((material) => {
-                        if (material.isSelected && material.searchText !== commitHash) {
+                        if (material.isSelected){
                             material.isMaterialLoading = true
                             material.searchText = commitHash
                             material.showAllCommits = false

--- a/src/components/common/GitInfoMaterial.tsx
+++ b/src/components/common/GitInfoMaterial.tsx
@@ -59,7 +59,8 @@ export default function GitInfoMaterial({
         if (!selectedMaterial || !selectedMaterial.searchText) {
             setSearchText('')
             setSearchApplied(false)
-        } else if (selectedMaterial.searchText !== searchText) {
+        } else if (selectedMaterial.searchText) {
+            setSearchText(selectedMaterial.searchText)
             setSearchApplied(true)
         }
         setShowAllCommits(selectedMaterial?.showAllCommits ?? false)
@@ -180,7 +181,7 @@ export default function GitInfoMaterial({
     const handleFilterKeyPress = (event): void => {
         const theKeyCode = event.key
         if (theKeyCode === 'Enter') {
-            if (event.target.value && !searchApplied) {
+            if (event.target.value) {
                 handleFilterChanges(event.target.value)
                 setSearchApplied(true)
             } else if (searchApplied) {


### PR DESCRIPTION
# Description

commit hash search box refresh its state on double enter

Fixes [#3499](https://github.com/devtron-labs/devtron/issues/3499)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
All tests are performed locally


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


