### PR TITLE
fix: config maps and secrets validation fix

### DIFF
--- a/src/components/ConfigMapSecret/ConfigMapSecret.reducer.ts
+++ b/src/components/ConfigMapSecret/ConfigMapSecret.reducer.ts
@@ -75,6 +75,7 @@ export const initState = (
         showProtectedDeleteOverrideModal: false,
         showDraftSaveModal: false,
         draftPayload: null,
+        isValidateFormError: false,
         ...secretInitState,
     }
     return initialState
@@ -142,6 +143,8 @@ export const ConfigMapReducer = (state: ConfigMapSecretState, action: ConfigMapA
 
         case ConfigMapActionTypes.toggleDraftSaveModal:
             return { ...state, showDraftSaveModal: !state.showDraftSaveModal }
+        case ConfigMapActionTypes.setValidateFormError:
+            return { ...state, isValidateFormError: action.payload }
 
         default:
             return state

--- a/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
@@ -56,32 +56,14 @@ export const ConfigMapSecretDataEditorContainer = React.memo(
             `Key must consist of alphanumeric characters, '.', '-' and '_'`,
         )
 
-        const randerValidationError = (error: string): JSX.Element => {
-            if (!error) {
-                if (state.isValidateFormError) {
-                    dispatch({
-                        type: ConfigMapActionTypes.setValidateFormError,
-                        payload: false,
-                    })
-                }
-                return null
-            }
-
-            // set validation error for blocking save operation
-            if (!state.isValidateFormError) {
-                dispatch({
-                    type: ConfigMapActionTypes.setValidateFormError,
-                    payload: true,
-                })
-            } 
-
-            return (
-                <div className="validation-error-block">
-                    <Info color="#f32e2e" style={{ height: '16px', width: '16px' }} />
-                    <div>{error}</div>
-                </div>
-            )
+        if (state.isValidateFormError !== !!error) {
+            console.log('error', error, state.isValidateFormError)
+            dispatch({
+                type: ConfigMapActionTypes.setValidateFormError,
+                payload: !!error,
+            })
         }
+
 
         const { yaml: lockedYaml } = useKeyValueYaml(
             state.currentData?.map(({ k, v }) => ({ k, v: Array(8).fill('*').join('') })),
@@ -311,7 +293,10 @@ export const ConfigMapSecretDataEditorContainer = React.memo(
 
                             <CodeEditor.Clipboard />
                         </CodeEditor.Header>
-                        {!state.external && randerValidationError(error)}
+                        {!state.external && error &&  <div className="validation-error-block">
+                    <Info color="#f32e2e" style={{ height: '16px', width: '16px' }} />
+                    <div>{error}</div>
+                </div>}
                     </CodeEditor>
                 </div>
             )

--- a/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Info, RadioGroup } from '../common'
 import { KeyValueInput, useKeyValueYaml } from './ConfigMapSecret.components'
 import CodeEditor from '../CodeEditor/CodeEditor'
@@ -29,7 +29,6 @@ export const ConfigMapSecretDataEditorContainer = React.memo(
         tempArr,
         readonlyView,
         draftMode,
-        setValidateFormError
     }: ConfigMapSecretDataEditorContainerProps): JSX.Element => {
         const memoisedHandleChange = (index, k, v) => {
             const _currentData = [...state.currentData]
@@ -56,7 +55,35 @@ export const ConfigMapSecretDataEditorContainer = React.memo(
             PATTERNS.CONFIG_MAP_AND_SECRET_KEY,
             `Key must consist of alphanumeric characters, '.', '-' and '_'`,
         )
-        setValidateFormError(error) 
+
+        const randerValidationError = (error: string): JSX.Element => {
+            console.log(error)
+            if (!error) {
+                if (state.isValidateFormError) {
+                    dispatch({
+                        type: ConfigMapActionTypes.setValidateFormError,
+                        payload: false,
+                    })
+                }
+                return null
+            }
+
+            // set validation error for blocking save operation
+            if (!state.isValidateFormError) {
+                dispatch({
+                    type: ConfigMapActionTypes.setValidateFormError,
+                    payload: true,
+                })
+            } 
+
+            return (
+                <div className="validation-error-block">
+                    <Info color="#f32e2e" style={{ height: '16px', width: '16px' }} />
+                    <div>{error}</div>
+                </div>
+            )
+        }
+
         const { yaml: lockedYaml } = useKeyValueYaml(
             state.currentData?.map(({ k, v }) => ({ k, v: Array(8).fill('*').join('') })),
             setKeyValueArray,
@@ -285,12 +312,7 @@ export const ConfigMapSecretDataEditorContainer = React.memo(
 
                             <CodeEditor.Clipboard />
                         </CodeEditor.Header>
-                        {!state.external && error && (
-                            <div className="validation-error-block">
-                                <Info color="#f32e2e" style={{ height: '16px', width: '16px' }} />
-                                <div>{error}</div>
-                            </div>
-                        )}
+                        {!state.external && randerValidationError(error)}
                     </CodeEditor>
                 </div>
             )

--- a/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Info, RadioGroup } from '../common'
 import { KeyValueInput, useKeyValueYaml } from './ConfigMapSecret.components'
 import CodeEditor from '../CodeEditor/CodeEditor'

--- a/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
@@ -57,7 +57,6 @@ export const ConfigMapSecretDataEditorContainer = React.memo(
         )
 
         if (state.isValidateFormError !== !!error) {
-            console.log('error', error, state.isValidateFormError)
             dispatch({
                 type: ConfigMapActionTypes.setValidateFormError,
                 payload: !!error,

--- a/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
@@ -57,7 +57,6 @@ export const ConfigMapSecretDataEditorContainer = React.memo(
         )
 
         const randerValidationError = (error: string): JSX.Element => {
-            console.log(error)
             if (!error) {
                 if (state.isValidateFormError) {
                     dispatch({

--- a/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
@@ -292,10 +292,12 @@ export const ConfigMapSecretDataEditorContainer = React.memo(
 
                             <CodeEditor.Clipboard />
                         </CodeEditor.Header>
-                        {!state.external && error &&  <div className="validation-error-block">
-                    <Info color="#f32e2e" style={{ height: '16px', width: '16px' }} />
-                    <div>{error}</div>
-                </div>}
+                        {!state.external && error && (
+                            <div className="validation-error-block">
+                                <Info color="#f32e2e" style={{ height: '16px', width: '16px' }} />
+                                <div>{error}</div>
+                            </div>
+                        )}
                     </CodeEditor>
                 </div>
             )

--- a/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
@@ -29,6 +29,7 @@ export const ConfigMapSecretDataEditorContainer = React.memo(
         tempArr,
         readonlyView,
         draftMode,
+        setValidateFormError
     }: ConfigMapSecretDataEditorContainerProps): JSX.Element => {
         const memoisedHandleChange = (index, k, v) => {
             const _currentData = [...state.currentData]
@@ -55,6 +56,7 @@ export const ConfigMapSecretDataEditorContainer = React.memo(
             PATTERNS.CONFIG_MAP_AND_SECRET_KEY,
             `Key must consist of alphanumeric characters, '.', '-' and '_'`,
         )
+        setValidateFormError(error) 
         const { yaml: lockedYaml } = useKeyValueYaml(
             state.currentData?.map(({ k, v }) => ({ k, v: Array(8).fill('*').join('') })),
             setKeyValueArray,

--- a/src/components/ConfigMapSecret/ConfigMapSecretForm.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecretForm.tsx
@@ -85,7 +85,6 @@ export const ConfigMapSecretForm = React.memo(
             memoizedReducer,
             initState(configMapSecretData, componentType, cmSecretStateLabel, draftMode || latestDraftData?.draftId),
         )
-        const [validateFormError, setValidateFormError] = React.useState<string>("")
         const { appId, envId } = useParams<{ appId; envId }>()
 
         const isChartVersion309OrBelow =
@@ -1019,7 +1018,6 @@ export const ConfigMapSecretForm = React.memo(
                                 tempArr={tempArr}
                                 readonlyView={readonlyView}
                                 draftMode={draftMode}
-                                setValidateFormError={setValidateFormError}
                             />
                         )}
                     </div>
@@ -1043,7 +1041,7 @@ export const ConfigMapSecretForm = React.memo(
                                 disabled={
                                     (!draftMode && state.cmSecretState === CM_SECRET_STATE.INHERITED) ||
                                     (draftMode && !isAppAdmin) || 
-                                    !!validateFormError
+                                    state.isValidateFormError
                                 }
                                 data-testid={`${componentType === 'secret' ? 'Secret' : 'ConfigMap'}-save-button`}
                                 type="button"

--- a/src/components/ConfigMapSecret/ConfigMapSecretForm.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecretForm.tsx
@@ -85,7 +85,7 @@ export const ConfigMapSecretForm = React.memo(
             memoizedReducer,
             initState(configMapSecretData, componentType, cmSecretStateLabel, draftMode || latestDraftData?.draftId),
         )
-
+        const [validateFormError, setValidateFormError] = React.useState<string>("")
         const { appId, envId } = useParams<{ appId; envId }>()
 
         const isChartVersion309OrBelow =
@@ -1019,6 +1019,7 @@ export const ConfigMapSecretForm = React.memo(
                                 tempArr={tempArr}
                                 readonlyView={readonlyView}
                                 draftMode={draftMode}
+                                setValidateFormError={setValidateFormError}
                             />
                         )}
                     </div>
@@ -1041,7 +1042,8 @@ export const ConfigMapSecretForm = React.memo(
                             <button
                                 disabled={
                                     (!draftMode && state.cmSecretState === CM_SECRET_STATE.INHERITED) ||
-                                    (draftMode && !isAppAdmin)
+                                    (draftMode && !isAppAdmin) || 
+                                    !!validateFormError
                                 }
                                 data-testid={`${componentType === 'secret' ? 'Secret' : 'ConfigMap'}-save-button`}
                                 type="button"

--- a/src/components/ConfigMapSecret/Types.ts
+++ b/src/components/ConfigMapSecret/Types.ts
@@ -81,6 +81,7 @@ export interface ConfigMapSecretDataEditorContainerProps {
     tempArr
     readonlyView: boolean
     draftMode: boolean
+    setValidateFormError: React.Dispatch<React.SetStateAction<string>>
 }
 
 export interface DraftDetailsForCommentDrawerType {

--- a/src/components/ConfigMapSecret/Types.ts
+++ b/src/components/ConfigMapSecret/Types.ts
@@ -81,7 +81,6 @@ export interface ConfigMapSecretDataEditorContainerProps {
     tempArr
     readonlyView: boolean
     draftMode: boolean
-    setValidateFormError: React.Dispatch<React.SetStateAction<string>>
 }
 
 export interface DraftDetailsForCommentDrawerType {
@@ -165,6 +164,7 @@ export interface ConfigMapState {
     showProtectedDeleteModal: boolean
     showProtectedDeleteOverrideModal: boolean
     draftPayload: any
+    isValidateFormError: boolean
 }
 export interface ConfigMapSecretState extends ConfigMapState, SecretState {}
 
@@ -198,6 +198,7 @@ export enum ConfigMapActionTypes {
     toggleProtectedDeleteModal = 'setShowProtectedDeleteModal',
     toggleProtectedDeleteOverrideModal = 'toggleProtectedDeleteOverrideModal',
     toggleDraftSaveModal = 'toggleDraftSaveModal',
+    setValidateFormError = 'setValidateFormError',
 }
 
 export interface ConfigMapAction {


### PR DESCRIPTION
# Description

1: select any devtron app and create a config map for the same .
2: The correct format is for e.g "key":"sde" but you added key:sde .
3: A warning would be there regarding wrong format , click on save -> cm would get created .
4: open the cm again , you will see yaml like this "key":"0" 

Issue : - Allow us to save even there is warning and value is not right that we entered 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested Locally
- [x] Test By deploying it in VM


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


