### PR TITLE
fix: Both Trigger-options of pre-cd get un-selected in specific case 

### DIFF
--- a/src/components/cdPipeline/NewCDPipeline.tsx
+++ b/src/components/cdPipeline/NewCDPipeline.tsx
@@ -424,14 +424,14 @@ export default function NewCDPipeline({
             if(pipelineConfigFromRes.preDeployStage.steps?.length > 0){
                 form.preBuildStage = pipelineConfigFromRes.preDeployStage
             }else {
-                form.preBuildStage = {...pipelineConfigFromRes.preDeployStage, steps: []}
+                form.preBuildStage = {...pipelineConfigFromRes.preDeployStage, steps: [], triggerType: TriggerType.Auto}
             }
         }
         if (pipelineConfigFromRes?.postDeployStage) {
             if(pipelineConfigFromRes.postDeployStage.steps?.length > 0){
                 form.postBuildStage = pipelineConfigFromRes?.postDeployStage
             }else {
-                form.postDeployStage = {...pipelineConfigFromRes.postDeployStage, steps: []}
+                form.postDeployStage = {...pipelineConfigFromRes.postDeployStage, steps: [], triggerType: TriggerType.Auto}
             }
         }
         form.requiredApprovals = `${pipelineConfigFromRes.userApprovalConfig?.requiredCount || ''}`


### PR DESCRIPTION
# Description

Both Trigger-options of pre-cd get un-selected when we update cd configuration without any task.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
All tests are performed locally.


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


