### PR TITLE
FIx: Pre cd post cd same name issue

### DIFF
--- a/src/components/cdPipeline/cdpipeline.util.tsx
+++ b/src/components/cdPipeline/cdpipeline.util.tsx
@@ -231,11 +231,10 @@ const checkStepsUniqueness = (list, type?: string): boolean => {
 
     if(type) {
         if(type === "pre") {
-            stageNameList.array.forEach(task => {
+            stageNameList.forEach(task => {
                 taskNameSet.add(task)
             });
         } else {
-            console.log(taskNameSet)
             stageNameList.forEach(task => {
                 if(taskNameSet.has(task)) {
                     flag=false;


### PR DESCRIPTION
# Description

The same names of pre-cd and post-cd should not be saved. But same names of pre-cd and post-cd are getting saved.

Fixes (https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/5732/)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] By creating a new app and adding a new task for pre & post CD and keeping same name for that 


# Checklist:

* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have performed a self-review of my own code
* [X] I have commented my code, particularly in hard-to-understand areas


