### PR TITLE
fix : Resource Browser continous loading after selecting namespace

### DIFF
--- a/src/components/ResourceBrowser/ResourceList/K8SResourceList.tsx
+++ b/src/components/ResourceBrowser/ResourceList/K8SResourceList.tsx
@@ -213,7 +213,7 @@ export function K8SResourceList({
                             >
                                 <span
                                     dangerouslySetInnerHTML={{
-                                        __html: highlightSearchedText(searchText, resourceData[columnName].toString()),
+                                        __html: highlightSearchedText(searchText, resourceData[columnName]?.toString()),
                                     }}
                                 ></span>
                             </ConditionalWrap>

--- a/src/components/ResourceBrowser/ResourceList/ResourceFilterOptions.tsx
+++ b/src/components/ResourceBrowser/ResourceList/ResourceFilterOptions.tsx
@@ -64,7 +64,7 @@ function ResourceFilterOptions({
         } else if (_key === 'Backspace' && searchText.length === 0) {
             clearSearch()
         } else {
-            handleFilterChanges(e.currentTarget.value, resourceList)
+            handleFilterChanges(e.currentTarget.value, resourceList, true)
             setSearchApplied(!!e.currentTarget.value)
         }
     }

--- a/src/components/ResourceBrowser/Types.ts
+++ b/src/components/ResourceBrowser/Types.ts
@@ -126,7 +126,7 @@ export interface ResourceFilterOptionsProps {
     setSearchText: React.Dispatch<React.SetStateAction<string>>
     searchApplied: boolean
     setSearchApplied: React.Dispatch<React.SetStateAction<boolean>>
-    handleFilterChanges: (_searchText: string, _resourceList: ResourceDetailType) => void
+    handleFilterChanges: (_searchText: string, _resourceList: ResourceDetailType, hideLoader?: boolean ) => void
     clearSearch: () => void
     isNamespaceSelectDisabled?: boolean
     isSearchInputDisabled?: boolean


### PR DESCRIPTION
# Description
 Resource Browser continous loading after selecting namespace

Fixes https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/5546

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- Go to Resource Browser, search a pod of the specific namespace for e.g. orchestrator 
- now change the namespace from all to devtroncd and observe
- Continous loading will no more appears

# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


