### PR TITLE
fix: no rows selected warning is coming on configure page of helm charts 

### DIFF
--- a/src/components/v2/appDetails/AppDetails.component.tsx
+++ b/src/components/v2/appDetails/AppDetails.component.tsx
@@ -45,6 +45,8 @@ const AppDetailsComponent = ({
     loadingDetails: boolean
     loadingResourceTree: boolean
 }) => {
+    const [loadingDetailsTemp, setLoadingDetailsTemp] = useState(true)
+    const [loadingResourceTreeTemp, setLoadingResourceTreeTemp] = useState(true)
     const params = useParams<{ appId: string; envId: string; nodeType: string }>()
     const [streamData, setStreamData] = useState<AppStreamData>(null)
     const [appDetails] = useSharedState(IndexStore.getAppDetails(), IndexStore.getAppDetailsObservable())
@@ -52,6 +54,13 @@ const AppDetailsComponent = ({
     const Host = process.env.REACT_APP_ORCHESTRATOR_ROOT
     const location = useLocation()
     const deploymentModalShownRef = useRef(false)
+
+    useEffect(() => {
+        if (appDetails?.appType !== null) {
+            setLoadingDetailsTemp(false)
+            setLoadingResourceTreeTemp(false)
+        }
+    }, [appDetails?.appType])
 
     const [deploymentStatusDetailsBreakdownData, setDeploymentStatusDetailsBreakdownData] =
         useState<DeploymentStatusDetailsBreakdownDataType>({
@@ -165,14 +174,14 @@ const AppDetailsComponent = ({
                 <EnvironmentSelectorComponent
                     isExternalApp={isExternalApp}
                     _init={_init}
-                    loadingResourceTree={loadingResourceTree}
+                    loadingResourceTree={loadingResourceTreeTemp}
                     isVirtualEnvironment={isVirtualEnv.current}
                 />
                 {!appDetails.deploymentAppDeleteRequest && (
                     <EnvironmentStatusComponent
                         appStreamData={streamData}
-                        loadingDetails={loadingDetails}
-                        loadingResourceTree={loadingResourceTree}
+                        loadingDetails={loadingDetailsTemp}
+                        loadingResourceTree={loadingResourceTreeTemp}
                         deploymentStatusDetailsBreakdownData={deploymentStatusDetailsBreakdownData}
                         isVirtualEnvironment={isVirtualEnv.current}
                         isHelmApp={true}

--- a/src/components/v2/appDetails/AppDetails.component.tsx
+++ b/src/components/v2/appDetails/AppDetails.component.tsx
@@ -46,8 +46,6 @@ const AppDetailsComponent = ({
     loadingDetails: boolean
     loadingResourceTree: boolean
 }) => {
-    const [loadingDetailsTemp, setLoadingDetailsTemp] = useState(true)
-    const [loadingResourceTreeTemp, setLoadingResourceTreeTemp] = useState(true)
     const params = useParams<{ appId: string; envId: string; nodeType: string }>()
     const [streamData, setStreamData] = useState<AppStreamData>(null)
     const [appDetails] = useSharedState(IndexStore.getAppDetails(), IndexStore.getAppDetailsObservable())
@@ -55,13 +53,6 @@ const AppDetailsComponent = ({
     const Host = process.env.REACT_APP_ORCHESTRATOR_ROOT
     const location = useLocation()
     const deploymentModalShownRef = useRef(false)
-
-    useEffect(() => {
-        if (appDetails?.appType !== null) {
-            setLoadingDetailsTemp(false)
-            setLoadingResourceTreeTemp(false)
-        }
-    }, [appDetails?.appType])
 
     const [deploymentStatusDetailsBreakdownData, setDeploymentStatusDetailsBreakdownData] =
         useState<DeploymentStatusDetailsBreakdownDataType>({
@@ -196,14 +187,14 @@ const AppDetailsComponent = ({
                 <EnvironmentSelectorComponent
                     isExternalApp={isExternalApp}
                     _init={_init}
-                    loadingResourceTree={loadingResourceTreeTemp}
+                    loadingResourceTree={loadingResourceTree || !appDetails?.appType}
                     isVirtualEnvironment={isVirtualEnv.current}
                 />
                 {!appDetails.deploymentAppDeleteRequest && (
                     <EnvironmentStatusComponent
                         appStreamData={streamData}
-                        loadingDetails={loadingDetailsTemp}
-                        loadingResourceTree={loadingResourceTreeTemp}
+                        loadingDetails={loadingDetails || !appDetails?.appType}
+                        loadingResourceTree={loadingResourceTree || !appDetails?.appType}
                         deploymentStatusDetailsBreakdownData={deploymentStatusDetailsBreakdownData}
                         isVirtualEnvironment={isVirtualEnv.current}
                         isHelmApp={true}

--- a/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
+++ b/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
@@ -889,7 +889,9 @@ function ChartValuesView({
               appDetails?.isVirtualEnvironment && onClickManifestDownload(res.result.installedAppId, +envId, res.result.appName, res.result?.helmPackageName)
                 toast.success(CHART_VALUE_TOAST_MSGS.UpdateInitiated)
                 IndexStore.publishAppDetails({} as AppDetails, null)
+                // console.log('url = ', `${url.split('/').slice(0, -1).join('/')}/${URLS.APP_DETAILS}?refetchData=true`)
                 history.push(`${url.split('/').slice(0, -1).join('/')}/${URLS.APP_DETAILS}?refetchData=true`)
+                history.go(0)
             } else {
                 toast.error(SOME_ERROR_MSG)
             }

--- a/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
+++ b/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
@@ -889,9 +889,7 @@ function ChartValuesView({
               appDetails?.isVirtualEnvironment && onClickManifestDownload(res.result.installedAppId, +envId, res.result.appName, res.result?.helmPackageName)
                 toast.success(CHART_VALUE_TOAST_MSGS.UpdateInitiated)
                 IndexStore.publishAppDetails({} as AppDetails, null)
-                // console.log('url = ', `${url.split('/').slice(0, -1).join('/')}/${URLS.APP_DETAILS}?refetchData=true`)
                 history.push(`${url.split('/').slice(0, -1).join('/')}/${URLS.APP_DETAILS}?refetchData=true`)
-                history.go(0)
             } else {
                 toast.error(SOME_ERROR_MSG)
             }

--- a/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
+++ b/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
@@ -111,6 +111,8 @@ import {
 } from './ChartValuesView.constants'
 import ClusterNotReachableDailog from '../../../common/ClusterNotReachableDailog/ClusterNotReachableDialog'
 import { VIEW_MODE } from '../../../ConfigMapSecret/Secret/secret.utils'
+import IndexStore from '../../appDetails/index.store'
+import { AppDetails } from '../../appDetails/appDetails.type'
 
 const GeneratedHelmDownload = importComponentFromFELibrary('GeneratedHelmDownload')
 const getDeployManifestDownload = importComponentFromFELibrary('getDeployManifestDownload', null, 'function')
@@ -886,6 +888,7 @@ function ChartValuesView({
             } else if (res?.result && (res.result.success || res.result.appName)) {
               appDetails?.isVirtualEnvironment && onClickManifestDownload(res.result.installedAppId, +envId, res.result.appName, res.result?.helmPackageName)
                 toast.success(CHART_VALUE_TOAST_MSGS.UpdateInitiated)
+                IndexStore.publishAppDetails({} as AppDetails, null)
                 history.push(`${url.split('/').slice(0, -1).join('/')}/${URLS.APP_DETAILS}?refetchData=true`)
             } else {
                 toast.error(SOME_ERROR_MSG)


### PR DESCRIPTION
# Description

These changes fix the issue of "no rows selected" warning when we configure any existing helm chart, click "update and deploy" button and navigate again to "configure" page when the page is still loading.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] Tested Locally 
- [x] Tested by deploying on Cluster


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


