### PR TITLE
fix: reload after deletion

### DIFF
--- a/src/components/ResourceBrowser/ResourceList/DeleteResourcePopup.tsx
+++ b/src/components/ResourceBrowser/ResourceList/DeleteResourcePopup.tsx
@@ -36,7 +36,6 @@ export default function DeleteResourcePopup({
             toast.success('Resource deleted successfully')
             getResourceListData(true)
             toggleDeleteDialog()
-            window.location.reload()
             if (removeTabByIdentifier) {
                 const pushURL = removeTabByIdentifier(
                     `${selectedResource?.gvk?.Kind.toLowerCase()}_${resourceData.namespace}/${resourceData.name}`,

--- a/src/components/ResourceBrowser/ResourceList/DeleteResourcePopup.tsx
+++ b/src/components/ResourceBrowser/ResourceList/DeleteResourcePopup.tsx
@@ -36,6 +36,7 @@ export default function DeleteResourcePopup({
             toast.success('Resource deleted successfully')
             getResourceListData(true)
             toggleDeleteDialog()
+            window.location.reload()
             if (removeTabByIdentifier) {
                 const pushURL = removeTabByIdentifier(
                     `${selectedResource?.gvk?.Kind.toLowerCase()}_${resourceData.namespace}/${resourceData.name}`,

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetail.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetail.component.tsx
@@ -418,7 +418,7 @@ function NodeDetailComponent({
                         },
                         namespaced: false,
                     }}
-                    getResourceListData={noop}
+                    getResourceListData={getContainersFromManifest}
                     toggleDeleteDialog={toggleDeleteDialog}
                     removeTabByIdentifier={removeTabByIdentifier}
                 />


### PR DESCRIPTION
# Description

we have to add a refresh function after deletion so that directly we see manifest not found screen .

Fixes https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/5759/

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] By deleting the resources in resource browser page and observing the manifest code Editor after deletion


# Checklist:

* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have performed a self-review of my own code
* [X] I have commented my code, particularly in hard-to-understand areas


