### PR TITLE
fix: overridden CI workflow link breaking

### DIFF
--- a/src/components/workflowEditor/Workflow.tsx
+++ b/src/components/workflowEditor/Workflow.tsx
@@ -286,7 +286,7 @@ export class Workflow extends Component<WorkflowProps, WorkflowState> {
         } else if (node.isExternalCI) {
             url = getExCIPipelineURL(appId, this.props.id.toString(), node.id)
         } else {
-            const currPipeline = this.props.filteredCIPipelines.find((pipeline) => +pipeline.id === +node.id)
+            const currPipeline = (this.props.filteredCIPipelines ?? []).find((pipeline) => +pipeline.id === +node.id)
             url = getCIPipelineURL(
                 appId,
                 this.props.id.toString(),


### PR DESCRIPTION
# Description

Fixed: Link for overridden CI workflows sidebar is breaking.

Fixes https://github.com/devtron-labs/devtron/issues/4002

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Devtron App without overridden CI
- [x] Devtron App with overridden CI

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


