### PR TITLE
fix: deleted cd in an env when again selected from drop down shows used env

### DIFF
--- a/src/components/workflowEditor/workflowEditor.tsx
+++ b/src/components/workflowEditor/workflowEditor.tsx
@@ -111,11 +111,10 @@ class WorkflowEdit extends Component<WorkflowEditProps, WorkflowEditState> {
                 const allCINodeMap = new Map()
                 const allDeploymentNodeMap = new Map()
                 let isDeletionInProgress
+                const _envIds = []
                 for (const workFlow of result.workflows) {
                     for (const node of workFlow.nodes) {
-                        this.setState({
-                            envIds: [...this.state.envIds, node.environmentId]
-                        })
+                        _envIds.push(node.environmentId)
                         if (node.type === WorkflowNodeType.CI) {
                             allCINodeMap.set(node.id, node)
                         } else if (node.type === WorkflowNodeType.CD) {
@@ -142,7 +141,8 @@ class WorkflowEdit extends Component<WorkflowEditProps, WorkflowEditState> {
                     allDeploymentNodeMap: allDeploymentNodeMap,
                     view: ViewType.FORM,
                     envToShowWebhookTippy: -1,
-                    filteredCIPipelines: result.filteredCIPipelines
+                    filteredCIPipelines: result.filteredCIPipelines,
+                    envIds: _envIds
                 })
             })
             .catch((errors) => {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Current behaviour :- When a user selects an env from dropdown while creating a pipeline in App Configurations page and then delete the pipeline then again goes and select the same env which he/she deleted instantly, then the UI shows the env is being used but it's not

This PR aims at fixing the above issue.

Fixes #[4014](https://github.com/devtron-labs/devtron/issues/4014)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested while creating multiple cd pipelines (parallel/sequential). 
- [ ] Test B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


