### PR TITLE
chore: revert default tooltip without word break

### DIFF
--- a/src/components/scopedVariables/VariablesList.tsx
+++ b/src/components/scopedVariables/VariablesList.tsx
@@ -17,7 +17,7 @@ export default function VariablesList({ variablesList }: { variablesList: Variab
     const renderVariablesListItem = ({ data, classes, tooltip }: VariablesListItemProps) => (
         <div className={classes}>
             {tooltip ? (
-                <Tippy content={data?.length ? data : NO_DESCRIPTION_MESSAGE} className="default-tt" placement="top">
+                <Tippy content={data?.length ? data : NO_DESCRIPTION_MESSAGE} className="default-tt dc__word-break-all" placement="top">
                     {data?.length ? (
                         <p className="dc__ellipsis-right cn-9 fs-13 fw-4 lh-20 m-0">{data}</p>
                     ) : (

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -1381,7 +1381,6 @@ button.anchor {
     line-height: 1.6;
     border: 1px solid rgba(255, 255, 255, 0.4);
     background-color: var(--N900);
-    word-break: break-all;
 }
 
 .tippy-box.default-white {


### PR DESCRIPTION
# Description
Removing word-break from default-tt and and adding it in the required places

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


