### PR TITLE
fix: Add params should not be in Kubernetes External config map

### DIFF
--- a/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecretDataEditorContainer.tsx
@@ -381,7 +381,8 @@ export const ConfigMapSecretDataEditorContainer = React.memo(
                 {(state.cmSecretState !== CM_SECRET_STATE.INHERITED || draftMode) &&
                     !state.unAuthorized &&
                     !state.secretMode &&
-                    !state.yamlMode && (
+                    !state.yamlMode &&
+                    !state.external && (
                         <div
                             className="dc__bold anchor pointer pb-10 dc_max-width__max-content"
                             onClick={handleAddParam}


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Add params should not be in Kubernetes External config map.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


