### PR TITLE
feat: listing all artifacts in case of ci-job type

### DIFF
--- a/src/components/app/details/cIDetails/CIDetails.tsx
+++ b/src/components/app/details/cIDetails/CIDetails.tsx
@@ -496,7 +496,7 @@ const HistoryLogs = ({
                 appReleaseTagNames={appReleaseTags}
                 hideImageTaggingHardDelete={hideImageTaggingHardDelete}
                 type={HistoryComponentType.CI}
-                jobCiClass="pb-0-imp"
+                jobCIClass="pb-0-imp"
             />
         )
     })

--- a/src/components/app/details/cIDetails/CIDetails.tsx
+++ b/src/components/app/details/cIDetails/CIDetails.tsx
@@ -464,7 +464,7 @@ const HistoryLogs = ({
             setLoading(true)
             getArtifactsForCiJobRes()
         }
-    }, [])
+    }, [triggerDetails])
     const getArtifactsForCiJobRes = async () => {
         try {
             const { result } = await getArtifactForJobCi(pipelineId, buildId)

--- a/src/components/app/details/cicdHistory/Artifacts.tsx
+++ b/src/components/app/details/cicdHistory/Artifacts.tsx
@@ -121,7 +121,7 @@ export default function Artifacts({
         )
     } else {
         return (
-            <div className={`flex left column p-16 ${jobCIClass}`}>
+            <div className={`flex left column p-16 ${jobCIClass??''}`}>
                 {!isJobView && type !== HistoryComponentType.CD && (
                     <CIListItem
                         type="artifact"

--- a/src/components/app/details/cicdHistory/Artifacts.tsx
+++ b/src/components/app/details/cicdHistory/Artifacts.tsx
@@ -36,6 +36,7 @@ export default function Artifacts({
     appReleaseTagNames,
     tagsEditable,
     hideImageTaggingHardDelete,
+    jobCiClass
 }: ArtifactType) {
     const { triggerId, buildId } = useParams<{
         triggerId: string
@@ -120,7 +121,7 @@ export default function Artifacts({
         )
     } else {
         return (
-            <div className="flex left column p-16">
+            <div className={`flex left column p-16 ${jobCiClass}`}>
                 {!isJobView && type !== HistoryComponentType.CD && (
                     <CIListItem
                         type="artifact"

--- a/src/components/app/details/cicdHistory/Artifacts.tsx
+++ b/src/components/app/details/cicdHistory/Artifacts.tsx
@@ -36,7 +36,7 @@ export default function Artifacts({
     appReleaseTagNames,
     tagsEditable,
     hideImageTaggingHardDelete,
-    jobCiClass
+    jobCIClass
 }: ArtifactType) {
     const { triggerId, buildId } = useParams<{
         triggerId: string
@@ -121,7 +121,7 @@ export default function Artifacts({
         )
     } else {
         return (
-            <div className={`flex left column p-16 ${jobCiClass}`}>
+            <div className={`flex left column p-16 ${jobCIClass}`}>
                 {!isJobView && type !== HistoryComponentType.CD && (
                     <CIListItem
                         type="artifact"

--- a/src/components/app/details/cicdHistory/types.tsx
+++ b/src/components/app/details/cicdHistory/types.tsx
@@ -83,7 +83,7 @@ export interface ArtifactType {
     appReleaseTagNames?: string[]
     tagsEditable?: boolean
     hideImageTaggingHardDelete?: boolean
-    jobCiClass?: string
+    jobCIClass?: string
 }
 
 export interface CopyTippyWithTextType {

--- a/src/components/app/details/cicdHistory/types.tsx
+++ b/src/components/app/details/cicdHistory/types.tsx
@@ -83,6 +83,7 @@ export interface ArtifactType {
     appReleaseTagNames?: string[]
     tagsEditable?: boolean
     hideImageTaggingHardDelete?: boolean
+    jobCiClass?: string
 }
 
 export interface CopyTippyWithTextType {

--- a/src/components/app/service.ts
+++ b/src/components/app/service.ts
@@ -15,7 +15,7 @@ import {
 import { createGitCommitUrl, handleUTCTime, ISTTimeModal } from '../common'
 import moment from 'moment-timezone'
 import { History } from './details/cicdHistory/types'
-import { AppDetails, CreateAppLabelsRequest } from './types'
+import { AppDetails, ArtifactsCiJob, CreateAppLabelsRequest } from './types'
 import { DeploymentWithConfigType } from './details/triggerView/types'
 import { AppMetaInfo } from './types'
 
@@ -111,6 +111,10 @@ interface AppDetailsResponse extends ResponseType {
 
 interface AppMetaInfoResponse extends ResponseType {
     result?: AppMetaInfo
+}
+
+export interface ArtifactCiJobResponse extends ResponseType {
+    result?: ArtifactsCiJob
 }
 
 export function fetchAppDetails(appId: number | string, envId: number | string): Promise<AppDetailsResponse> {
@@ -600,6 +604,11 @@ export function getArtifact(pipelineId, workflowId) {
     return get(URL).then((response) => {
         return response
     })
+}
+
+export function getArtifactForJobCi(pipelineId, workflowId): Promise<ArtifactCiJobResponse> {
+    const URL = `${Routes.CI_CONFIG_GET}/${pipelineId}/workflow/${workflowId}/ci-job/artifacts`
+    return get(URL)
 }
 
 export function getNodeStatus({ appName, envName, version, namespace, group, kind, name }) {

--- a/src/components/app/types.ts
+++ b/src/components/app/types.ts
@@ -87,6 +87,10 @@ export interface AppMetaInfo {
     labels?: TagType[]
 }
 
+export interface ArtifactsCiJob {
+    artifacts?: string[]
+}
+
 interface Description{
     id: number
     description: string


### PR DESCRIPTION
# Description

Currently we only show latest image in case of ci job type but there can be multiple images from Plugin (Pull Images) which user wants to see and perform actions on.

Fixes #4028

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


