### PR TITLE
fix: Environment dropdown is not opening until resource tree is not coming 

### DIFF
--- a/src/components/app/details/appDetails/AppDetails.tsx
+++ b/src/components/app/details/appDetails/AppDetails.tsx
@@ -544,10 +544,10 @@ export const Details: React.FC<DetailsType> = ({
         toggleDetailedStatus(true)
     }
 
-    if ((!appDetails?.resourceTree || !appDetails.resourceTree.nodes?.length) && !isVirtualEnvRef.current) {
+    if (!loadingResourceTree && (!appDetails?.resourceTree || !appDetails.resourceTree.nodes?.length) && !isVirtualEnvRef.current) {
         return (
             <>
-                {environments?.length > 0 && (
+            {environments?.length > 0 && (
                     <div className="flex left ml-20 mt-16">
                         <EnvSelector
                             environments={environments}
@@ -556,9 +556,7 @@ export const Details: React.FC<DetailsType> = ({
                         />
                     </div>
                 )}
-
-                {!loadingResourceTree && (
-                    isAppDeleted ? (
+                {isAppDeleted ? (
                     <DeletedAppComponent
                         resourceTreeFetchTimeOut={resourceTreeFetchTimeOut}
                         showApplicationDetailedModal={showApplicationDetailedModal}
@@ -573,7 +571,7 @@ export const Details: React.FC<DetailsType> = ({
                         buttonTitle={ERROR_EMPTY_SCREEN.GO_TO_DEPLOY}
                         appConfigTabs={URLS.APP_TRIGGER}
                     />
-                ))}
+                )}
             </>
         )
     }
@@ -892,11 +890,10 @@ export function EnvSelector({
                         IndicatorSeparator: null,
                         Option,
                         GroupHeading: (props) => <GroupHeading {...props} hideClusterName={true} />,
-                        DropdownIndicator: disabled ? null : components.DropdownIndicator,
+                        DropdownIndicator: components.DropdownIndicator,
                         ValueContainer: (props) => <CustomValueContainer {...props} valClassName="env-select" />,
                     }}
                     styles={envSelectorStyle}
-                    isDisabled={disabled}
                     isSearchable={true}
                     classNamePrefix="app-environment-select"
                     formatOptionLabel={formatOptionLabel}

--- a/src/components/app/details/appDetails/AppDetails.tsx
+++ b/src/components/app/details/appDetails/AppDetails.tsx
@@ -357,7 +357,7 @@ export const Details: React.FC<DetailsType> = ({
     }
 
     async function callAppDetailsAPI(fetchExternalLinks?: boolean) {
-        appDetailsAPI(params.appId, params.envId, 25000)
+        appDetailsAPI(params.appId, params.envId, 25000, appDetailsAbortRef.current.signal)
             .then((response) => {
                 if (!response.result.appName && !response.result.environmentName) {
                     setResourceTreeFetchTimeOut(false)

--- a/src/components/app/details/appDetails/appDetails.type.ts
+++ b/src/components/app/details/appDetails/appDetails.type.ts
@@ -183,7 +183,7 @@ export interface NodeSelectorsType {
 
 export interface DetailsType {
     environment?: any
-    appDetailsAPI: (appId: string, envId: string, timeout: number) => Promise<any>
+    appDetailsAPI: (appId: string, envId: string, timeout: number, signal?: AbortSignal) => Promise<any>
     setAppDetailResultInParent?: (appDetails) => void
     isAppDeployment?: boolean
     environments: any

--- a/src/components/app/service.ts
+++ b/src/components/app/service.ts
@@ -129,8 +129,9 @@ export function fetchResourceTreeInTime(
     appId: number | string,
     envId: number | string,
     reloadTimeOut: number,
+    signal?: AbortSignal,
 ): Promise<AppDetailsResponse> {
-    return get(`${Routes.APP_DETAIL}/resource-tree?app-id=${appId}&env-id=${envId}`, { timeout: reloadTimeOut })
+    return get(`${Routes.APP_DETAIL}/resource-tree?app-id=${appId}&env-id=${envId}`, { timeout: reloadTimeOut, signal: signal })
 }
 
 export function getEvents(pathParams) {

--- a/src/components/app/service.ts
+++ b/src/components/app/service.ts
@@ -121,8 +121,9 @@ export function fetchAppDetailsInTime(
     appId: number | string,
     envId: number | string,
     reloadTimeOut: number,
+    signal?: AbortSignal
 ): Promise<AppDetailsResponse> {
-    return get(`${Routes.APP_DETAIL}/v2?app-id=${appId}&env-id=${envId}`, { timeout: reloadTimeOut })
+    return get(`${Routes.APP_DETAIL}/v2?app-id=${appId}&env-id=${envId}`, { timeout: reloadTimeOut, signal: signal })
 }
 
 export function fetchResourceTreeInTime(


### PR DESCRIPTION
# Description

1: add an environment in unreachable cluster .
2: deploy something on that app .
3: deployment will get failed .
4: now go to app detail page , it will be in loading state , click on env dropdown . it won't open 

Fixes https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/5849/

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] By deploying multiple workflows in different environments. 


# Checklist:

* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have performed a self-review of my own code
* [X] I have commented my code, particularly in hard-to-understand areas


