### PR TITLE
fix: helm app list filter fixed and added NOT DEPLOYED filter for devtron apps

### DIFF
--- a/src/components/app/config.tsx
+++ b/src/components/app/config.tsx
@@ -73,4 +73,5 @@ export const APP_STATUS = {
     Hibernating: 'HIBERNATING',
     Missing: 'Missing',
     Progressing : 'Progressing',
+    ['Not Deployed'] : 'NOT DEPLOYED',
 }

--- a/src/components/app/list-new/AppList.tsx
+++ b/src/components/app/list-new/AppList.tsx
@@ -681,6 +681,7 @@ export default function AppList({ isSuperAdmin, appListCount, isArgoInstalled }:
 
     function renderMasterFilters() {
         let _isAnyClusterFilterApplied = masterFilters.clusters.some((_cluster) => _cluster.isChecked)
+        const appStatusFilters = (params.appType === AppListConstants.AppType.HELM_APPS) ? masterFilters.appStatus.slice(0,masterFilters.appStatus.length - 1) : masterFilters.appStatus
         const showExportCsvButton =
             userRoleResponse?.result?.roles?.indexOf('role:super-admin___') !== -1 &&
             currentTab === AppListConstants.AppTabs.DEVTRON_APPS &&
@@ -716,7 +717,7 @@ export default function AppList({ isSuperAdmin, appListCount, isArgoInstalled }:
                     {isArgoInstalled && (
                         <>
                             <Filter
-                                list={masterFilters.appStatus}
+                                list={appStatusFilters}
                                 labelKey="label"
                                 buttonText={APP_LIST_HEADERS.AppStatus}
                                 placeholder={APP_LIST_HEADERS.SearchAppStatus}

--- a/src/components/app/list-new/HelmAppList.tsx
+++ b/src/components/app/list-new/HelmAppList.tsx
@@ -69,7 +69,7 @@ export default function HelmAppList({
     const [sortBy, setSortBy] = useState(SortBy.APP_NAME)
     const [sortOrder, setSortOrder] = useState(OrderBy.ASC)
     const [clusterIdsCsv, setClusterIdsCsv] = useState('')
-    const [appStatus, setAppStatus] = useState('')
+    const [appStatus, setAppStatus] = useState(_getAppStatusFromRequestUrl())
     const [sseConnection, setSseConnection] = useState<EventSource>(undefined)
     const [externalHelmListFetchErrors, setExternalHelmListFetchErrors] = useState<string[]>([])
     const [showGuidedContentCards, setShowGuidedContentCards] = useState(false)
@@ -144,7 +144,9 @@ export default function HelmAppList({
         setDevtronInstalledHelmAppsList([])
         setFilteredHelmAppsList([])
         setClusterIdsCsv(_getClusterIdsFromRequestUrl())
-        setAppStatus(_getAppStatusFromRequestUrl())
+        if (appStatus !== _getAppStatusFromRequestUrl()) {
+            setAppStatus(_getAppStatusFromRequestUrl())
+        }
         setExternalHelmAppsList([])
         if (sseConnection) {
             sseConnection.close()


### PR DESCRIPTION
# Description

These changes fix the app-list filter where if we apply the app status filter (eg: healthy) and then refresh the page OR open some healthy app and then go back to the app-list page by clicking the back button, then the app-list would contain all the apps while the healthy filter would still be applied.

Also, added NOT DEPLOYED filter in devtron apps.

Fixes # [(issue)](https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/5237)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested Manually

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


