### PR TITLE
fix: don't allow special chars in data vol in cm cs

### DIFF
--- a/src/components/ConfigMapSecret/ConfigMapSecretForm.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecretForm.tsx
@@ -243,15 +243,17 @@ export const ConfigMapSecretForm = React.memo(
                         payload: { value: state.volumeMountPath.value, error: 'This is a required field' },
                     })
                     isFormValid = false
-                }else {
-                    if (!rules.cmVolumeMountPath(state.volumeMountPath.value).isValid){
-                        dispatch({
-                            type: ConfigMapActionTypes.setVolumeMountPath,
-                            payload: { value: state.volumeMountPath.value, error: rules.cmVolumeMountPath(state.volumeMountPath.value).message },
-                        })
-                        isFormValid = false
-                    }
+                } else if (!rules.cmVolumeMountPath(state.volumeMountPath.value).isValid) {
+                    dispatch({
+                        type: ConfigMapActionTypes.setVolumeMountPath,
+                        payload: {
+                            value: state.volumeMountPath.value,
+                            error: rules.cmVolumeMountPath(state.volumeMountPath.value).message,
+                        },
+                    })
+                    isFormValid = false
                 }
+            
 
                 if (state.isFilePermissionChecked && !isChartVersion309OrBelow) {
                     const isFilePermissionValid = validateFilePermission()

--- a/src/components/ConfigMapSecret/ConfigMapSecretForm.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecretForm.tsx
@@ -57,6 +57,7 @@ import { ConfigMapSecretDataEditorContainer } from './ConfigMapSecretDataEditorC
 import { INVALID_YAML_MSG } from '../../config/constantMessaging'
 import '../EnvironmentOverride/environmentOverride.scss'
 import './ConfigMapSecret.scss'
+import { ValidationRules } from '../cdPipeline/validationRules'
 
 const SaveChangesModal = importComponentFromFELibrary('SaveChangesModal')
 const DeleteModal = importComponentFromFELibrary('DeleteModal')
@@ -206,6 +207,7 @@ export const ConfigMapSecretForm = React.memo(
         }
 
         const validateForm = (): KeyValueValidated => {
+            const rules = new ValidationRules()
             const configMapSecretNameRegex = new RegExp(PATTERNS.CONFIGMAP_AND_SECRET_NAME)
             let isFormValid = true
             if (componentType === 'secret' && state.unAuthorized) {
@@ -241,7 +243,16 @@ export const ConfigMapSecretForm = React.memo(
                         payload: { value: state.volumeMountPath.value, error: 'This is a required field' },
                     })
                     isFormValid = false
+                }else {
+                    if (!rules.cmVolumeMountPath(state.volumeMountPath.value).isValid){
+                        dispatch({
+                            type: ConfigMapActionTypes.setVolumeMountPath,
+                            payload: { value: state.volumeMountPath.value, error: rules.cmVolumeMountPath(state.volumeMountPath.value).message },
+                        })
+                        isFormValid = false
+                    }
                 }
+
                 if (state.isFilePermissionChecked && !isChartVersion309OrBelow) {
                     const isFilePermissionValid = validateFilePermission()
                     if (!isFilePermissionValid) {

--- a/src/components/cdPipeline/validationRules.ts
+++ b/src/components/cdPipeline/validationRules.ts
@@ -38,4 +38,16 @@ export class ValidationRules {
         if (!repository.length) return { isValid: false, message: REQUIRED_FIELD_MSG }
         return { isValid: true, message: null }
     }
+
+    cmVolumeMountPath = (value: string): { isValid: boolean; message: string } => {
+        const re = PATTERNS.ALPHANUMERIC_WITH_DASH_UNDERSCORE_AND_SLASH
+        const regExp = new RegExp(re)
+        const test = regExp.test(value)
+        if (!test)
+            return {
+                isValid: false,
+                message: 'place holder to b',
+            }
+        else return { isValid: true, message: '' }
+    }
 }

--- a/src/components/cdPipeline/validationRules.ts
+++ b/src/components/cdPipeline/validationRules.ts
@@ -40,7 +40,7 @@ export class ValidationRules {
     }
 
     cmVolumeMountPath = (value: string): { isValid: boolean; message: string } => {
-        const re = PATTERNS.ALPHANUMERIC_WITH_DASH_UNDERSCORE_AND_SLASH
+        const re = PATTERNS.ALPHANUMERIC_WITH_SPECIAL_CHAR_AND_SLASH
         const regExp = new RegExp(re)
         const test = regExp.test(value)
         if (!test)

--- a/src/components/cdPipeline/validationRules.ts
+++ b/src/components/cdPipeline/validationRules.ts
@@ -1,5 +1,5 @@
 import { PATTERNS } from "../../config";
-import { CHARACTER_ERROR_MAX,CHARACTER_ERROR_MIN,ERROR_MESSAGE_FOR_VALIDATION,REQUIRED_FIELD_MSG } from "../../config/constantMessaging";
+import { CHARACTER_ERROR_MAX,CHARACTER_ERROR_MIN,ERROR_MESSAGE_FOR_VALIDATION,INVALID_VOLUME_MOUNT_PATH_IN_CM_CS,REQUIRED_FIELD_MSG } from "../../config/constantMessaging";
 
 export class ValidationRules {
     name = (value: string, pattern?: string): { isValid: boolean; message: string } => {
@@ -46,7 +46,7 @@ export class ValidationRules {
         if (!test)
             return {
                 isValid: false,
-                message: 'place holder to b',
+                message: INVALID_VOLUME_MOUNT_PATH_IN_CM_CS,
             }
         else return { isValid: true, message: '' }
     }

--- a/src/components/cdPipeline/validationRules.ts
+++ b/src/components/cdPipeline/validationRules.ts
@@ -43,11 +43,12 @@ export class ValidationRules {
         const re = PATTERNS.ALPHANUMERIC_WITH_SPECIAL_CHAR_AND_SLASH
         const regExp = new RegExp(re)
         const test = regExp.test(value)
-        if (!test)
+        if (!test){
             return {
                 isValid: false,
                 message: INVALID_VOLUME_MOUNT_PATH_IN_CM_CS,
             }
-        else return { isValid: true, message: '' }
+        }  
+        return { isValid: true, message: '' }
     }
 }

--- a/src/config/constantMessaging.ts
+++ b/src/config/constantMessaging.ts
@@ -48,6 +48,7 @@ export const enum DeleteComponentsName {
 
 export const LEARN_MORE = 'Learn more'
 export const REQUIRED_FIELD_MSG = 'This is a required field'
+export const INVALID_VOLUME_MOUNT_PATH_IN_CM_CS = 'Use only alphanumeric, (/), (-), (_); Do not use "spaces"'
 export const MAX_LENGTH_30 = 'Max 30 characters allowed'
 export const REPO_NAME_VALIDATION = 'Repository name is not valid; Invalid character(s) "_"'
 export const MULTI_REQUIRED_FIELDS_MSG = 'Some required fields are missing'

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -283,7 +283,7 @@ export const PATTERNS = {
     KUBERNETES_KEY_NAME: /^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$/,
     START_END_ALPHANUMERIC: /^([A-Za-z0-9]).*[A-Za-z0-9]$|^[A-Za-z0-9]{1}$/,
     ALPHANUMERIC_WITH_SPECIAL_CHAR: /^[A-Za-z0-9._-]+$/, // allow alphanumeric,(.) ,(-),(_)
-    ALPHANUMERIC_WITH_DASH_UNDERSCORE_AND_SLASH: /^[A-Za-z0-9._/-]+$/, // allow alphanumeric,(.) ,(-),(_),(/)
+    ALPHANUMERIC_WITH_SPECIAL_CHAR_AND_SLASH: /^[A-Za-z0-9._/-]+$/, // allow alphanumeric,(.) ,(-),(_),(/)
 }
 
 export const TriggerType = {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -283,6 +283,7 @@ export const PATTERNS = {
     KUBERNETES_KEY_NAME: /^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$/,
     START_END_ALPHANUMERIC: /^([A-Za-z0-9]).*[A-Za-z0-9]$|^[A-Za-z0-9]{1}$/,
     ALPHANUMERIC_WITH_SPECIAL_CHAR: /^[A-Za-z0-9._-]+$/, // allow alphanumeric,(.) ,(-),(_)
+    ALPHANUMERIC_WITH_DASH_UNDERSCORE_AND_SLASH: /^[A-Za-z0-9._/-]+$/, // allow alphanumeric,(.) ,(-),(_),(/)
 }
 
 export const TriggerType = {


### PR DESCRIPTION
# Description
This pr aims at fixing the issue where a user can add any special characters in data volume path when adding a cm or cs via Data Volume. Added validation where special characters are not allowed, (.),(/),(-),(_) these characters are allowed.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


