### PR TITLE
fix: loading state in resource browser

### DIFF
--- a/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
@@ -290,7 +290,12 @@ export default function ResourceList() {
                 setErrorStatusCode(err['code'])
             }
         } finally {
-          setResourceListLoader(false)
+            if (
+                nodeType === SIDEBAR_KEYS.overviewGVK.Kind.toLowerCase() ||
+                nodeType === SIDEBAR_KEYS.nodeGVK.Kind.toLowerCase()
+            ) {
+                setResourceListLoader(false)
+            }
         }
     }
 


### PR DESCRIPTION
# Description

It bugs out generally in subsequent request made to events page or pods page in resource browser section. The frontend displays the screen No result found after 2-3 seconds even if backend request is still processing.

Fixes #4109

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


