### PR TITLE
fix:issue with service URL and port numbers

### DIFF
--- a/src/components/v2/appDetails/k8Resource/nodeType/Node.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeType/Node.component.tsx
@@ -201,22 +201,24 @@ function NodeComponent({ handleFocusTabs, externalLinks, monitoringTools, isDevt
 
     const makeNodeTree = (nodes: Array<iNode>, showHeader?: boolean) => {
         const additionalTippyContent = (node) => {
+            const portList = [...new Set(node?.port)];
             return (
                 <>
-                    {node?.port.map((val) => {
+                    {portList.map((val, idx) => {
+                        if(idx>0) {
                         return (
                             <div className="flex left cn-9 m-0 dc__no-decore">
                                 <div className="" key={node.name}>
-                                    {node.name}:{val}
+                                    {node.name}:{node.namespace}:{val}
                                 <Clipboard
                                     className="ml-0 resource-action-tabs__clipboard fs-13 dc__truncate-text cursor pt-8"
                                     onClick={(event) => {
-                                        toggleClipBoardPort(event, node.name.concat(":",val))
+                                        toggleClipBoardPort(event, `${node.name}:${node.namespace}:${val}`)
                                     }}
                                 />
                                 </div>
                             </div>
-                        )
+                        )}
                     })}
             </>
             )
@@ -234,7 +236,7 @@ function NodeComponent({ handleFocusTabs, externalLinks, monitoringTools, isDevt
                             <Clipboard
                                 className="resource-action-tabs__clipboard icon-dim-12 pointer ml-8 mr-8"
                                 onClick={(event) => {
-                                    toggleClipBoardPort(event, node.name.concat(":", node.port))
+                                    toggleClipBoardPort(event, `${node.name}:${node.namespace}:${node.port[0]}`)
                                 }}
                             />
                         </span>

--- a/src/components/v2/appDetails/k8Resource/nodeType/Node.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeType/Node.component.tsx
@@ -205,22 +205,23 @@ function NodeComponent({ handleFocusTabs, externalLinks, monitoringTools, isDevt
             return (
                 <>
                     {portList.map((val, idx) => {
-                        if(idx>0) {
-                        return (
-                            <div className="flex left cn-9 m-0 dc__no-decore">
-                                <div className="" key={node.name}>
-                                    {node.name}:{node.namespace}:{val}
-                                <Clipboard
-                                    className="ml-0 resource-action-tabs__clipboard fs-13 dc__truncate-text cursor pt-8"
-                                    onClick={(event) => {
-                                        toggleClipBoardPort(event, `${node.name}:${node.namespace}:${val}`)
-                                    }}
-                                />
+                        if (idx > 0) {
+                            return (
+                                <div className="flex left cn-9 m-0 dc__no-decore">
+                                    <div className="" key={node.name}>
+                                        {node.name}:{node.namespace}:{val}
+                                        <Clipboard
+                                            className="ml-0 resource-action-tabs__clipboard fs-13 dc__truncate-text cursor pt-8"
+                                            onClick={(event) => {
+                                                toggleClipBoardPort(event, `${node.name}:${node.namespace}:${val}`)
+                                            }}
+                                        />
+                                    </div>
                                 </div>
-                            </div>
-                        )}
+                            )
+                        }
                     })}
-            </>
+                </>
             )
         }
         const portNumberPlaceHolder = (node) => {


### PR DESCRIPTION
# Description

-> On copying service URL from dashboard, it copies all the port numbers in the URL in comma separated way.
-> Incomplete service URL if you click on (+ more) button. It does not include the namespace in the service URL.
-> Shows duplicate service URL.

Fixes https://github.com/devtron-labs/devtron/issues/4025

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] By deploying an app with multiple services and multiple port number


# Checklist:

* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have performed a self-review of my own code
* [X] I have commented my code, particularly in hard-to-understand areas


