### PR TITLE
fix: Changes to persist cluster terminal session even on tab switches

### DIFF
--- a/src/components/ClusterNodes/ClusterSelectionList.tsx
+++ b/src/components/ClusterNodes/ClusterSelectionList.tsx
@@ -21,6 +21,7 @@ export default function ClusterSelectionList({
     isSuperAdmin,
     clusterListLoader,
     refreshData,
+    initTabsBasedOnRole
 }: ClusterSelectionType) {
     const location = useLocation()
     const history = useHistory()
@@ -105,6 +106,7 @@ export default function ClusterSelectionList({
         const queryParams = new URLSearchParams(location.search)
         queryParams.set('clusterId', clusterData.id)
         history.push(`${location.pathname}/${clusterData.id}/all/${AppDetailsTabs.terminal}/${K8S_EMPTY_GROUP}`)
+        initTabsBasedOnRole(true, isSuperAdmin)
     }
 
     const selectCluster = (e): void => {

--- a/src/components/ClusterNodes/ClusterTerminal.tsx
+++ b/src/components/ClusterNodes/ClusterTerminal.tsx
@@ -51,11 +51,11 @@ export default function ClusterTerminal({
     clusterImageList,
     isClusterDetailsPage,
     isNodeDetailsPage,
-    namespaceList=[],
+    namespaceList = [],
     node,
     taints,
     setSelectedNode,
-    showTerminal
+    showTerminal,
 }: ClusterTerminalType) {
     const location = useLocation()
     const history = useHistory()
@@ -626,8 +626,6 @@ export default function ClusterTerminal({
     const clearTerminal = () => {
         setTerminalCleared(!terminalCleared)
     }
-
-
 
     const renderRegisterLinkMatcher = (terminal) => {
         const linkMatcherRegex = new RegExp(`${POD_LINKS.POD_MANIFEST}|${POD_LINKS.POD_EVENTS}`)

--- a/src/components/ClusterNodes/ClusterTerminal.tsx
+++ b/src/components/ClusterNodes/ClusterTerminal.tsx
@@ -14,7 +14,7 @@ import { clusterImageDescription, convertToOptionsList } from '../common'
 import { get, ServerErrors, showError } from '@devtron-labs/devtron-fe-common-lib'
 import ClusterManifest, { ManifestPopupMenu } from './ClusterManifest'
 import ClusterEvents from './ClusterEvents'
-import { ClusterTerminalType } from './types'
+import { ClusterTerminalType, NodeTaintType } from './types'
 import {
     AUTO_SELECT,
     clusterImageSelect,
@@ -51,10 +51,11 @@ export default function ClusterTerminal({
     clusterImageList,
     isClusterDetailsPage,
     isNodeDetailsPage,
-    namespaceList,
+    namespaceList=[],
     node,
     taints,
     setSelectedNode,
+    showTerminal
 }: ClusterTerminalType) {
     const location = useLocation()
     const history = useHistory()
@@ -119,7 +120,7 @@ export default function ClusterTerminal({
         manifest: manifestData,
         debugNode: debugMode,
         podName: resourceData?.podName || '',
-        taints: taints.get(selectedNodeName.value),
+        taints: (taints as Map<string, NodeTaintType[]>).get(selectedNodeName.value) || [],
         containerName: containerName,
     }
 
@@ -971,7 +972,7 @@ export default function ClusterTerminal({
     }
 
     return (
-        <>
+        <div className={`${showTerminal ? '' : 'cluster-terminal-hidden'}`}>
             <TerminalWrapper
                 selectionListData={selectionListData}
                 socketConnection={socketConnection}
@@ -988,6 +989,6 @@ export default function ClusterTerminal({
                     forceDeletePod={setForceDelete}
                 />
             )}
-        </>
+        </div>
     )
 }

--- a/src/components/ClusterNodes/clusterNodes.scss
+++ b/src/components/ClusterNodes/clusterNodes.scss
@@ -15,7 +15,6 @@
 }
 
 .node-list {
-
     .list-min-height {
         min-height: calc(100vh - 120px);
         &.no-result-container {
@@ -472,4 +471,9 @@
 
 .node-code-editor-header {
     background: var(--terminal-bg);
+}
+
+.cluster-terminal-hidden {
+    visibility: hidden;
+    height: 0;
 }

--- a/src/components/ClusterNodes/clusterNodes.scss
+++ b/src/components/ClusterNodes/clusterNodes.scss
@@ -477,3 +477,7 @@
     visibility: hidden;
     height: 0;
 }
+
+.cluster-terminal-hidden * {
+    height: 0 !important;
+}

--- a/src/components/ClusterNodes/types.ts
+++ b/src/components/ClusterNodes/types.ts
@@ -183,7 +183,7 @@ export interface ClusterListType {
     ) => boolean
     updateNodeSelectionData: (_selected: Record<string, any>, _group?: string) => void
     k8SObjectMapRaw: Map<string, K8SObjectMapType>
-    lastDataSync:boolean
+    lastDataSync: boolean
 }
 
 export interface ClusterDetailsPropType extends ClusterListType {

--- a/src/components/ClusterNodes/types.ts
+++ b/src/components/ClusterNodes/types.ts
@@ -221,7 +221,8 @@ export interface ClusterTerminalType {
     node?: string
     setSelectedNode?: React.Dispatch<React.SetStateAction<string>>
     nodeGroups?: SelectGroupType[]
-    taints: Map<string, NodeTaintType[]>
+    taints: Map<string, NodeTaintType[]> | {}
+    showTerminal: boolean
 }
 
 export const TEXT_COLOR_CLASS = {

--- a/src/components/ClusterNodes/types.ts
+++ b/src/components/ClusterNodes/types.ts
@@ -221,7 +221,7 @@ export interface ClusterTerminalType {
     node?: string
     setSelectedNode?: React.Dispatch<React.SetStateAction<string>>
     nodeGroups?: SelectGroupType[]
-    taints: Map<string, NodeTaintType[]> | {}
+    taints: Map<string, NodeTaintType[]>
     showTerminal: boolean
 }
 

--- a/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
@@ -354,19 +354,17 @@ export default function ResourceList() {
         if (!superAdminRef.current) {
             return
         }
-        if (selectedCluster?.value && selectedNamespace?.value && nodeType) {
+        if (selectedCluster?.value && nodeType) {
             const _searchParam = tabs[1]?.url.split('?')[1] ? `?${tabs[1].url.split('?')[1]}` : ''
             updateTabUrl(
                 `${AppDetailsTabsIdPrefix.terminal}-${AppDetailsTabs.terminal}`,
                 `${URLS.RESOURCE_BROWSER}/${selectedCluster.value}/${
-                    selectedNamespace.value ? selectedNamespace.value : ALL_NAMESPACE_OPTION.value
+                    selectedNamespace?.value ? selectedNamespace.value : ALL_NAMESPACE_OPTION.value
                 }/${AppDetailsTabs.terminal}/${K8S_EMPTY_GROUP}${
                     nodeType === AppDetailsTabs.terminal ? location.search : _searchParam
                 }`,
                 `${AppDetailsTabs.terminal} '${selectedCluster.label}'`,
             )
-        } else {
-            removeTabByIdentifier(`${AppDetailsTabsIdPrefix.terminal}-${AppDetailsTabs.terminal}`)
         }
         if (tabs.length > 0 && nodeType === AppDetailsTabs.terminal) {
             markTabActiveByIdentifier(AppDetailsTabsIdPrefix.terminal, AppDetailsTabs.terminal)
@@ -1094,6 +1092,7 @@ export default function ResourceList() {
                     isSuperAdmin={superAdminRef.current}
                     clusterListLoader={terminalLoader}
                     refreshData={refreshSync}
+                    initTabsBasedOnRole={initTabsBasedOnRole}
                 />
             )
         }

--- a/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
@@ -929,22 +929,7 @@ export default function ResourceList() {
                 />
             )
         }
-        if (nodeType === AppDetailsTabs.terminal) {
-            if (terminalLoader) {
-                return (
-                    <div className="h-100 node-data-container bcn-0">
-                        <Progressing pageLoader />
-                    </div>
-                )
-            } else if (!selectedTerminal || !namespaceDefaultList?.[selectedTerminal.name]) {
-              return (
-                  <div className="bcn-0 node-data-container flex">
-                      {superAdminRef.current ? <Reload /> : <ErrorScreenManager code={403} />}
-                  </div>
-              )
-            }
-            return null
-        } else if (node) {
+        if (node) {
             return (
                 <div className="resource-details-container">
                     <NodeDetailComponent
@@ -1057,8 +1042,7 @@ export default function ResourceList() {
                         <DynamicTabs tabs={tabs} removeTabByIdentifier={removeTabByIdentifier} stopTabByIdentifier={stopTabByIdentifier} enableShortCut={!showCreateResourceModal} refreshData={refreshData} lastDataSync={lastDataSync} loader={loader||rawGVKLoader||clusterLoader||resourceListLoader} isOverview={isOverview} isStaleDataRef={isStaleDataRef} setLastDataSyncTimeString={setLastDataSyncTimeString}/>
                     </div>
                 </div>
-                {renderResourceBrowser()}
-                {nodeType === AppDetailsTabs.terminal && renderTerminalLoader()}
+                {nodeType === AppDetailsTabs.terminal ? renderTerminalLoader() : renderResourceBrowser()}
                 {renderClusterTerminal()}
             </div>
         )

--- a/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
@@ -348,10 +348,6 @@ export default function ResourceList() {
     }, [selectedCluster, selectedNamespace, selectedResource])
 
     useEffect(() => {
-        toggleShowTerminal()
-    }, [location.search])
-
-    useEffect(() => {
         if (!superAdminRef.current) {
             return
         }
@@ -373,6 +369,10 @@ export default function ResourceList() {
             markTabActiveByIdentifier(AppDetailsTabsIdPrefix.terminal, AppDetailsTabs.terminal)
         }
     }, [clusterCapacityData, location.search])
+
+    useEffect(() => {
+        toggleShowTerminal()
+    }, [location.search])
 
     useEffect(() => {
         if (

--- a/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
@@ -320,6 +320,9 @@ export default function ResourceList() {
 
     useEffect(() => {
         toggleShowTerminal()
+    }, [location.search])
+
+    useEffect(() => {
         if (!superAdminRef.current) {
             return
         }
@@ -361,8 +364,10 @@ export default function ResourceList() {
 
    const toggleShowTerminal = () => {
         if(nodeType === AppDetailsTabs.terminal) {
+            setTerminalLoader(false)
             setShowTerminal(true)
         } else{
+            setTerminalLoader(true)
             setShowTerminal(false)
         }
    }
@@ -878,6 +883,23 @@ export default function ResourceList() {
         }
     }
 
+    const renderTerminalLoader = () => {
+        if (terminalLoader) {
+            return (
+                <div className="h-100 node-data-container bcn-0">
+                    <Progressing pageLoader />
+                </div>
+            )
+        } else if (!selectedTerminal || !namespaceDefaultList?.[selectedTerminal.name]) {
+            return (
+                <div className="bcn-0 node-data-container flex">
+                    {superAdminRef.current ? <Reload /> : <ErrorScreenManager code={403} />}
+                </div>
+            )
+        }
+        return null
+    }
+
     const renderClusterTerminal = (): JSX.Element => {
         const _imageList = selectedTerminal ? filterImageList(imageList, selectedTerminal.serverVersion) : []
         const hideTerminal = nodeType !== AppDetailsTabs.terminal || !(selectedTerminal && namespaceDefaultList?.[selectedTerminal.name]) || terminalLoader
@@ -1036,6 +1058,7 @@ export default function ResourceList() {
                     </div>
                 </div>
                 {renderResourceBrowser()}
+                {nodeType === AppDetailsTabs.terminal && renderTerminalLoader()}
                 {renderClusterTerminal()}
             </div>
         )

--- a/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
@@ -445,13 +445,11 @@ export default function ResourceList() {
                 // Otherwise  keep the previous data as it will be the detail data updated by getDetailsClusterList
                 setClusterList((prev) => {
                     if (prev && prev.length === 0) {
-                        console.log('setClusterList 0 going inside')
                         return _clusterList
                     } else {
                         return prev
                     }
                 })
-                console.log('setClusterList 0')
 
                 const _selectedCluster = _clusterOptions.find((cluster) => cluster.value == clusterId)
                 if (_selectedCluster) {

--- a/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
@@ -950,10 +950,9 @@ export default function ResourceList() {
     }
 
     const renderClusterTerminal = (): JSX.Element => {
-        if (!startTerminal) return null
+        if (!startTerminal && nodeType !== AppDetailsTabs.terminal) return null
         const _imageList = selectedTerminal ? filterImageList(imageList, selectedTerminal.serverVersion) : []
-        const _showTerminal =
-            nodeType === AppDetailsTabs.terminal && selectedTerminal && namespaceDefaultList?.[selectedTerminal.name]
+        const _showTerminal = selectedTerminal && namespaceDefaultList?.[selectedTerminal.name]
 
         return (
             selectedTerminal && (

--- a/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
@@ -139,7 +139,7 @@ export default function ResourceList() {
     const [terminalLoader, setTerminalLoader] = useState(false)
     const [clusterList, setClusterList] = useState<ClusterDetail[]>([])
     const [toggleSync, setToggle] = useState(false)
-    const [showTerminal, setShowTerminal] = useState<boolean>(false)
+    const [startTerminal, setStartTerminal] = useState<boolean>(false)
     const isStaleDataRef = useRef<boolean>(false)
     const superAdminRef = useRef<boolean>(!!window._env_.K8S_CLIENT)
     const resourceListAbortController = new AbortController()
@@ -372,7 +372,7 @@ export default function ResourceList() {
 
     useEffect(() => {
         toggleShowTerminal()
-    }, [location.search])
+    }, [location.search, nodeType])
 
     useEffect(() => {
         if (
@@ -400,11 +400,10 @@ export default function ResourceList() {
 
     const toggleShowTerminal = () => {
         if (nodeType === AppDetailsTabs.terminal) {
+            setStartTerminal(true)
             setTerminalLoader(false)
-            setShowTerminal(true)
         } else {
             setTerminalLoader(true)
-            setShowTerminal(false)
         }
     }
 
@@ -951,15 +950,15 @@ export default function ResourceList() {
     }
 
     const renderClusterTerminal = (): JSX.Element => {
+        if (!startTerminal) return null
         const _imageList = selectedTerminal ? filterImageList(imageList, selectedTerminal.serverVersion) : []
-        const hideTerminal =
-            nodeType !== AppDetailsTabs.terminal ||
-            !(selectedTerminal && namespaceDefaultList?.[selectedTerminal.name]) ||
-            terminalLoader
+        const _showTerminal =
+            nodeType === AppDetailsTabs.terminal && selectedTerminal && namespaceDefaultList?.[selectedTerminal.name]
+
         return (
             selectedTerminal && (
                 <ClusterTerminal
-                    showTerminal={showTerminal && !hideTerminal}
+                    showTerminal={_showTerminal}
                     clusterId={+clusterId}
                     nodeGroups={createGroupSelectList(selectedTerminal.nodeDetails, 'nodeName')}
                     taints={createTaintsList(selectedTerminal.nodeDetails, 'nodeName')}

--- a/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
@@ -102,7 +102,7 @@ export default function ResourceList() {
         removeTabByIdentifier,
         updateTabUrl,
         stopTabByIdentifier,
-    } = useTabs(`${URLS.RESOURCE_BROWSER}`)
+    } = useTabs(URLS.RESOURCE_BROWSER)
     const [loader, setLoader] = useState(false)
     const [rawGVKLoader, setRawGVKLoader] = useState(false)
     const [clusterLoader, setClusterLoader] = useState(false)
@@ -370,8 +370,10 @@ export default function ResourceList() {
         }
     }, [clusterCapacityData, location.search])
 
+    // Trigger a terminal session, if the terminal tab is selected once
+    // and retain this terminal session until user exits the selected cluster
     useEffect(() => {
-        toggleShowTerminal()
+        triggerTerminal()
     }, [location.search, nodeType])
 
     useEffect(() => {
@@ -398,7 +400,7 @@ export default function ResourceList() {
         }
     }, [selectedNamespace])
 
-    const toggleShowTerminal = () => {
+    const triggerTerminal = () => {
         if (nodeType === AppDetailsTabs.terminal) {
             setStartTerminal(true)
             setTerminalLoader(false)
@@ -952,7 +954,8 @@ export default function ResourceList() {
     const renderClusterTerminal = (): JSX.Element => {
         if (!startTerminal && nodeType !== AppDetailsTabs.terminal) return null
         const _imageList = selectedTerminal ? filterImageList(imageList, selectedTerminal.serverVersion) : []
-        const _showTerminal = selectedTerminal && namespaceDefaultList?.[selectedTerminal.name]
+        const _showTerminal =
+            nodeType === AppDetailsTabs.terminal && selectedTerminal && namespaceDefaultList?.[selectedTerminal.name]
 
         return (
             selectedTerminal && (

--- a/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
@@ -7,7 +7,16 @@ import {
     processK8SObjects,
     sortObjectArrayAlphabetically,
 } from '../../common'
-import { showError, Progressing, ServerErrors, getUserRole, BreadCrumb, useBreadcrumb, ErrorScreenManager, Reload } from '@devtron-labs/devtron-fe-common-lib'
+import {
+    showError,
+    Progressing,
+    ServerErrors,
+    getUserRole,
+    BreadCrumb,
+    useBreadcrumb,
+    ErrorScreenManager,
+    Reload,
+} from '@devtron-labs/devtron-fe-common-lib'
 import PageHeader from '../../common/header/PageHeader'
 import {
     ApiResourceGroupType,
@@ -24,13 +33,7 @@ import {
     namespaceListByClusterId,
 } from '../ResourceBrowser.service'
 import { Nodes, OptionType } from '../../app/types'
-import {
-    ALL_NAMESPACE_OPTION,
-    EVENT_LIST,
-    K8S_EMPTY_GROUP,
-    ORDERED_AGGREGATORS,
-    SIDEBAR_KEYS,
-} from '../Constants'
+import { ALL_NAMESPACE_OPTION, EVENT_LIST, K8S_EMPTY_GROUP, ORDERED_AGGREGATORS, SIDEBAR_KEYS } from '../Constants'
 import { URLS } from '../../../config'
 import Sidebar from './Sidebar'
 import { K8SResourceList } from './K8SResourceList'
@@ -58,9 +61,20 @@ import {
     sortEventListData,
 } from '../Utils'
 import '../ResourceBrowser.scss'
-import { ClusterCapacityType, ClusterDetail, ClusterErrorType, ClusterImageList, ERROR_TYPE } from '../../ClusterNodes/types'
+import {
+    ClusterCapacityType,
+    ClusterDetail,
+    ClusterErrorType,
+    ClusterImageList,
+    ERROR_TYPE,
+} from '../../ClusterNodes/types'
 import { getHostURLConfiguration } from '../../../services/service'
-import { clusterNamespaceList, getClusterCapacity, getClusterList, getClusterListMin } from '../../ClusterNodes/clusterNodes.service'
+import {
+    clusterNamespaceList,
+    getClusterCapacity,
+    getClusterList,
+    getClusterListMin,
+} from '../../ClusterNodes/clusterNodes.service'
 import ClusterSelectionList from '../../ClusterNodes/ClusterSelectionList'
 import ClusterSelector from './ClusterSelector'
 import ClusterOverview from '../../ClusterNodes/ClusterOverview'
@@ -69,7 +83,6 @@ import ClusterTerminal from '../../ClusterNodes/ClusterTerminal'
 import { createTaintsList } from '../../cluster/cluster.util'
 import NodeDetailsList from '../../ClusterNodes/NodeDetailsList'
 import NodeDetails from '../../ClusterNodes/NodeDetails'
-
 
 export default function ResourceList() {
     const { clusterId, namespace, nodeType, node, group } = useParams<{
@@ -81,9 +94,15 @@ export default function ResourceList() {
     }>()
     const { replace, push } = useHistory()
     const location = useLocation()
-    const { tabs, initTabs, addTab, markTabActiveByIdentifier, removeTabByIdentifier, updateTabUrl, stopTabByIdentifier } = useTabs(
-        `${URLS.RESOURCE_BROWSER}`,
-    )
+    const {
+        tabs,
+        initTabs,
+        addTab,
+        markTabActiveByIdentifier,
+        removeTabByIdentifier,
+        updateTabUrl,
+        stopTabByIdentifier,
+    } = useTabs(`${URLS.RESOURCE_BROWSER}`)
     const [loader, setLoader] = useState(false)
     const [rawGVKLoader, setRawGVKLoader] = useState(false)
     const [clusterLoader, setClusterLoader] = useState(false)
@@ -135,7 +154,12 @@ export default function ResourceList() {
     const isTerminal = nodeType === AppDetailsTabs.terminal
     const isNodes = nodeType === SIDEBAR_KEYS.nodeGVK.Kind.toLowerCase()
     const searchWorkerRef = useRef(null)
-    const hideSyncWarning: boolean = loader || rawGVKLoader || showErrorState || !isStaleDataRef.current || !(!node && lastDataSyncTimeString && !resourceListLoader)
+    const hideSyncWarning: boolean =
+        loader ||
+        rawGVKLoader ||
+        showErrorState ||
+        !isStaleDataRef.current ||
+        !(!node && lastDataSyncTimeString && !resourceListLoader)
 
     useEffect(() => {
         if (typeof window['crate']?.hide === 'function') {
@@ -153,7 +177,7 @@ export default function ResourceList() {
                 setResourceSelectionData(parsedTabsData.resourceSelectionData)
                 setNodeSelectionData(parsedTabsData.nodeSelectionData)
             }
-        } catch (err) { }
+        } catch (err) {}
 
         // Clean up on unmount
         return (): void => {
@@ -168,7 +192,7 @@ export default function ResourceList() {
 
     useEffect(() => {
         getDetailsClusterList()
-    },[toggleSync])
+    }, [toggleSync])
 
     useEffect(() => {
         if (clusterId && terminalClusterData?.length > 0) {
@@ -208,27 +232,27 @@ export default function ResourceList() {
     }, [location.pathname])
 
     const getGVKData = async (_clusterId): Promise<void> => {
-      if (!_clusterId) return
-      try {
-          setRawGVKLoader(true)
-          setK8SObjectMapRaw(null)
-          const { result } = await getResourceGroupListRaw(_clusterId)
-          if (result) {
-              const processedData = processK8SObjects(result.apiResources, nodeType)
-              const _k8SObjectMap = processedData.k8SObjectMap
-              const _k8SObjectList: K8SObjectType[] = []
-              for (const element of ORDERED_AGGREGATORS) {
-                  if (_k8SObjectMap.get(element)) {
-                      _k8SObjectList.push(_k8SObjectMap.get(element))
-                  }
-              }
-              setK8SObjectMapRaw(getGroupedK8sObjectMap(_k8SObjectList, nodeType))
-          }
-          setRawGVKLoader(false)
-      } catch (err) {
-          setRawGVKLoader(false)
-      }
-  }
+        if (!_clusterId) return
+        try {
+            setRawGVKLoader(true)
+            setK8SObjectMapRaw(null)
+            const { result } = await getResourceGroupListRaw(_clusterId)
+            if (result) {
+                const processedData = processK8SObjects(result.apiResources, nodeType)
+                const _k8SObjectMap = processedData.k8SObjectMap
+                const _k8SObjectList: K8SObjectType[] = []
+                for (const element of ORDERED_AGGREGATORS) {
+                    if (_k8SObjectMap.get(element)) {
+                        _k8SObjectList.push(_k8SObjectMap.get(element))
+                    }
+                }
+                setK8SObjectMapRaw(getGroupedK8sObjectMap(_k8SObjectList, nodeType))
+            }
+            setRawGVKLoader(false)
+        } catch (err) {
+            setRawGVKLoader(false)
+        }
+    }
 
     const updateOnClusterChange = async (clusterId) => {
         try {
@@ -276,8 +300,9 @@ export default function ResourceList() {
                     for (const _nodeError of _nodeErrors) {
                         const _errorLength = result.nodeErrors[_nodeError].length
                         _errorList.push({
-                            errorText: `${_nodeError} on ${_errorLength === 1 ? `${_errorLength} node` : `${_errorLength} nodes`
-                                }`,
+                            errorText: `${_nodeError} on ${
+                                _errorLength === 1 ? `${_errorLength} node` : `${_errorLength} nodes`
+                            }`,
                             errorType: _nodeError,
                             filterText: result.nodeErrors[_nodeError],
                         })
@@ -304,13 +329,17 @@ export default function ResourceList() {
 
     useEffect(() => {
         if (selectedCluster?.value && selectedNamespace?.value && selectedResource?.gvk?.Kind) {
-            const updateData = [{
-                id: `${AppDetailsTabsIdPrefix.k8s_Resources}-${AppDetailsTabs.k8s_Resources}`,
-                url: `${URLS.RESOURCE_BROWSER}/${selectedCluster.value}/${selectedNamespace.value
-                    }/${selectedResource.gvk.Kind.toLowerCase()}/${selectedResource.gvk.Group.toLowerCase() || K8S_EMPTY_GROUP
+            const updateData = [
+                {
+                    id: `${AppDetailsTabsIdPrefix.k8s_Resources}-${AppDetailsTabs.k8s_Resources}`,
+                    url: `${URLS.RESOURCE_BROWSER}/${selectedCluster.value}/${
+                        selectedNamespace.value
+                    }/${selectedResource.gvk.Kind.toLowerCase()}/${
+                        selectedResource.gvk.Group.toLowerCase() || K8S_EMPTY_GROUP
                     }`,
-                dynamicTitle: selectedResource.gvk.Kind
-            }]
+                    dynamicTitle: selectedResource.gvk.Kind,
+                },
+            ]
             updateData.forEach((data) => updateTabUrl(data.id, data.url, data.dynamicTitle))
         }
         return (): void => {
@@ -327,16 +356,16 @@ export default function ResourceList() {
             return
         }
         if (selectedCluster?.value && selectedNamespace?.value && nodeType) {
-          const _searchParam = tabs[1]?.url.split('?')[1] ? `?${tabs[1].url.split('?')[1]}` : ''
-          updateTabUrl(
-              `${AppDetailsTabsIdPrefix.terminal}-${AppDetailsTabs.terminal}`,
-              `${URLS.RESOURCE_BROWSER}/${selectedCluster.value}/${
-                  selectedNamespace.value ? selectedNamespace.value : ALL_NAMESPACE_OPTION.value
-              }/${AppDetailsTabs.terminal}/${K8S_EMPTY_GROUP}${
-                  nodeType === AppDetailsTabs.terminal ? location.search : _searchParam
-              }`,
-              `${AppDetailsTabs.terminal} '${selectedCluster.label}'`,
-          )
+            const _searchParam = tabs[1]?.url.split('?')[1] ? `?${tabs[1].url.split('?')[1]}` : ''
+            updateTabUrl(
+                `${AppDetailsTabsIdPrefix.terminal}-${AppDetailsTabs.terminal}`,
+                `${URLS.RESOURCE_BROWSER}/${selectedCluster.value}/${
+                    selectedNamespace.value ? selectedNamespace.value : ALL_NAMESPACE_OPTION.value
+                }/${AppDetailsTabs.terminal}/${K8S_EMPTY_GROUP}${
+                    nodeType === AppDetailsTabs.terminal ? location.search : _searchParam
+                }`,
+                `${AppDetailsTabs.terminal} '${selectedCluster.label}'`,
+            )
         } else {
             removeTabByIdentifier(`${AppDetailsTabsIdPrefix.terminal}-${AppDetailsTabs.terminal}`)
         }
@@ -346,7 +375,14 @@ export default function ResourceList() {
     }, [clusterCapacityData, location.search])
 
     useEffect(() => {
-        if (clusterId && selectedResource && selectedResource.gvk.Kind!==SIDEBAR_KEYS.overviewGVK.Kind && !isOverview && !isTerminal && !isNodes) {
+        if (
+            clusterId &&
+            selectedResource &&
+            selectedResource.gvk.Kind !== SIDEBAR_KEYS.overviewGVK.Kind &&
+            !isOverview &&
+            !isTerminal &&
+            !isNodes
+        ) {
             getResourceListData()
             setSearchText('')
             setSearchApplied(false)
@@ -362,24 +398,24 @@ export default function ResourceList() {
         }
     }, [selectedNamespace])
 
-   const toggleShowTerminal = () => {
-        if(nodeType === AppDetailsTabs.terminal) {
+    const toggleShowTerminal = () => {
+        if (nodeType === AppDetailsTabs.terminal) {
             setTerminalLoader(false)
             setShowTerminal(true)
-        } else{
+        } else {
             setTerminalLoader(true)
             setShowTerminal(false)
         }
-   }
+    }
 
     const getDetailsClusterList = async () => {
         setTerminalLoader(true)
         getClusterList()
             .then((response) => {
                 if (response.result) {
-                  response.result.sort((a, b) => a['name'].localeCompare(b['name']))
-                  setTerminalCluster(response.result)
-                  setClusterList(response.result)
+                    response.result.sort((a, b) => a['name'].localeCompare(b['name']))
+                    setTerminalCluster(response.result)
+                    setClusterList(response.result)
                 }
                 setTerminalLoader(false)
             })
@@ -422,7 +458,7 @@ export default function ResourceList() {
                 setImageList(JSON.parse(imageValue))
             }
             if (userRole?.result) {
-                superAdminRef.current=userRole.result.superAdmin
+                superAdminRef.current = userRole.result.superAdmin
                 initTabsBasedOnRole(false, userRole.result.superAdmin)
             }
             if (namespaceList.result) {
@@ -440,40 +476,40 @@ export default function ResourceList() {
         }
     }
 
-    const initTabsBasedOnRole = (reInit:boolean, _isSuperAdmin?: boolean)=>{
-      const _nodeType = nodeType ? `/${nodeType}` : ''
-      const _tabs = [
-          {
-              idPrefix: AppDetailsTabsIdPrefix.k8s_Resources,
-              name: AppDetailsTabs.k8s_Resources,
-              url: `${URLS.RESOURCE_BROWSER}/${clusterId}/${namespace}${_nodeType}`,
-              isSelected: true,
-              positionFixed: true,
-              iconPath: K8ResourceIcon,
-              showNameOnSelect: false,
-          },
-      ]
-      if (superAdminRef.current) {
-          _tabs.push({
-              idPrefix: AppDetailsTabsIdPrefix.terminal,
-              name: AppDetailsTabs.terminal,
-              url: `${URLS.RESOURCE_BROWSER}/${clusterId}/${namespace}/${AppDetailsTabs.terminal}/${K8S_EMPTY_GROUP}${location.search}`,
-              isSelected: false,
-              positionFixed: true,
-              iconPath: TerminalIcon,
-              showNameOnSelect: true,
-          })
-      }
+    const initTabsBasedOnRole = (reInit: boolean, _isSuperAdmin?: boolean) => {
+        const _nodeType = nodeType ? `/${nodeType}` : ''
+        const _tabs = [
+            {
+                idPrefix: AppDetailsTabsIdPrefix.k8s_Resources,
+                name: AppDetailsTabs.k8s_Resources,
+                url: `${URLS.RESOURCE_BROWSER}/${clusterId}/${namespace}${_nodeType}`,
+                isSelected: true,
+                positionFixed: true,
+                iconPath: K8ResourceIcon,
+                showNameOnSelect: false,
+            },
+        ]
+        if (superAdminRef.current) {
+            _tabs.push({
+                idPrefix: AppDetailsTabsIdPrefix.terminal,
+                name: AppDetailsTabs.terminal,
+                url: `${URLS.RESOURCE_BROWSER}/${clusterId}/${namespace}/${AppDetailsTabs.terminal}/${K8S_EMPTY_GROUP}${location.search}`,
+                isSelected: false,
+                positionFixed: true,
+                iconPath: TerminalIcon,
+                showNameOnSelect: true,
+            })
+        }
 
-      if (reInit) {
-          initTabs(_tabs, true)
-      } else {
-          initTabs(
-              _tabs,
-              false,
-              !superAdminRef.current ? [`${AppDetailsTabsIdPrefix.terminal}-${AppDetailsTabs.terminal}`] : null,
-          )
-      }
+        if (reInit) {
+            initTabs(_tabs, true)
+        } else {
+            initTabs(
+                _tabs,
+                false,
+                !superAdminRef.current ? [`${AppDetailsTabsIdPrefix.terminal}-${AppDetailsTabs.terminal}`] : null,
+            )
+        }
     }
 
     const getNamespaceList = async (_clusterId: string) => {
@@ -502,7 +538,10 @@ export default function ResourceList() {
                 const processedData = processK8SObjects(result.apiResources, nodeType)
                 const _k8SObjectMap = processedData.k8SObjectMap
                 const _k8SObjectList: K8SObjectType[] = []
-                const currentNodeType = clusterId == _clusterId ? nodeType || SIDEBAR_KEYS.overviewGVK.Kind.toLowerCase() : SIDEBAR_KEYS.overviewGVK.Kind.toLowerCase()
+                const currentNodeType =
+                    clusterId == _clusterId
+                        ? nodeType || SIDEBAR_KEYS.overviewGVK.Kind.toLowerCase()
+                        : SIDEBAR_KEYS.overviewGVK.Kind.toLowerCase()
 
                 for (const element of ORDERED_AGGREGATORS) {
                     if (_k8SObjectMap.get(element)) {
@@ -518,10 +557,11 @@ export default function ResourceList() {
 
                 if (!isResourceGroupPresent && !node) {
                     parentNode.isExpanded = true
-                    const searchParam =location.search? `/${location.search}`:''
+                    const searchParam = location.search ? `/${location.search}` : ''
                     replace({
-                        pathname: `${URLS.RESOURCE_BROWSER}/${_clusterId}/${namespace || ALL_NAMESPACE_OPTION.value
-                            }/${SIDEBAR_KEYS.overviewGVK.Kind.toLowerCase()}/${K8S_EMPTY_GROUP}${searchParam}`,
+                        pathname: `${URLS.RESOURCE_BROWSER}/${_clusterId}/${
+                            namespace || ALL_NAMESPACE_OPTION.value
+                        }/${SIDEBAR_KEYS.overviewGVK.Kind.toLowerCase()}/${K8S_EMPTY_GROUP}${searchParam}`,
                     })
                 }
 
@@ -613,7 +653,7 @@ export default function ResourceList() {
                         'type',
                         'age',
                         'node',
-                        'ip'
+                        'ip',
                     ],
                     origin: new URL(process.env.PUBLIC_URL, window.location.href).origin,
                 },
@@ -625,13 +665,17 @@ export default function ResourceList() {
         if (hideSyncWarning) {
             return null
         }
-        return <div className="fs-13 flex left w-100 bcy-1 h-32 warning-icon-y7-imp dc__border-bottom-y2">
-            <div className="pl-12 flex fs-13 pt-6 pb-6 pl-12">
-                <Warning className="icon-dim-20 mr-8" />
-                <span>Last synced {lastDataSyncTimeString}. The data might be stale. </span>
-                <span className='cb-5 ml-4 fw-6 cursor' onClick={refreshData}>Sync now</span>
+        return (
+            <div className="fs-13 flex left w-100 bcy-1 h-32 warning-icon-y7-imp dc__border-bottom-y2">
+                <div className="pl-12 flex fs-13 pt-6 pb-6 pl-12">
+                    <Warning className="icon-dim-20 mr-8" />
+                    <span>Last synced {lastDataSyncTimeString}. The data might be stale. </span>
+                    <span className="cb-5 ml-4 fw-6 cursor" onClick={refreshData}>
+                        Sync now
+                    </span>
+                </div>
             </div>
-        </div>
+        )
     }
 
     const getResourceListData = async (retainSearched?: boolean): Promise<void> => {
@@ -714,7 +758,7 @@ export default function ResourceList() {
     }
 
     const onClusterChange = (value) => {
-      onChangeCluster(value, true, false)
+        onChangeCluster(value, true, false)
     }
 
     const { breadcrumbs } = useBreadcrumb(
@@ -725,13 +769,19 @@ export default function ResourceList() {
                     linked: true,
                 },
                 ':clusterId?': {
-                    component: <ClusterSelector onChange={onClusterChange} clusterList={clusterOptions} clusterId={clusterId} />,
+                    component: (
+                        <ClusterSelector
+                            onChange={onClusterChange}
+                            clusterList={clusterOptions}
+                            clusterId={clusterId}
+                        />
+                    ),
                     linked: false,
                 },
                 ':namespace?': null,
                 ':nodeType?': null,
                 ':group?': null,
-                ':node?': null
+                ':node?': null,
             },
         },
         [clusterId, clusterOptions],
@@ -902,18 +952,23 @@ export default function ResourceList() {
 
     const renderClusterTerminal = (): JSX.Element => {
         const _imageList = selectedTerminal ? filterImageList(imageList, selectedTerminal.serverVersion) : []
-        const hideTerminal = nodeType !== AppDetailsTabs.terminal || !(selectedTerminal && namespaceDefaultList?.[selectedTerminal.name]) || terminalLoader
-        return (selectedTerminal &&
-            <ClusterTerminal
-                showTerminal={showTerminal && !hideTerminal}
-                clusterId={+clusterId}
-                nodeGroups={createGroupSelectList(selectedTerminal.nodeDetails, 'nodeName')}
-                taints={createTaintsList(selectedTerminal.nodeDetails, 'nodeName')}
-                clusterImageList={_imageList}
-                namespaceList={namespaceDefaultList[selectedTerminal.name]}
-                isNodeDetailsPage={true}
-            />
-                )
+        const hideTerminal =
+            nodeType !== AppDetailsTabs.terminal ||
+            !(selectedTerminal && namespaceDefaultList?.[selectedTerminal.name]) ||
+            terminalLoader
+        return (
+            selectedTerminal && (
+                <ClusterTerminal
+                    showTerminal={showTerminal && !hideTerminal}
+                    clusterId={+clusterId}
+                    nodeGroups={createGroupSelectList(selectedTerminal.nodeDetails, 'nodeName')}
+                    taints={createTaintsList(selectedTerminal.nodeDetails, 'nodeName')}
+                    clusterImageList={_imageList}
+                    namespaceList={namespaceDefaultList[selectedTerminal.name]}
+                    isNodeDetailsPage={true}
+                />
+            )
+        )
     }
 
     const renderResourceBrowser = (): JSX.Element => {
@@ -973,19 +1028,30 @@ export default function ResourceList() {
     }
 
     const addClusterButton = () => {
-        if (clusterId) return (!loader && !showErrorState && k8SObjectMap &&
-            <><div
-                className="cursor flex cta small h-28 pl-8 pr-10 pt-5 pb-5 lh-n fcb-5 mr-16"
-                data-testid="create-resource"
-                onClick={showResourceModal}
-            >
-                <Add className="icon-dim-16 fcb-5 mr-5" /> Create resource
-            </div>
-                <span className="dc__divider" /></>)
+        if (clusterId)
+            return (
+                !loader &&
+                !showErrorState &&
+                k8SObjectMap && (
+                    <>
+                        <div
+                            className="cursor flex cta small h-28 pl-8 pr-10 pt-5 pb-5 lh-n fcb-5 mr-16"
+                            data-testid="create-resource"
+                            onClick={showResourceModal}
+                        >
+                            <Add className="icon-dim-16 fcb-5 mr-5" /> Create resource
+                        </div>
+                        <span className="dc__divider" />
+                    </>
+                )
+            )
 
         return (
             <>
-                <NavLink className="flex dc__no-decor cta small h-28 pl-8 pr-10 pt-5 pb-5 lh-n fcb-5 mr-16" to={URLS.GLOBAL_CONFIG_CLUSTER}>
+                <NavLink
+                    className="flex dc__no-decor cta small h-28 pl-8 pr-10 pt-5 pb-5 lh-n fcb-5 mr-16"
+                    to={URLS.GLOBAL_CONFIG_CLUSTER}
+                >
                     <Add
                         data-testid="add_cluster_button"
                         className="icon-dim-16 mr-4 fcb-5 dc__vertical-align-middle"
@@ -1006,9 +1072,9 @@ export default function ResourceList() {
     }
 
     const renderResourceListBody = () => {
-        if(accessDeniedCode) {
+        if (accessDeniedCode) {
             return (
-                <div className='flex' style={{ height: 'calc(100vh - 48px)' }}>
+                <div className="flex" style={{ height: 'calc(100vh - 48px)' }}>
                     <ErrorScreenManager code={accessDeniedCode} />
                 </div>
             )
@@ -1039,7 +1105,18 @@ export default function ResourceList() {
                     }}
                 >
                     <div className="resource-browser-tab flex left w-100">
-                        <DynamicTabs tabs={tabs} removeTabByIdentifier={removeTabByIdentifier} stopTabByIdentifier={stopTabByIdentifier} enableShortCut={!showCreateResourceModal} refreshData={refreshData} lastDataSync={lastDataSync} loader={loader||rawGVKLoader||clusterLoader||resourceListLoader} isOverview={isOverview} isStaleDataRef={isStaleDataRef} setLastDataSyncTimeString={setLastDataSyncTimeString}/>
+                        <DynamicTabs
+                            tabs={tabs}
+                            removeTabByIdentifier={removeTabByIdentifier}
+                            stopTabByIdentifier={stopTabByIdentifier}
+                            enableShortCut={!showCreateResourceModal}
+                            refreshData={refreshData}
+                            lastDataSync={lastDataSync}
+                            loader={loader || rawGVKLoader || clusterLoader || resourceListLoader}
+                            isOverview={isOverview}
+                            isStaleDataRef={isStaleDataRef}
+                            setLastDataSyncTimeString={setLastDataSyncTimeString}
+                        />
                     </div>
                 </div>
                 {nodeType === AppDetailsTabs.terminal ? renderTerminalLoader() : renderResourceBrowser()}
@@ -1051,7 +1128,12 @@ export default function ResourceList() {
     return (
         <ShortcutProvider>
             <div className="resource-browser-container">
-                <PageHeader isBreadcrumbs={!!clusterId} breadCrumbs={renderBreadcrumbs} headerName={!clusterId ? 'Kubernetes Resource Browser' : ''} renderActionButtons={addClusterButton} />
+                <PageHeader
+                    isBreadcrumbs={!!clusterId}
+                    breadCrumbs={renderBreadcrumbs}
+                    headerName={!clusterId ? 'Kubernetes Resource Browser' : ''}
+                    renderActionButtons={addClusterButton}
+                />
                 {renderResourceListBody()}
                 {showCreateResourceModal && <CreateResource closePopup={closeResourceModal} clusterId={clusterId} />}
             </div>

--- a/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
@@ -195,13 +195,16 @@ export default function ResourceList() {
     }, [toggleSync])
 
     useEffect(() => {
+        if(clusterList && clusterList.length > 0 && !clusterList[0]?.nodeCount && terminalClusterData) {
+            setClusterList(terminalClusterData)
+        }
         if (clusterId && terminalClusterData?.length > 0) {
             const _selectedCluster = terminalClusterData.find((list) => list.id == +clusterId)
             if (_selectedCluster) {
                 setSelectedTerminal(_selectedCluster)
             }
         }
-    }, [clusterId, terminalClusterData])
+    }, [clusterId, terminalClusterData, clusterList])
 
     // Mark tab active on path change
     useEffect(() => {
@@ -370,8 +373,8 @@ export default function ResourceList() {
         }
     }, [clusterCapacityData, location.search])
 
-    // Trigger a terminal session, if the terminal tab is selected once
-    // and retain this terminal session until user exits the selected cluster
+    // Scrolls the view to top on the path change in the url
+    // Starts the cluster terminal when the cluster tab is opened for the first time
     useEffect(() => {
         triggerTerminal()
     }, [location.search, nodeType])
@@ -400,12 +403,10 @@ export default function ResourceList() {
         }
     }, [selectedNamespace])
 
+    // Triggers the cluster terminal when the cluster tab is opened for the first time
     const triggerTerminal = () => {
         if (nodeType === AppDetailsTabs.terminal) {
             setStartTerminal(true)
-            setTerminalLoader(false)
-        } else {
-            setTerminalLoader(true)
         }
     }
 

--- a/src/components/ResourceBrowser/Types.ts
+++ b/src/components/ResourceBrowser/Types.ts
@@ -97,6 +97,7 @@ export interface ClusterSelectionType {
     isSuperAdmin: boolean
     clusterListLoader: boolean
     refreshData: () => void
+    initTabsBasedOnRole: (reInit: boolean, _isSuperAdmin?: boolean) => void
 }
 
 export interface CreateResourceType {

--- a/src/components/cluster/cluster.type.ts
+++ b/src/components/cluster/cluster.type.ts
@@ -12,6 +12,13 @@ export const AuthenticationType = {
     IAM: 'IAM',
 }
 
+export const emptyClusterTerminalParamsData = {
+    selectedImage: null,
+    selectedNamespace: null,
+    selectedNode: null,
+    selectedShell: null
+}
+
 export interface UserDetails {
     userName: string
     errorInConnecting: string,

--- a/src/components/cluster/cluster.type.ts
+++ b/src/components/cluster/cluster.type.ts
@@ -16,28 +16,28 @@ export const emptyClusterTerminalParamsData = {
     selectedImage: null,
     selectedNamespace: null,
     selectedNode: null,
-    selectedShell: null
+    selectedShell: null,
 }
 
 export interface UserDetails {
     userName: string
-    errorInConnecting: string,
+    errorInConnecting: string
     config: ConfigCluster
 }
 
 export interface UserNameList {
-    label: string,
-    value: string,
+    label: string
+    value: string
 }
 
 export enum SSHAuthenticationType {
-    Password = "PASSWORD",
-    SSH_Private_Key = "SSH_PRIVATE_KEY",
-    Password_And_SSH_Private_Key = "PASSWORD_AND_SSH_PRIVATE_KEY"
+    Password = 'PASSWORD',
+    SSH_Private_Key = 'SSH_PRIVATE_KEY',
+    Password_And_SSH_Private_Key = 'PASSWORD_AND_SSH_PRIVATE_KEY',
 }
 
 export interface DataListType {
-    id: number;
+    id: number
     cluster_name: string
     userInfos: UserDetails[]
     server_url: string
@@ -50,17 +50,17 @@ export interface DataListType {
 }
 
 export interface SaveClusterPayloadType {
-    id: number,
-    cluster_name: string,
-    insecureSkipTlsVerify: boolean,
-    config: ConfigCluster,
-    active: boolean,
-    prometheus_url: string,
-    prometheusAuth: Record<string, string>,
-    server_url: string,
-    proxyUrl: string,
+    id: number
+    cluster_name: string
+    insecureSkipTlsVerify: boolean
+    config: ConfigCluster
+    active: boolean
+    prometheus_url: string
+    prometheusAuth: Record<string, string>
+    server_url: string
+    proxyUrl: string
     isConnectedViaSSHTunnel: boolean
-    sshTunnelConfig: Record<string, string>,
+    sshTunnelConfig: Record<string, string>
 }
 
 export const DEFAULT_SECRET_PLACEHOLDER = '••••••••'

--- a/src/components/cluster/cluster.util.ts
+++ b/src/components/cluster/cluster.util.ts
@@ -46,15 +46,15 @@ export function getClusterTerminalParamsData(
     clusterShellList: OptionType[],
     node: string,
 ): ClusterTerminalParamsType {
-    if (!nodeList) return emptyClusterTerminalParamsData
+    if (!nodeList || nodeList.length === 0) return emptyClusterTerminalParamsData
     const _selectedImage = imageList.find((image) => image.value === params.get('image'))
     const _selectedNamespace = namespaceList.find((namespace) => namespace.value === params.get('namespace'))
     let nodeOptionList: OptionType[] = []
     nodeList?.forEach((item) => nodeOptionList.push(...item.options))
 
     const _selectedNode: OptionType =
-        nodeOptionList?.find((data) => data.value === params.get('node')) ||
-        (node ? nodeOptionList?.find((item) => item.value === node) : nodeList[0]?.options[0])
+        nodeOptionList.find((data) => data.value === params.get('node')) ||
+        (node ? nodeOptionList.find((item) => item.value === node) : nodeList[0].options[0])
 
     const _selectedShell = clusterShellList.find((shell) => shell.value === params.get('shell'))
 

--- a/src/components/cluster/cluster.util.ts
+++ b/src/components/cluster/cluster.util.ts
@@ -5,6 +5,7 @@ import {
     ClusterComponentStatusType,
     ClusterComponentStatus,
     ClusterTerminalParamsType,
+    emptyClusterTerminalParamsData,
 } from './cluster.type'
 
 export function getEnvName(components: ClusterComponentType[], agentInstallationStage): string {
@@ -45,14 +46,15 @@ export function getClusterTerminalParamsData(
     clusterShellList: OptionType[],
     node: string,
 ): ClusterTerminalParamsType {
+    if(!nodeList) return emptyClusterTerminalParamsData
     const _selectedImage = imageList.find((image) => image.value === params.get('image'))
     const _selectedNamespace = namespaceList.find((namespace) => namespace.value === params.get('namespace'))
     let nodeOptionList: OptionType[] = []
     nodeList?.forEach((item) => nodeOptionList.push(...item.options))
 
     const _selectedNode: OptionType =
-        nodeOptionList.find((data) => data.value === params.get('node')) ||
-        (node ? nodeOptionList.find((item) => item.value === node) : nodeList[0].options[0])
+        nodeOptionList?.find((data) => data.value === params.get('node')) ||
+        (node ? nodeOptionList?.find((item) => item.value === node) : nodeList[0]?.options[0])
 
     const _selectedShell = clusterShellList.find((shell) => shell.value === params.get('shell'))
 

--- a/src/components/cluster/cluster.util.ts
+++ b/src/components/cluster/cluster.util.ts
@@ -46,7 +46,7 @@ export function getClusterTerminalParamsData(
     clusterShellList: OptionType[],
     node: string,
 ): ClusterTerminalParamsType {
-    if(!nodeList) return emptyClusterTerminalParamsData
+    if (!nodeList) return emptyClusterTerminalParamsData
     const _selectedImage = imageList.find((image) => image.value === params.get('image'))
     const _selectedNamespace = namespaceList.find((namespace) => namespace.value === params.get('namespace'))
     let nodeOptionList: OptionType[] = []

--- a/src/components/common/DynamicTabs/useTabs.ts
+++ b/src/components/common/DynamicTabs/useTabs.ts
@@ -13,7 +13,7 @@ export function useTabs(persistanceKey: string) {
         positionFixed: boolean,
         iconPath: string,
         dynamicTitle: string,
-        showNameOnSelect: boolean
+        showNameOnSelect: boolean,
     ) => {
         return {
             id,
@@ -25,10 +25,18 @@ export function useTabs(persistanceKey: string) {
             positionFixed,
             iconPath,
             dynamicTitle,
-            showNameOnSelect
+            showNameOnSelect,
         } as DynamicTabType
     }
 
+    /**
+     * To serialize tab data and store it in localStorage. The stored data can be retrieved
+     * when initializing tabs to maintain their state across page loads.
+     * 
+     * @param {DynamicTabType[]} _tabs - Array of tab data
+     * @param {Record<string, any>} [parsedTabsData] - (Optional) previously parsed tab data.
+     * @returns {string} - JSON string representing tab data
+     */
     const stringifyData = (_tabs: any[], parsedTabsData?: Record<string, any>) => {
         let _parsedTabsData: Record<string, any> = {}
 
@@ -47,48 +55,88 @@ export function useTabs(persistanceKey: string) {
             data: _tabs,
         })
     }
-
+    
+    /**
+     * Populates tab data for initializing a new tab.
+     * 
+     * @param {InitTabType} _initTab - Data for initializing the new tab 
+     * @param {number} idx - Index to determine if the tab should be selected 
+     * @returns {DynamicTabType} - Tab data for initialization
+     */
     const populateInitTab = (_initTab: InitTabType, idx: number) => {
         const url = `${_initTab.url}${_initTab.url.endsWith('/') ? '' : '/'}`
         const title = _initTab.kind ? `${_initTab.kind}/${_initTab.name}` : _initTab.name
         const _id = `${_initTab.idPrefix}-${title}`
-        return populateTabData(_id, title, url, idx === 0, title, _initTab.positionFixed, _initTab.iconPath, _initTab.dynamicTitle, _initTab.showNameOnSelect)
+        return populateTabData(
+            _id,
+            title,
+            url,
+            idx === 0,
+            title,
+            _initTab.positionFixed,
+            _initTab.iconPath,
+            _initTab.dynamicTitle,
+            _initTab.showNameOnSelect,
+        )
     }
 
-    const initTabs = (initTabsData: InitTabType[], reInit?: boolean, tabsToRemove?:string[]) => {
+    /**
+     * This function initializes the tabs with an array of InitTabType objects.
+     * It allows for reinitializing tabs,removing specific tabs, and ensuring
+     * that tabs are not duplicated. It uses localStorage to store and retrieve tab data.
+     * 
+     * @param {InitTabType[]} initTabsData - An array of initial tab data
+     * @param {boolean} [reInit=false] - If true, re-initialize the tabs
+     * @param {string[]} [tabsToRemove] - An array of tab IDs to be removed
+     * @returns {DynamicTabType[]} - An array of initialized tabs 
+     */
+    const initTabs = (initTabsData: InitTabType[], reInit?: boolean, tabsToRemove?: string[]) => {
         let _tabs: DynamicTabType[] = []
         let parsedTabsData: Record<string, any> = {}
-                setTabs((prevTabs)=>{
-                    if (!reInit) {
-                        const persistedTabsData = localStorage.getItem('persisted-tabs-data')
-                        try {
-                            parsedTabsData = JSON.parse(persistedTabsData)
-                            _tabs = persistedTabsData ? parsedTabsData.data : prevTabs
-                        } catch (err) {
-                            _tabs = prevTabs
-                        }
+        setTabs((prevTabs) => {
+            if (!reInit) {
+                const persistedTabsData = localStorage.getItem('persisted-tabs-data')
+                try {
+                    parsedTabsData = JSON.parse(persistedTabsData)
+                    _tabs = persistedTabsData ? parsedTabsData.data : prevTabs
+                } catch (err) {
+                    _tabs = prevTabs
+                }
+            }
+            if (_tabs.length > 0) {
+                if (tabsToRemove?.length) {
+                    _tabs = _tabs.filter((_tab) => tabsToRemove.indexOf(_tab.id) === -1)
+                }
+                const tabNames = _tabs.map((_tab) => _tab.name)
+                initTabsData.forEach((_initTab, idx) => {
+                    if (!tabNames.includes(_initTab.name)) {
+                        _tabs.push(populateInitTab(_initTab, idx))
                     }
-                    if (_tabs.length > 0) {
-                        if (tabsToRemove?.length) {
-                            _tabs = _tabs.filter((_tab) => tabsToRemove.indexOf(_tab.id) === -1)
-                        }
-                        const tabNames = _tabs.map((_tab) => _tab.name)
-                        initTabsData.forEach((_initTab, idx) => {
-                            if (!tabNames.includes(_initTab.name)) {
-                                _tabs.push(populateInitTab(_initTab, idx))
-                            }
-                        })
-                    } else {
-                        initTabsData.forEach((_initTab, idx) => {
-                            _tabs.push(populateInitTab(_initTab, idx))
-                        })
-                    }
-                    localStorage.setItem('persisted-tabs-data', stringifyData(_tabs, parsedTabsData))
-                    return _tabs
-
+                })
+            } else {
+                initTabsData.forEach((_initTab, idx) => {
+                    _tabs.push(populateInitTab(_initTab, idx))
+                })
+            }
+            localStorage.setItem('persisted-tabs-data', stringifyData(_tabs, parsedTabsData))
+            return _tabs
         })
     }
 
+    /**
+     * This function allows adding new tabs. It checks if a tab with a similar title already exists,
+     * and if so, it updates the existing tab. Otherwise, it adds a new tab to the collection.
+     * 
+     * @param {string} idPrefix - Prefix for generating tab IDs 
+     * @param {string} kind - Kind of tab 
+     * @param {string} name - Name of the tab 
+     * @param {string} url - URL for the tab 
+     * @param {boolean} [positionFixed] - Whether the tab's position is fixed 
+     * @param {string} [iconPath] - Path to the tab's icon 
+     * @param {string} [dynamicTitle] - Dynamic title for the tab 
+     * @param {boolean} [showNameOnSelect] - Whether to show the tab name when selected 
+     * @returns {boolean} True if the tab was successfully added
+     */
     const addTab = (
         idPrefix: string,
         kind: string,
@@ -97,15 +145,15 @@ export function useTabs(persistanceKey: string) {
         positionFixed?: boolean,
         iconPath?: string,
         dynamicTitle?: string,
-        showNameOnSelect?: boolean
+        showNameOnSelect?: boolean,
     ): boolean => {
         if (!name || !url || !kind) return
 
         const title = `${kind}/${name}`
         let alreadyAdded = false
         const _id = `${idPrefix}-${title}`
-        
-        setTabs((prevTabs)=>{
+
+        setTabs((prevTabs) => {
             const _tabs = prevTabs.map((tab) => {
                 tab.isSelected = false
                 if (tab.title.toLowerCase() === title.toLowerCase() && tab.id === _id) {
@@ -115,54 +163,76 @@ export function useTabs(persistanceKey: string) {
                 }
                 return tab
             })
-    
+
             if (!alreadyAdded) {
-                _tabs.push(populateTabData(_id, title, url, true, title, positionFixed, iconPath, dynamicTitle, showNameOnSelect))
+                _tabs.push(
+                    populateTabData(
+                        _id,
+                        title,
+                        url,
+                        true,
+                        title,
+                        positionFixed,
+                        iconPath,
+                        dynamicTitle,
+                        showNameOnSelect,
+                    ),
+                )
             }
             localStorage.setItem('persisted-tabs-data', stringifyData(_tabs))
             return _tabs
-
         })
         return true
     }
 
+    /**
+     * This function removes a tab by its identifier (id). If the removed tab was selected,
+     * it ensures that another tab becomes selected.
+     * 
+     * @param {string} id - The identifier of the tab to be removed 
+     * @returns {string} - URL of the tab to navigate to after removal
+     */
     const removeTabByIdentifier = (id: string): string => {
-      let pushURL = ''
-      let selectedRemoved = false
-      setTabs((prevTabs)=>{
-        const _tabs = prevTabs.filter((tab) => {
-            if (tab.id === id) {
-                selectedRemoved = tab.isSelected
-                return false
-            }
-            return true
-        })
-  
-        if (selectedRemoved) {
-            _tabs[0].isSelected = true
-            pushURL = _tabs[0].url
-        }
-  
-        localStorage.setItem('persisted-tabs-data', stringifyData(_tabs))
-        return _tabs
+        let pushURL = ''
+        let selectedRemoved = false
+        setTabs((prevTabs) => {
+            const _tabs = prevTabs.filter((tab) => {
+                if (tab.id === id) {
+                    selectedRemoved = tab.isSelected
+                    return false
+                }
+                return true
+            })
 
-      })
-      return pushURL
+            if (selectedRemoved) {
+                _tabs[0].isSelected = true
+                pushURL = _tabs[0].url
+            }
+
+            localStorage.setItem('persisted-tabs-data', stringifyData(_tabs))
+            return _tabs
+        })
+        return pushURL
     }
 
+    /**
+     * Stops or deactivate a tab by its title.
+     * 
+     * @param {string} title - The title of the tab to be stopped 
+     * @returns {string} - URL of the tab to navigate to after stopping
+     */
     const stopTabByIdentifier = (title: string): string => {
         let pushURL = ''
         let selectedRemoved = false
-       
 
-        setTabs((prevTabs)=>{
+        setTabs((prevTabs) => {
             const _tabs = prevTabs.map((tab) => {
                 if (tab.title.toLowerCase() === title.toLowerCase()) {
                     selectedRemoved = tab.isSelected
                     return {
                         ...tab,
                         url: tab.url.split('?')[0],
-                        isSelected: false
+                        isSelected: false,
                     }
                 } else return tab
             })
@@ -172,12 +242,21 @@ export function useTabs(persistanceKey: string) {
             }
             localStorage.setItem('persisted-tabs-data', stringifyData(_tabs))
             return _tabs
-
         })
-        
+
         return pushURL
     }
 
+    /**
+     * This function is used to mark a tab as active based on its identifier (id or title).
+     * It can also update the URL associated with the tab
+     * 
+     * @param {string} idPrefix - Prefix for generating tab IDs
+     * @param {string} name - Name of the tab 
+     * @param {string} kind - Kind of tab 
+     * @param {string} [url] - URL for the tab 
+     * @returns {boolean} - True if the tab was found and marked as active
+     */
     const markTabActiveByIdentifier = (idPrefix: string, name: string, kind?: string, url?: string) => {
         if (!name) return
 
@@ -188,8 +267,8 @@ export function useTabs(persistanceKey: string) {
         }
 
         const _id = `${idPrefix}-${title}`
-        
-        setTabs((prevTabs)=>{
+
+        setTabs((prevTabs) => {
             const _tabs = prevTabs.map((tab) => {
                 tab.isSelected = false
                 if (tab.title.toLowerCase() === title.toLowerCase() && tab.id === _id) {
@@ -201,12 +280,17 @@ export function useTabs(persistanceKey: string) {
             })
             localStorage.setItem('persisted-tabs-data', stringifyData(_tabs))
             return _tabs
-
-
         })
         return isTabFound
     }
 
+    /**
+     * This function marks a tab as deleted by its identifier.
+     * 
+     * @param {string} idPrefix - Prefix for generating tab IDs 
+     * @param {string} name - Name of the tab 
+     * @param {string} kind - Kind of tab 
+     */
     const markTabResourceDeletedByIdentifier = (idPrefix: string, name: string, kind?: string) => {
         let title = name
         if (kind) {
@@ -214,7 +298,7 @@ export function useTabs(persistanceKey: string) {
         }
 
         const _id = `${idPrefix}-${title}`
-        setTabs((prevTabs)=>{
+        setTabs((prevTabs) => {
             const _tabs = prevTabs.map((tab) => {
                 if (tab.title.toLowerCase() === title.toLowerCase() && tab.id === _id) {
                     tab.isDeleted = true
@@ -223,13 +307,19 @@ export function useTabs(persistanceKey: string) {
             })
             localStorage.setItem('persisted-tabs-data', stringifyData(_tabs))
             return _tabs
-
         })
     }
 
+    /**
+     * Updates the URL of a tab by its identifier.
+     * 
+     * @param {string} id - Identifier of the tab to update 
+     * @param {string} url - New URL for the tab 
+     * @param {string} [dynamicTitle] - Dynamic title for the tab 
+     */
     const updateTabUrl = (id: string, url: string, dynamicTitle?: string) => {
-        setTabs((prevTabs)=>{
-            const _tabs=prevTabs.map((tab) => {
+        setTabs((prevTabs) => {
+            const _tabs = prevTabs.map((tab) => {
                 if (tab.id === id) {
                     tab.url = url
                     tab.dynamicTitle = dynamicTitle || ''
@@ -249,6 +339,6 @@ export function useTabs(persistanceKey: string) {
         markTabActiveByIdentifier,
         markTabResourceDeletedByIdentifier,
         updateTabUrl,
-        stopTabByIdentifier
+        stopTabByIdentifier,
     }
 }

--- a/src/components/common/helpers/Helpers.tsx
+++ b/src/components/common/helpers/Helpers.tsx
@@ -823,6 +823,7 @@ export const convertToOptionsList = (
     customValue?: string,
     customFieldKey?: string,
 ): OptionType[] => {
+    if(!Array.isArray(arr) || !arr) return [];
     return arr.map((ele) => {
         const _option = {
             label: customLabel ? ele[customLabel] : ele,
@@ -1024,8 +1025,9 @@ export const trackByGAEvent = (category: string, action: string): void => {
 }
 
 export const createGroupSelectList = (list, nodeLabel): SelectGroupType[] => {
+    if(!list) return []
     let emptyHeadingCount = 0
-    const objList: Record<string, OptionType[]> = list.reduce((acc, obj) => {
+    const objList: Record<string, OptionType[]> = list?.reduce((acc, obj) => {
         if (obj.nodeGroup) {
             emptyHeadingCount++
         }

--- a/src/components/common/helpers/Helpers.tsx
+++ b/src/components/common/helpers/Helpers.tsx
@@ -609,7 +609,7 @@ export function useEventSource(
     return eventSourceRef.current
 }
 
-export function useDebouncedEffect(callback, delay, deps: unknown[] = [] ) {
+export function useDebouncedEffect(callback, delay, deps: unknown[] = []) {
     // function will be executed only after the specified time once the user stops firing the event.
     const firstUpdate = useRef(true)
     useEffect(() => {
@@ -823,7 +823,7 @@ export const convertToOptionsList = (
     customValue?: string,
     customFieldKey?: string,
 ): OptionType[] => {
-    if(!Array.isArray(arr) || !arr) return [];
+    if (!Array.isArray(arr) || !arr) return []
     return arr.map((ele) => {
         const _option = {
             label: customLabel ? ele[customLabel] : ele,
@@ -1025,7 +1025,7 @@ export const trackByGAEvent = (category: string, action: string): void => {
 }
 
 export const createGroupSelectList = (list, nodeLabel): SelectGroupType[] => {
-    if(!list) return []
+    if (!list) return []
     let emptyHeadingCount = 0
     const objList: Record<string, OptionType[]> = list?.reduce((acc, obj) => {
         if (obj.nodeGroup) {
@@ -1128,5 +1128,5 @@ export const hasApproverAccess = (approverList: string[]): boolean => {
 }
 
 export const getNonEditableChartRepoText = (name: string): string => {
-   return `Cannot edit chart repo "${name}". Some charts from this repository are being used by helm apps.`
+    return `Cannot edit chart repo "${name}". Some charts from this repository are being used by helm apps.`
 }

--- a/src/components/v2/appDetails/appDetails.type.ts
+++ b/src/components/v2/appDetails/appDetails.type.ts
@@ -422,6 +422,7 @@ export interface TerminalComponentProps {
     selectedContainerName: string
     setSelectedContainerName: React.Dispatch<React.SetStateAction<string>>
     switchSelectedContainer: (string) => void
+    showTerminal: boolean
 }
 
 export interface NodeTreeTabListProps extends LogSearchTermType {

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Terminal.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Terminal.component.tsx
@@ -38,6 +38,7 @@ function TerminalComponent({
     setSelectedContainerName,
     switchSelectedContainer,
     setContainers,
+    showTerminal
 }: TerminalComponentProps) {
     const params = useParams<{ actionName: string; podName: string; nodeType: string; node: string, clusterId?: string; namespace: string }>()
     const { url } = useRouteMatch()
@@ -193,6 +194,10 @@ function TerminalComponent({
     }, [params.podName, params.node, params.namespace])
 
     useEffect(() => {
+        selectedTab(NodeDetailTab.TERMINAL, url)
+    }, [showTerminal])
+
+    useEffect(() => {
         setSelectedContainerName(_selectedContainer)
     }, [containers])
     useEffect(() => {
@@ -300,13 +305,15 @@ function TerminalComponent({
     }
 
     return (
-        <TerminalWrapper
+        <div className={`${showTerminal ? '' : 'pod-terminal-hidden'}`}>
+            <TerminalWrapper
             dataTestId="terminal-editor-header"
             selectionListData={selectionListData}
             socketConnection={socketConnection}
             setSocketConnection={setSocketConnection}
             className={isResourceBrowserView ? 'k8s-resource-view-container' : 'terminal-view-container'}
         />
+        </div>
     )
 }
 

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/nodeDetailTab.scss
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/nodeDetailTab.scss
@@ -216,3 +216,7 @@
     visibility: hidden;
     height: 0;
 }
+
+.pod-terminal-hidden * {
+    height: 0 !important;
+}

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/nodeDetailTab.scss
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/nodeDetailTab.scss
@@ -185,27 +185,34 @@
     }
 }
 
-.code-editor-container{
+.code-editor-container {
     height: 100%;
     background: var(--N50);
     border: 0;
     border-radius: none;
 
-    .code-editor__header{
+    .code-editor__header {
         background-color: var(--N000);
     }
 
-    .react-monaco-editor-container, .overflow-guard {
-        height: calc(100vh - 178px)!important;
+    .react-monaco-editor-container,
+    .overflow-guard {
+        height: calc(100vh - 178px) !important;
     }
-    .monaco-editor{
-        .monaco-editor-background, .margin {
+    .monaco-editor {
+        .monaco-editor-background,
+        .margin {
             background-color: var(--N50) !important;
         }
         height: calc(100vh - 178px) !important;
     }
-    .radio-group{
+    .radio-group {
         border: 1px solid var(--N200);
         border-radius: 4px;
     }
+}
+
+.pod-terminal-hidden {
+    visibility: hidden;
+    height: 0;
 }

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/Terminal.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/Terminal.tsx
@@ -33,11 +33,11 @@ export default function TerminalView({
 
     function resizeSocket() {
         if (terminalRef.current && fitAddon && isTerminalTab) {
-            const dim = fitAddon.proposeDimensions()
+            const dim = fitAddon?.proposeDimensions()
             if (dim && socket.current?.readyState === WebSocket.OPEN) {
                 socket.current?.send(JSON.stringify({ Op: 'resize', Cols: dim.cols, Rows: dim.rows }))
             }
-            fitAddon.fit()
+            fitAddon?.fit()
         }
     }
 
@@ -97,7 +97,7 @@ export default function TerminalView({
             registerLinkMatcher(terminalRef.current)
         }
         terminalRef.current.loadWebfontAndOpen(document.getElementById('terminal-id'))
-        fitAddon.fit()
+        fitAddon?.fit()
         terminalRef.current.reset()
         terminalRef.current.attachCustomKeyEventHandler((event) => {
             if ((event.metaKey && event.key === 'k') || event.key === 'K') {
@@ -192,7 +192,7 @@ export default function TerminalView({
     useEffect(() => {
         if (firstMessageReceived) {
             if (isTerminalTab) {
-                fitAddon.fit()
+                fitAddon?.fit()
             }
             terminalRef.current.setOption('cursorBlink', true)
             setSocketConnection(SocketConnectionType.CONNECTED)

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/Terminal.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/Terminal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState} from 'react'
+import React, { useEffect, useRef, useState} from 'react'
 import { elementDidMount, useHeightObserver } from '../../../../../../common/helpers/Helpers'
 import CopyToast, { handleSelectionChange } from '../CopyToast'
 import { Terminal } from 'xterm'
@@ -11,8 +11,6 @@ import { TERMINAL_STATUS } from './constants'
 import './terminal.scss'
 import { TerminalViewType } from './terminal.type'
 
-let socket
-let terminal
 let fitAddon
 let clusterTimeOut
 
@@ -28,15 +26,16 @@ export default function TerminalView({
     clearTerminal,
     dataTestId
 }: TerminalViewType) {
+    const socket = useRef(null)
     const [firstMessageReceived, setFirstMessageReceived] = useState(false)
     const [isReconnection, setIsReconnection] = useState(false)
     const [popupText, setPopupText] = useState<boolean>(false)
 
     function resizeSocket() {
-        if (terminal && fitAddon && isTerminalTab) {
+        if (terminalRef.current && fitAddon && isTerminalTab) {
             const dim = fitAddon.proposeDimensions()
-            if (dim && socket?.readyState === WebSocket.OPEN) {
-                socket?.send(JSON.stringify({ Op: 'resize', Cols: dim.cols, Rows: dim.rows }))
+            if (dim && socket.current?.readyState === WebSocket.OPEN) {
+                socket.current?.send(JSON.stringify({ Op: 'resize', Cols: dim.cols, Rows: dim.rows }))
             }
             fitAddon.fit()
         }
@@ -45,12 +44,12 @@ export default function TerminalView({
     const [myDivRef] = useHeightObserver(resizeSocket)
 
     useEffect(() => {
-        if (!terminal) {
+        if (!terminalRef.current) {
             elementDidMount('#terminal-id').then(() => {
                 createNewTerminal()
             })
         }
-        if (sessionId && terminal) {
+        if (sessionId && terminalRef.current) {
             setIsReconnection(true)
             postInitialize(sessionId)
         } else {
@@ -69,15 +68,15 @@ export default function TerminalView({
             if (clusterTimeOut) {
                 clearTimeout(clusterTimeOut)
             }
-            if (socket) {
-                socket.close()
-                socket = undefined
+            if (socket.current) {
+                socket.current.close()
+                socket.current = undefined
             }
         }
     }, [socketConnection])
 
     const createNewTerminal = () => {
-        terminal = new Terminal({
+        terminalRef.current = new Terminal({
             scrollback: 99999,
             fontSize: 14,
             lineHeight: 1.4,
@@ -89,21 +88,20 @@ export default function TerminalView({
                 foreground: '#FFFFFF',
             },
         })
-        terminalRef.current = terminal
-        handleSelectionChange(terminal, setPopupText)
+        handleSelectionChange(terminalRef.current, setPopupText)
         fitAddon = new FitAddon()
         const webFontAddon = new XtermWebfont()
-        terminal.loadAddon(fitAddon)
-        terminal.loadAddon(webFontAddon)
+        terminalRef.current.loadAddon(fitAddon)
+        terminalRef.current.loadAddon(webFontAddon)
         if (typeof registerLinkMatcher === 'function') {
-            registerLinkMatcher(terminal)
+            registerLinkMatcher(terminalRef.current)
         }
-        terminal.loadWebfontAndOpen(document.getElementById('terminal-id'))
+        terminalRef.current.loadWebfontAndOpen(document.getElementById('terminal-id'))
         fitAddon.fit()
-        terminal.reset()
-        terminal.attachCustomKeyEventHandler((event) => {
+        terminalRef.current.reset()
+        terminalRef.current.attachCustomKeyEventHandler((event) => {
             if ((event.metaKey && event.key === 'k') || event.key === 'K') {
-                terminal?.clear()
+                terminalRef.current?.clear()
             }
 
             return true
@@ -119,12 +117,12 @@ export default function TerminalView({
     const postInitialize = (sessionId: string) => {
         const socketURL = generateSocketURL()
 
-        socket?.close()
+        socket.current?.close()
         setFirstMessageReceived(false)
 
-        socket = new SockJS(socketURL)
-        const _socket = socket
-        const _terminal = terminal
+        socket.current = new SockJS(socketURL)
+        const _socket = socket.current
+        const _terminal = terminalRef.current
         const _fitAddon = fitAddon
 
         const disableInput = (): void => {
@@ -141,7 +139,7 @@ export default function TerminalView({
         _terminal.onData(function (data) {
             resizeSocket()
             const inData = { Op: 'stdin', SessionID: '', Data: data }
-            if (_socket.readyState === WebSocket.OPEN) {
+            if (_socket?.readyState === WebSocket.OPEN) {
                 _socket?.send(JSON.stringify(inData))
             }
         })
@@ -153,7 +151,7 @@ export default function TerminalView({
             const startData = { Op: 'bind', SessionID: sessionId }
             _socket.send(JSON.stringify(startData))
 
-            let dim = _fitAddon.proposeDimensions()
+            let dim = _fitAddon?.proposeDimensions()
             if (dim) {
                 _socket.send(JSON.stringify({ Op: 'resize', Cols: dim.cols, Rows: dim.rows }))
             }
@@ -196,7 +194,7 @@ export default function TerminalView({
             if (isTerminalTab) {
                 fitAddon.fit()
             }
-            terminal.setOption('cursorBlink', true)
+            terminalRef.current.setOption('cursorBlink', true)
             setSocketConnection(SocketConnectionType.CONNECTED)
         }
     }, [firstMessageReceived, isTerminalTab])
@@ -215,20 +213,20 @@ export default function TerminalView({
         setSocketConnection(SocketConnectionType.CONNECTING)
 
         return () => {
-            socket?.close()
-            terminal?.dispose()
-            socket = undefined
+            socket.current?.close()
+            terminalRef.current?.dispose()
+            socket.current = undefined
             terminalRef.current = undefined
-            terminal = undefined
+            terminalRef.current = undefined
             fitAddon = undefined
             clearTimeout(clusterTimeOut)
         }
     }, [])
 
     useEffect(() => {
-        if (terminal) {
-            terminal.clear()
-            terminal.focus()
+        if (terminalRef.current) {
+            terminalRef.current.clear()
+            terminalRef.current.focus()
         }
     }, [clearTerminal])
 


### PR DESCRIPTION
# Description

**Steps:**

1. Open a terminal connection using the Resource Browser
2. Now open a new Resource 
3. switch back to the last terminal

**Actual Output:**

We are initiating the new session instead of resuming the old session of the terminal

**Implementation:**

Keep the terminal instance hidden behind the `visibility: hidden` css so that the session and the socket connection keep running in the background.

Fixes #1405

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested multiple tab switches and notice if the session of terminal persists or a new session is being created everytime
- [x] Whenever user navigates away and comes back to Resource browser and select a cluster and open the default terminal tab => a new session is started, which persists on tab switches within the cluster.

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas

# Video post changes:

https://github.com/devtron-labs/dashboard/assets/146105157/1263172d-d794-4d95-a8b8-c659cccf937a


