### PR TITLE
fix: CSS fix

### DIFF
--- a/src/components/ApplicationGroup/Details/TriggerView/EnvTriggerView.scss
+++ b/src/components/ApplicationGroup/Details/TriggerView/EnvTriggerView.scss
@@ -19,14 +19,6 @@
     }
 }
 
-.filter-divider {
-    width: 1px;
-    height: 20px;
-    background-color: var(--N200);
-    margin-left: 12px;
-    margin-right: 12px;
-}
-
 .bulk-ci-trigger-container {
     .bulk-ci-trigger {
         display: grid;

--- a/src/components/ApplicationGroup/Details/TriggerView/EnvTriggerView.scss
+++ b/src/components/ApplicationGroup/Details/TriggerView/EnvTriggerView.scss
@@ -19,6 +19,14 @@
     }
 }
 
+.filter-divider-env {
+    width: 1px;
+    height: 20px;
+    background-color: var(--N200);
+    margin-left: 12px;
+    margin-right: 12px;
+}
+
 .bulk-ci-trigger-container {
     .bulk-ci-trigger {
         display: grid;

--- a/src/components/ApplicationGroup/Details/TriggerView/EnvTriggerView.tsx
+++ b/src/components/ApplicationGroup/Details/TriggerView/EnvTriggerView.tsx
@@ -2181,7 +2181,7 @@ export default function EnvTriggerView({ filteredAppIds, isVirtualEnv }: AppGrou
                         Change branch
                     </span>
                 </button>
-                <span className="filter-divider"></span>
+                <span className="filter-divider-env"></span>
                 <button
                     className="cta flex h-36 mr-12"
                     data-testid="bulk-build-image-button"

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -3149,6 +3149,10 @@ textarea,
     max-height: 390px !important;
 }
 
+.min-h {
+    min-height: 100%
+}
+
 // Height in percentage
 .h-100 {
     height: 100%;

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -3149,7 +3149,7 @@ textarea,
     max-height: 390px !important;
 }
 
-.min-h {
+.min-h-100 {
     min-height: 100%
 }
 


### PR DESCRIPTION
# Description

App list > Filter dropdown spacing fixtures and protection configuration background colour should be same while scrolling down which changes when it exceeds height beyond 100.

Fixes #1418 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] By refreshing the App list page and comparing the spacing between the filter dropdown and visiting the Protect configuration page checking the bg color 


# Checklist:

* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have performed a self-review of my own code
* [X] I have commented my code, particularly in hard-to-understand areas


