### PR TITLE
fix: API calls aborting on landing cluster-overview page

### DIFF
--- a/src/components/ClusterNodes/ClusterOverview.tsx
+++ b/src/components/ClusterNodes/ClusterOverview.tsx
@@ -212,7 +212,7 @@ function ClusterOverview({
     const getClusterNoteAndCapacity = async (clusterId: string): Promise<void> => {
         setErrorMsg('')
         setIsLoading(true)
-
+        sideDataAbortController.new = new AbortController()
         const [clusterNoteResponse, clusterCapacityResponse] = await Promise.allSettled([
             getClusterDetails(clusterId, sideDataAbortController.new.signal),
             getClusterCapacity(clusterId, sideDataAbortController.new.signal),
@@ -509,21 +509,23 @@ function ClusterOverview({
                         <div className="fs-13 fw-4 lh-20 cn-7 mb-4">Region</div>
                         <div className="fs-13 fw-6 lh-20 cn-9 dc__ellipsis-right">{clusterInfo.Region}</div>
                     </div> */}
-                    <div>
-                        <div className="fs-13 fw-4 lh-20 cn-7 mb-4">Server URL</div>
-                        <div className="flexbox">
-                            <div className="fs-13 fw-6 lh-20 cn-9 dc__ellipsis-right mr-6">
-                                {clusterDetails.serverURL}
+                    {clusterDetails.serverURL && (
+                        <div>
+                            <div className="fs-13 fw-4 lh-20 cn-7 mb-4">Server URL</div>
+                            <div className="flexbox">
+                                <div className="fs-13 fw-6 lh-20 cn-9 dc__ellipsis-right mr-6">
+                                    {clusterDetails.serverURL}
+                                </div>
+                                <ClipboardButton
+                                    content={clusterDetails.serverURL}
+                                    copiedTippyText="Copied Server URL"
+                                    duration={1000}
+                                    trigger={triggerCopy}
+                                    setTrigger={setTriggerCopy}
+                                />
                             </div>
-                            <ClipboardButton
-                                content={clusterDetails.serverURL}
-                                copiedTippyText="Copied Server URL"
-                                duration={1000}
-                                trigger={triggerCopy}
-                                setTrigger={setTriggerCopy}
-                            />
                         </div>
-                    </div>
+                    )}
                     <div>
                         <div className="fs-13 fw-4 lh-20 cn-7 mb-4">Added on</div>
                         <div className="fs-13 fw-6 lh-20 cn-9 dc__ellipsis-right">{clusterDetails.addedOn}</div>


### PR DESCRIPTION
# Description
Fix the cluster details and cluster note API calls aborting even before landing on the cluster overview page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


