### PR TITLE
fix: Persist cluster terminal logs on switching back from pod terminal

### DIFF
--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetail.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetail.component.tsx
@@ -76,7 +76,9 @@ function NodeDetailComponent({
     const [selectedContainerName, setSelectedContainerName] = useState(_selectedContainer)
     useEffect(() => toggleManagedFields(isManagedFields), [selectedTabName])
     useEffect(() => {
-        if (location.pathname.includes('/terminal')) setStartTerminal(true)
+        if (location.pathname.includes('/terminal') && params.nodeType === Nodes.Pod.toLowerCase()) {
+            setStartTerminal(true)
+        }
     }, [location])
 
     useEffect(() => {

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/Terminal.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/Terminal.tsx
@@ -11,7 +11,6 @@ import { TERMINAL_STATUS } from './constants'
 import './terminal.scss'
 import { TerminalViewType } from './terminal.type'
 
-let fitAddon
 let clusterTimeOut
 
 export default function TerminalView({
@@ -30,14 +29,15 @@ export default function TerminalView({
     const [firstMessageReceived, setFirstMessageReceived] = useState(false)
     const [isReconnection, setIsReconnection] = useState(false)
     const [popupText, setPopupText] = useState<boolean>(false)
+    const fitAddon = useRef(null)
 
     function resizeSocket() {
-        if (terminalRef.current && fitAddon && isTerminalTab) {
-            const dim = fitAddon?.proposeDimensions()
+        if (terminalRef.current && fitAddon.current && isTerminalTab) {
+            const dim = fitAddon.current?.proposeDimensions()
             if (dim && socket.current?.readyState === WebSocket.OPEN) {
                 socket.current?.send(JSON.stringify({ Op: 'resize', Cols: dim.cols, Rows: dim.rows }))
             }
-            fitAddon?.fit()
+            fitAddon.current?.fit()
         }
     }
 
@@ -89,15 +89,15 @@ export default function TerminalView({
             },
         })
         handleSelectionChange(terminalRef.current, setPopupText)
-        fitAddon = new FitAddon()
+        fitAddon.current = new FitAddon()
         const webFontAddon = new XtermWebfont()
-        terminalRef.current.loadAddon(fitAddon)
+        terminalRef.current.loadAddon(fitAddon.current)
         terminalRef.current.loadAddon(webFontAddon)
         if (typeof registerLinkMatcher === 'function') {
             registerLinkMatcher(terminalRef.current)
         }
         terminalRef.current.loadWebfontAndOpen(document.getElementById('terminal-id'))
-        fitAddon?.fit()
+        fitAddon.current?.fit()
         terminalRef.current.reset()
         terminalRef.current.attachCustomKeyEventHandler((event) => {
             if ((event.metaKey && event.key === 'k') || event.key === 'K') {
@@ -123,7 +123,7 @@ export default function TerminalView({
         socket.current = new SockJS(socketURL)
         const _socket = socket.current
         const _terminal = terminalRef.current
-        const _fitAddon = fitAddon
+        const _fitAddon = fitAddon.current
 
         const disableInput = (): void => {
             _terminal.setOption('cursorBlink', false)
@@ -192,7 +192,7 @@ export default function TerminalView({
     useEffect(() => {
         if (firstMessageReceived) {
             if (isTerminalTab) {
-                fitAddon?.fit()
+                fitAddon.current?.fit()
             }
             terminalRef.current.setOption('cursorBlink', true)
             setSocketConnection(SocketConnectionType.CONNECTED)
@@ -218,7 +218,7 @@ export default function TerminalView({
             socket.current = undefined
             terminalRef.current = undefined
             terminalRef.current = undefined
-            fitAddon = undefined
+            fitAddon.current = null
             clearTimeout(clusterTimeOut)
         }
     }, [])


### PR DESCRIPTION
# Description

Persist cluster terminal logs on switching  back from pod terminal

Fixes #1422 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Tested by switching between cluster terminal and pod terminal to check whether the old logs of cluster terminal retained or not

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


