### PR TITLE
fix: overflow issue in md editor, set shimmer loaders rows to 3

### DIFF
--- a/src/components/app/Overview/Overview.tsx
+++ b/src/components/app/Overview/Overview.tsx
@@ -413,7 +413,7 @@ export default function AppOverview({ appMetaInfo, getAppMetaInfoRes, filteredEn
             return (
                 <div className="app-overview-wrapper flexbox-col dc__gap-12">
                     <RadioGroup
-                        className="gui-yaml-switch gui-yaml-switch-window-bg flex-justify-start dc__no-background-imp"
+                        className="gui-yaml-switch gui-yaml-switch--lg gui-yaml-switch-window-bg flex-justify-start dc__no-background-imp"
                         name="overview-tabs"
                         initialTab={OVERVIEW_TABS.ABOUT}
                         disabled={false}
@@ -438,7 +438,7 @@ export default function AppOverview({ appMetaInfo, getAppMetaInfoRes, filteredEn
             return (
                 <div className="app-overview-wrapper flexbox-col dc__gap-12">
                     <RadioGroup
-                        className="gui-yaml-switch gui-yaml-switch-window-bg flex-justify-start dc__no-background-imp"
+                        className="gui-yaml-switch gui-yaml-switch--lg gui-yaml-switch-window-bg flex-justify-start dc__no-background-imp"
                         name="overview-tabs"
                         initialTab={OVERVIEW_TABS.ABOUT}
                         disabled={false}

--- a/src/components/app/Overview/constants.ts
+++ b/src/components/app/Overview/constants.ts
@@ -1,12 +1,12 @@
-import { AppEnvironment } from "../../../services/service.types";
+import { AppEnvironment } from '../../../services/service.types'
 
 /**
  * Mock data for the shimmer loader
  */
-export const loadingEnvironmentList: AppEnvironment[] = Array.from(Array(10).keys()).map(index => ({
-        environmentId: index,
-        environmentName: '',
-        appMetrics: false,
-        infraMetrics: false,
-        prod: false,
-    }))
+export const loadingEnvironmentList: AppEnvironment[] = Array.from(Array(3).keys()).map((index) => ({
+    environmentId: index,
+    environmentName: '',
+    appMetrics: false,
+    infraMetrics: false,
+    prod: false,
+}))

--- a/src/components/common/Description/GenericDescription.tsx
+++ b/src/components/common/Description/GenericDescription.tsx
@@ -330,7 +330,8 @@ export default function GenericDescription({
                         </div>
                         <ReactMde
                             classes={{
-                                reactMde: 'mark-down-editor-container pb-16 pt-8 mark-down-editor__no-border',
+                                reactMde:
+                                    'mark-down-editor-container dc__word-break pb-16 pt-8 mark-down-editor__no-border',
                                 toolbar: 'mark-down-editor__hidden',
                                 preview: 'mark-down-editor-preview dc__bottom-radius-4',
                                 textArea: 'mark-down-editor__hidden',
@@ -348,7 +349,7 @@ export default function GenericDescription({
                         <ReactMde
                             ref={mdeRef}
                             classes={{
-                                reactMde: `mark-down-editor-container ${
+                                reactMde: `mark-down-editor-container dc__word-break ${
                                     initialEditDescriptionView ? '' : 'create-app-description'
                                 }`,
                                 toolbar: 'mark-down-editor-toolbar tab-description',

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -1414,6 +1414,16 @@ button.anchor {
             }
         }
     }
+
+    &--lg {
+        &.radio-group {
+            height: 30px;
+
+            input + .radio__item-label {
+                padding-inline: 8px;
+            }
+        }
+    }
 }
 
 .manual-approvals-switch {


### PR DESCRIPTION
# Description

- fix overflow issue in MD Editor
- Set the shimmer loader rows to 3 for Environment List
- Add lg variant for the yaml switch

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


