### PR TITLE
fix: Auto trim https:// or oci:// in registry URL 

### DIFF
--- a/src/components/dockerRegistry/Docker.tsx
+++ b/src/components/dockerRegistry/Docker.tsx
@@ -341,6 +341,7 @@ function DockerForm({
         state.registryType.value === RegistryType.GCR || state.registryType.value === RegistryType.ARTIFACT_REGISTRY
             ? password.substring(1, password.length - 1)
             : password
+
     const [customState, setCustomState] = useState({
         awsAccessKeyId: { value: awsAccessKeyId, error: '' },
         awsSecretAccessKey: {
@@ -526,7 +527,7 @@ function DockerForm({
                     OCIRegistryStorageConfig?.CHART === OCIRegistryConfigConstants.PULL)
                     ? customState.repositoryList?.value.split(',') || []
                     : null,
-            registryUrl: customState.registryUrl.value,
+            registryUrl: customState.registryUrl.value.replace(/^https?:\/\//, '').replace(/^oci?:\/\//, ''),
             ...(selectedDockerRegistryType.value === RegistryType.ECR
                 ? {
                       awsAccessKeyId: customState.awsAccessKeyId.value?.trim(),

--- a/src/components/dockerRegistry/Docker.tsx
+++ b/src/components/dockerRegistry/Docker.tsx
@@ -527,7 +527,10 @@ function DockerForm({
                     OCIRegistryStorageConfig?.CHART === OCIRegistryConfigConstants.PULL)
                     ? customState.repositoryList?.value.split(',') || []
                     : null,
-            registryUrl: customState.registryUrl.value.replace(/^https?:\/\//, '').replace(/^oci?:\/\//, ''),
+            registryUrl: customState.registryUrl.value.replace(/^https?:\/\//, '')
+                .replace(/^oci?:\/\//, '')
+                .replace(/^docker?:\/\//, '')
+                .replace(/^http?:\/\//, ''),
             ...(selectedDockerRegistryType.value === RegistryType.ECR
                 ? {
                       awsAccessKeyId: customState.awsAccessKeyId.value?.trim(),


### PR DESCRIPTION
# Description

Auto trim https:// or oci:// in registry URL 

<img width="838" alt="Screenshot 2023-11-06 at 8 08 21 AM" src="https://github.com/devtron-labs/dashboard/assets/61836271/4a2384bd-73c9-4a95-b30c-fb868dd2c744">


Fixes https://github.com/devtron-labs/devtron/issues/4074

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


