### PR TITLE
fix: build history no pipeline

### DIFF
--- a/src/components/ApplicationGroup/AppGroup.types.ts
+++ b/src/components/ApplicationGroup/AppGroup.types.ts
@@ -277,6 +277,7 @@ interface CIPipeline {
     id: number
     parentCiPipeline: number
     parentAppId: number
+    pipelineType?: string
 }
 export interface CIConfigListType {
     pipelineList: CIPipeline[]

--- a/src/components/ApplicationGroup/Details/EnvCIDetails/EnvCIDetails.tsx
+++ b/src/components/ApplicationGroup/Details/EnvCIDetails/EnvCIDetails.tsx
@@ -12,7 +12,7 @@ import {
     FetchIdDataStatus,
 } from '../../../app/details/cicdHistory/types'
 import { Details } from '../../../app/details/cIDetails/CIDetails'
-import { CiPipeline } from '../../../app/details/triggerView/types'
+import { CiPipeline, PipelineType } from '../../../app/details/triggerView/types'
 import { getTriggerHistory } from '../../../app/service'
 import { asyncWrap, mapByKey, useInterval } from '../../../common'
 import { getCIConfigList } from '../../AppGroup.service'
@@ -30,6 +30,7 @@ export default function EnvCIDetails({ filteredAppIds }: AppGroupDetailDefaultTy
     const [triggerHistory, setTriggerHistory] = useState<Map<number, History>>(new Map())
     const [fullScreenView, setFullScreenView] = useState<boolean>(false)
     const [hasMoreLoading, setHasMoreLoading] = useState<boolean>(false)
+    // There seems to be typing issue since result gives CIPipeline here it is CiPipeline
     const [pipelineList, setPipelineList] = useState<CiPipeline[]>([])
     const [ciGroupLoading, setCiGroupLoading] = useState(false)
     const [securityModuleInstalled, setSecurityModuleInstalled] = useState(false)
@@ -47,11 +48,18 @@ export default function EnvCIDetails({ filteredAppIds }: AppGroupDetailDefaultTy
                     const _filteredPipelines = []
                     let selectedPipelineExist = false
                     result.pipelineList.forEach((pipeline) => {
+                        if (pipeline.pipelineType === PipelineType.LINKED_CD) {
+                            return
+                        }
+
                         _filteredPipelines.push(pipeline)
                         selectedPipelineExist = selectedPipelineExist || pipeline.id === +pipelineId
                     })
                     _filteredPipelines.sort((a, b) => sortCallback('appName', a, b))
-                    if (!selectedPipelineExist) {
+                    if (!_filteredPipelines.length && pipelineId) {
+                        replace(generatePath(path, { envId }))
+                    }
+                    else if (!selectedPipelineExist && _filteredPipelines.length ) {
                         replace(generatePath(path, { envId, pipelineId: _filteredPipelines[0].id }))
                     }
                     setPipelineList(_filteredPipelines)

--- a/src/components/app/details/cIDetails/CIDetails.tsx
+++ b/src/components/app/details/cIDetails/CIDetails.tsx
@@ -157,7 +157,7 @@ export default function CIDetails({ isJobView, filteredEnvIds }: { isJobView?: b
     const selectedPipelineExist = !pipelineId || pipelines.find((pipeline) => pipeline.id === +pipelineId)
 
     if (!pipelines.length && pipelineId) {
-        // reason is un-requried params like logs were leaking
+        // reason is un-required params like logs were leaking
         replace(generatePath(path, { appId }))
     }
     else if ((pipelines.length === 1 && !pipelineId) || (!selectedPipelineExist && pipelines.length)) {

--- a/src/components/app/details/cIDetails/CIDetails.tsx
+++ b/src/components/app/details/cIDetails/CIDetails.tsx
@@ -148,15 +148,19 @@ export default function CIDetails({ isJobView, filteredEnvIds }: { isJobView?: b
 
     if ((!hasMoreLoading && loading) || initDataLoading || (pipelineId && dependencyState[0] !== pipelineId)) {
         return <Progressing pageLoader />
-    } else if (!buildId && triggerHistory.size > 0) {
+    } else if (pipelineId && !buildId && triggerHistory.size > 0) {
         replace(generatePath(path, { buildId: triggerHistory.entries().next().value[0], appId, pipelineId }))
     }
     const pipelines: CIPipeline[] = (initDataResults[0]?.['value']?.['result'] || [])?.filter(
         (pipeline) => pipeline.pipelineType !== 'EXTERNAL' && pipeline.pipelineType !== PipelineType.LINKED_CD,
     ) // external and LINKED_CD pipelines not visible in dropdown
     const selectedPipelineExist = !pipelineId || pipelines.find((pipeline) => pipeline.id === +pipelineId)
-    // TODO: Look into this
-    if ((pipelines.length === 1 && !pipelineId) || (!selectedPipelineExist && pipelines.length)) {
+
+    if (!pipelines.length && pipelineId) {
+        // reason is un-requried params like logs were leaking
+        replace(generatePath(path, { appId }))
+    }
+    else if ((pipelines.length === 1 && !pipelineId) || (!selectedPipelineExist && pipelines.length)) {
         replace(generatePath(path, { appId, pipelineId: pipelines[0].id }))
     }
     const pipelineOptions: CICDSidebarFilterOptionType[] = (pipelines || []).map((item) => {


### PR DESCRIPTION
# Description
In CI Details (Build History tab) if we are viewing any log and filter env that is attached to no-source app then the page would either break or data will be retained to sidebar.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


