### PR TITLE
fix: ConfigMap Truncates for Long Integers

### DIFF
--- a/src/components/CIPipelineN/CustomImageTags.tsx
+++ b/src/components/CIPipelineN/CustomImageTags.tsx
@@ -270,7 +270,6 @@ function CustomImageTags({
                     </div>
                     <div className="" style={{ width: '32px', height: '20px' }}>
                         <Toggle
-                            disabled={window._env_.FORCE_SECURITY_SCANNING && formData.enableCustomTag}
                             selected={formData.enableCustomTag}
                             onSelect={handleCustomTagToggle}
                             dataTestId="create-build-pipeline-custom-tag-enabled-toggle"

--- a/src/components/ConfigMapSecret/ConfigMapSecret.components.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecret.components.tsx
@@ -677,8 +677,8 @@ export function ProtectedConfigMapSecretDetails({
     return selectedTab === 2 ? renderDiffView() : renderForm()
 }
 
-export const convertToValidValue = (k: any): string => {
-     if (typeof k !== 'string' && k !== false && k !== true && k !== '') {
+export const convertToValidValue = (k: any): string => {  
+     if (k !== false && k !== true && k !== '' && !isNaN(Number(k))) {
         return Number(k).toString()
     }
     return k.toString()

--- a/src/components/ConfigMapSecret/ConfigMapSecret.components.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecret.components.tsx
@@ -679,9 +679,9 @@ export function ProtectedConfigMapSecretDetails({
 
 export const convertToValidValue = (k: any): string => {
      if (k !== false && k !== true && k !== '' && Number(isNaN(k))) {
-        return Number(k).toString()
-    }
-    return k.toString()
+         return Number(k).toString()
+     }
+     return k.toString()
 }
 
 export function validateKeyValuePair(arr: KeyValue[]): KeyValueValidated {

--- a/src/components/ConfigMapSecret/ConfigMapSecret.components.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecret.components.tsx
@@ -678,10 +678,10 @@ export function ProtectedConfigMapSecretDetails({
 }
 
 export const convertToValidValue = (k: any): string => {
-     if (k !== false && k !== true && k !== '' && Number(isNaN(k))) {
-         return Number(k).toString()
-     }
-     return k.toString()
+     if (typeof k !== 'string' && k !== false && k !== true && k !== '') {
+        return Number(k).toString()
+    }
+    return k.toString()
 }
 
 export function validateKeyValuePair(arr: KeyValue[]): KeyValueValidated {

--- a/src/components/ConfigMapSecret/ConfigMapSecret.components.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecret.components.tsx
@@ -678,7 +678,7 @@ export function ProtectedConfigMapSecretDetails({
 }
 
 export const convertToValidValue = (k: any): string => {
-    if (k !== false && k !== true && k !== '' && !isNaN(Number(k))) {
+     if (k !== false && k !== true && k !== '' && Number(isNaN(k))) {
         return Number(k).toString()
     }
     return k.toString()

--- a/src/components/ConfigMapSecret/ConfigMapSecret.components.tsx
+++ b/src/components/ConfigMapSecret/ConfigMapSecret.components.tsx
@@ -677,9 +677,12 @@ export function ProtectedConfigMapSecretDetails({
     return selectedTab === 2 ? renderDiffView() : renderForm()
 }
 
-export const convertToValidValue = (k: any): string => {  
-     if (k !== false && k !== true && k !== '' && !isNaN(Number(k))) {
-        return Number(k).toString()
+export const convertToValidValue = (k: any): string => {
+    if (k !== false && k !== true && k !== '' && !isNaN(Number(k))) {
+        //Note: all long integers  & floating values in "double quotes" with spaces will be handled in this check
+        // eg val: "123678765678756764\n" or val: "1234.67856756787676\n" or "1276767634.67856\n" to trim down \n
+        const replacePattern = /\s/g
+        return k.toString().replace(replacePattern, '')
     }
     return k.toString()
 }


### PR DESCRIPTION
# Description

When saving a key-value pair with a decimal value in a ConfigMap, values with more than four decimal places are being truncated or rounded, resulting in a loss of data.

Fixes https://github.com/devtron-labs/devtron/issues/4345

testing with:
value1: 1
value2: |
  1234\n
value3: "shivam\n1"
value4: |
   dsdsdds\n\n
value5: 466
value6: |
  123.2
value7: 1234555
value8: shivam\n1
value9: |
  abc: 
    xyz: 123

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


