### PR TITLE
fix: node delete propagation

### DIFF
--- a/src/components/workflowEditor/nodes/CDNode.tsx
+++ b/src/components/workflowEditor/nodes/CDNode.tsx
@@ -45,7 +45,13 @@ export class CDNode extends Component<CDNodeProps, CDNodeState> {
     }
 
     handleDeleteCDNode = (e: React.MouseEvent) => {
+        e.stopPropagation()
         e.preventDefault()
+
+        if (this.props.deploymentAppDeleteRequest) {
+            this.onClickShowDeletePipelinePopup()
+            return
+        }
         this.setState({ showDeleteDialog: true })
     }
 


### PR DESCRIPTION
# Description
Adding stopPropagation for deleteCDNode for upfront delete in CDNode, this will stop the trigger happening in onClick of Link tag

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


