### PR TITLE
feat: separate configOverrideWorkflows api call from CIConfig

### DIFF
--- a/src/components/ciConfig/CIConfig.tsx
+++ b/src/components/ciConfig/CIConfig.tsx
@@ -2,11 +2,10 @@ import React, { useState, useEffect } from 'react'
 import { sortObjectArrayAlphabetically } from '../common'
 import { showError, Progressing} from '@devtron-labs/devtron-fe-common-lib'
 import { getDockerRegistryMinAuth } from './service'
-import { getSourceConfig, getCIConfig, getConfigOverrideWorkflowDetails } from '../../services/service'
+import { getSourceConfig, getCIConfig } from '../../services/service'
 import { useParams } from 'react-router-dom'
 import { ComponentStates } from '../EnvironmentOverride/EnvironmentOverrides.type'
 import { CIConfigProps } from './types'
-import { ConfigOverrideWorkflowDetails } from '../../services/service.types'
 import './CIConfig.scss'
 import CIConfigForm from './CIConfigForm'
 
@@ -27,7 +26,6 @@ export default function CIConfig({
     const [dockerRegistries, setDockerRegistries] = useState(parentState?.dockerRegistries)
     const [sourceConfig, setSourceConfig] = useState(parentState?.sourceConfig)
     const [ciConfig, setCIConfig] = useState(parentState?.ciConfig)
-    const [configOverrideWorkflows, setConfigOverrideWorkflows] = useState<ConfigOverrideWorkflowDetails[]>([])
     const [parentReloading, setParentReloading] = useState(false)
     const [loading, setLoading] = useState(
         configOverrideView && parentState?.loadingState === ComponentStates.loaded ? false : true,
@@ -47,12 +45,10 @@ export default function CIConfig({
                 { result: dockerRegistries },
                 { result: sourceConfig },
                 { result: ciConfig },
-                { result: configOverrideWorkflows },
             ] = await Promise.all([
                 getDockerRegistryMinAuth(appId),
                 getSourceConfig(appId),
                 getCIConfig(+appId),
-                getConfigOverrideWorkflowDetails(appId),
             ])
             Array.isArray(dockerRegistries) && sortObjectArrayAlphabetically(dockerRegistries, 'id')
             setDockerRegistries(dockerRegistries || [])
@@ -61,7 +57,6 @@ export default function CIConfig({
                 sortObjectArrayAlphabetically(sourceConfig.material, 'name')
             setSourceConfig(sourceConfig)
             setCIConfig(ciConfig)
-            setConfigOverrideWorkflows(configOverrideWorkflows?.workflows || [])
 
             if (setParentState) {
                 setParentState({
@@ -137,7 +132,6 @@ export default function CIConfig({
             reload={reload}
             appId={appId}
             selectedCIPipeline={parentState?.selectedCIPipeline}
-            configOverrideWorkflows={configOverrideWorkflows}
             configOverrideView={configOverrideView}
             allowOverride={allowOverride}
             updateDockerConfigOverride={updateDockerConfigOverride}

--- a/src/components/ciConfig/CIConfigDiffView.tsx
+++ b/src/components/ciConfig/CIConfigDiffView.tsx
@@ -1,24 +1,34 @@
-import React, { useState } from 'react'
-import { showError, Progressing, Drawer, DeleteDialog, noop, DockerConfigOverrideType } from '@devtron-labs/devtron-fe-common-lib'
+import React, { useEffect, useState } from 'react'
+import {
+    showError,
+    Progressing,
+    Drawer,
+    DeleteDialog,
+    noop,
+    DockerConfigOverrideType,
+    Reload,
+} from '@devtron-labs/devtron-fe-common-lib'
 import { ReactComponent as CloseIcon } from '../../assets/icons/ic-cross.svg'
 import { ReactComponent as EditIcon } from '../../assets/icons/ic-pencil.svg'
 import { ReactComponent as DeleteIcon } from '../../assets/icons/ic-delete-interactive.svg'
 import { Workflow } from '../workflowEditor/Workflow'
 import { Link, useHistory, useLocation, useParams, useRouteMatch } from 'react-router-dom'
 import { URLS } from '../../config'
-import { CIConfigDiffViewProps } from './types'
+import { CIConfigDiffViewProps, ProcessedWorkflowsType } from './types'
 import { WorkflowType } from '../app/details/triggerView/types'
 import { CIBuildConfigDiff } from './CIBuildConfigDiff'
 import Tippy from '@tippyjs/react'
 import { getInitDataWithCIPipeline, saveCIPipeline } from '../ciPipeline/ciPipeline.service'
 import { toast } from 'react-toastify'
+import { ConfigOverrideWorkflowDetails } from '../../services/service.types'
+import { getConfigOverrideWorkflowDetails, getWorkflowList } from '../../services/service'
+import { WorkflowCreate } from '../app/details/triggerView/config'
+import { processWorkflow } from '../app/details/triggerView/workflow.service'
 
 export default function CIConfigDiffView({
     parentReloading,
     ciConfig,
     configOverridenPipelines,
-    configOverrideWorkflows,
-    processedWorkflows,
     toggleConfigOverrideDiffModal,
     reload,
     gitMaterials,
@@ -34,7 +44,43 @@ export default function CIConfigDiffView({
     const [showDeleteDialog, setShowDeleteDialog] = useState(false)
     const [deleteInProgress, setDeleteInProgress] = useState(false)
     const [selectedWFId, setSelectedWFId] = useState(0)
+    const [configOverrideWorkflows, setConfigOverrideWorkflows] = useState<ConfigOverrideWorkflowDetails[]>([])
+    const [processedWorkflows, setProcessedWorkflows] = useState<ProcessedWorkflowsType>({
+        workflows: [],
+    })
+    const [loading, setLoading] = useState<boolean>(true)
+    const [error, setError] = useState<boolean>(false)
+
+    const handleOnMountAPICalls = async () => {
+        setLoading(true)
+        setError(false)
+        try {
+            const [{ result: _configOverridenWorkflows }, { result: _processedWorkflows }] = await Promise.all([
+                getConfigOverrideWorkflowDetails(appId),
+                getWorkflowList(appId),
+            ])
+
+            const { workflows = [] } =
+                processWorkflow(_processedWorkflows, ciConfig, null, null, WorkflowCreate, WorkflowCreate.workflow) ||
+                {}
+
+            setProcessedWorkflows({ workflows })
+            setConfigOverrideWorkflows(_configOverridenWorkflows?.workflows ?? [])
+        } catch (e) {
+            showError(e)
+            setError(true)
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    useEffect(() => {
+        setLoading(true)
+        handleOnMountAPICalls()
+    }, [])
+
     const wfCIMap = new Map<number, number>()
+    // NOTE: Even on reload after delete the data is going to be stale since we are not updating configOverrideWorkflows
     const _configOverridenWorkflows = configOverrideWorkflows.filter((_cwf) => {
         const _ciPipeline = configOverridenPipelines?.find((_ci) => _ci.id === _cwf.ciPipelineId)
         if (!!_ciPipeline) {
@@ -173,48 +219,56 @@ export default function CIConfigDiffView({
         }
     }
 
+    const renderBodyContent = () => {
+        if (parentReloading || loading) {
+            return <Progressing pageLoader />
+        }
+
+        if (error) {
+            return <Reload reload={handleOnMountAPICalls} />
+        }
+
+        return _overridenWorkflows.map((_wf) => (
+            <div className="mb-20 dc__position-rel" key={_wf.id}>
+                <Workflow
+                    key={_wf.id}
+                    id={+_wf.id}
+                    name={_wf.name}
+                    startX={_wf.startX}
+                    startY={_wf.startY}
+                    height={getWorkflowHeight(_wf)}
+                    width={'100%'}
+                    nodes={_wf.nodes}
+                    history={history}
+                    location={location}
+                    match={match}
+                    handleCDSelect={noop}
+                    handleCISelect={noop}
+                    openEditWorkflow={noop}
+                    showDeleteDialog={noop}
+                    addCIPipeline={noop}
+                    addWebhookCD={noop}
+                    cdWorkflowList={_configOverridenWorkflows}
+                />
+                {renderViewBuildPipelineRow(+_wf.id)}
+                <CIBuildConfigDiff
+                    configOverridenWorkflows={_configOverridenWorkflows}
+                    wfId={_wf.id}
+                    configOverridenPipelines={configOverridenPipelines}
+                    materials={ciConfig?.materials}
+                    globalCIConfig={globalCIConfig}
+                    gitMaterials={gitMaterials}
+                />
+            </div>
+        ))
+    }
+
     return (
         <Drawer parentClassName="dc__overflow-hidden" position="right" width="87%" minWidth="1024px" maxWidth="1246px">
             <div className="modal__body modal__config-override-diff br-0 modal__body--p-0 dc__overflow-hidden">
                 {renderConfigDiffModalTitle()}
                 <div className="config-override-diff__view h-100 p-20 dc__window-bg dc__overflow-scroll">
-                    {parentReloading || processedWorkflows.processing ? (
-                        <Progressing pageLoader />
-                    ) : (
-                        _overridenWorkflows.map((_wf) => (
-                            <div className="mb-20 dc__position-rel">
-                                <Workflow
-                                    key={_wf.id}
-                                    id={+_wf.id}
-                                    name={_wf.name}
-                                    startX={_wf.startX}
-                                    startY={_wf.startY}
-                                    height={getWorkflowHeight(_wf)}
-                                    width={'100%'}
-                                    nodes={_wf.nodes}
-                                    history={history}
-                                    location={location}
-                                    match={match}
-                                    handleCDSelect={noop}
-                                    handleCISelect={noop}
-                                    openEditWorkflow={noop}
-                                    showDeleteDialog={noop}
-                                    addCIPipeline={noop}
-                                    addWebhookCD={noop}
-                                    cdWorkflowList={_configOverridenWorkflows}
-                                />
-                                {renderViewBuildPipelineRow(+_wf.id)}
-                                <CIBuildConfigDiff
-                                    configOverridenWorkflows={_configOverridenWorkflows}
-                                    wfId={_wf.id}
-                                    configOverridenPipelines={configOverridenPipelines}
-                                    materials={ciConfig?.materials}
-                                    globalCIConfig={globalCIConfig}
-                                    gitMaterials = {gitMaterials}
-                                />
-                            </div>
-                        ))
-                    )}
+                    {renderBodyContent()}
                 </div>
                 {showDeleteDialog && (
                     <DeleteDialog

--- a/src/components/ciConfig/CIConfigDiffView.tsx
+++ b/src/components/ciConfig/CIConfigDiffView.tsx
@@ -237,7 +237,7 @@ export default function CIConfigDiffView({
                     startX={_wf.startX}
                     startY={_wf.startY}
                     height={getWorkflowHeight(_wf)}
-                    width={'100%'}
+                    width="100%"
                     nodes={_wf.nodes}
                     history={history}
                     location={location}

--- a/src/components/ciConfig/CIConfigDiffView.tsx
+++ b/src/components/ciConfig/CIConfigDiffView.tsx
@@ -75,7 +75,6 @@ export default function CIConfigDiffView({
     }
 
     useEffect(() => {
-        setLoading(true)
         handleOnMountAPICalls()
     }, [])
 

--- a/src/components/ciConfig/CIConfigForm.tsx
+++ b/src/components/ciConfig/CIConfigForm.tsx
@@ -1,20 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import { toast } from 'react-toastify'
 import { DOCUMENTATION } from '../../config'
-import { getWorkflowList } from '../../services/service'
 import { OptionType } from '../app/types'
 import { CIPipelineBuildType, DockerConfigOverrideKeys } from '../ciPipeline/types'
 import { useForm } from '../common'
-import {
-    CIBuildConfigType,
-    CIBuildType,
-    showError,
-    ConfirmationDialog,
-} from '@devtron-labs/devtron-fe-common-lib'
+import { CIBuildConfigType, CIBuildType, showError, ConfirmationDialog } from '@devtron-labs/devtron-fe-common-lib'
 import { saveCIConfig, updateCIConfig } from './service'
-import { CIBuildArgType, CIConfigFormProps, LoadingState, ProcessedWorkflowsType } from './types'
-import { processWorkflow } from '../app/details/triggerView/workflow.service'
-import { WorkflowCreate } from '../app/details/triggerView/config'
+import { CIBuildArgType, CIConfigFormProps, LoadingState } from './types'
 import warningIconSrc from '../../assets/icons/ic-warning-y6.svg'
 import { ReactComponent as BookOpenIcon } from '../../assets/icons/ic-book-open.svg'
 import { ReactComponent as NextIcon } from '../../assets/icons/ic-arrow-right.svg'
@@ -39,7 +31,6 @@ export default function CIConfigForm({
     reload,
     appId,
     selectedCIPipeline,
-    configOverrideWorkflows,
     configOverrideView,
     allowOverride,
     updateDockerConfigOverride,
@@ -106,11 +97,9 @@ export default function CIConfigForm({
     const [showCustomPlatformWarning, setShowCustomPlatformWarning] = useState<boolean>(_customTargetPlatorm)
     const [showCustomPlatformConfirmation, setShowCustomPlatformConfirmation] = useState<boolean>(false)
     const [showConfigOverrideDiff, setShowConfigOverrideDiff] = useState<boolean>(false)
-    const [processedWorkflows, setProcessedWorkflows] = useState<ProcessedWorkflowsType>({
-        processing: false,
-        workflows: [],
-    })
-    const configOverridenPipelines = ciConfig?.ciPipelines?.filter((_ci) => _ci.isDockerConfigOverridden && _ci?.pipelineType !== CIPipelineBuildType.CI_JOB)
+    const configOverridenPipelines = ciConfig?.ciPipelines?.filter(
+        (_ci) => _ci.isDockerConfigOverridden && _ci?.pipelineType !== CIPipelineBuildType.CI_JOB,
+    )
     const [currentCIBuildConfig, setCurrentCIBuildConfig] = useState<CIBuildConfigType>(
         initCurrentCIBuildConfig(
             allowOverride,
@@ -268,31 +257,6 @@ export default function CIConfigForm({
         )
     }
 
-    // FIXME: Not using anywhere but after opening of modal, so move it to child component
-    const processFetchedWorkflows = async () => {
-        if (!processedWorkflows.processing) {
-            try {
-                setProcessedWorkflows({
-                    ...processedWorkflows,
-                    processing: true,
-                })
-                const { result } = await getWorkflowList(appId)
-                const { workflows } = processWorkflow(
-                    result,
-                    ciConfig,
-                    null,
-                    null,
-                    WorkflowCreate,
-                    WorkflowCreate.workflow,
-                )
-
-                setProcessedWorkflows({ processing: false, workflows })
-            } catch (err) {
-                showError(err)
-            }
-        }
-    }
-
     const handleOnChangeConfig = (e) => {
         handleOnChange(e)
 
@@ -336,9 +300,6 @@ export default function CIConfigForm({
 
     const toggleConfigOverrideDiffModal = () => {
         setShowConfigOverrideDiff(!showConfigOverrideDiff)
-        if (!showConfigOverrideDiff) {
-            processFetchedWorkflows()
-        }
     }
 
     const { repository, dockerfile, projectPath, registry, repository_name, buildContext, key, value } = state
@@ -434,13 +395,13 @@ export default function CIConfigForm({
                 </div>
             )}
             {showCustomPlatformConfirmation && renderConfirmationModal()}
+            {/* Might cause bug in future since we are toggling the state but directly closes the modal on empty workflow */}
+            {/* TODO: Connect with product if empty state is better? */}
             {configOverridenPipelines?.length > 0 && showConfigOverrideDiff && (
                 <CIConfigDiffView
                     parentReloading={parentReloading}
                     ciConfig={ciConfig}
                     configOverridenPipelines={configOverridenPipelines}
-                    configOverrideWorkflows={configOverrideWorkflows}
-                    processedWorkflows={processedWorkflows}
                     toggleConfigOverrideDiffModal={toggleConfigOverrideDiffModal}
                     reload={reload}
                     gitMaterials={sourceConfig.material}

--- a/src/components/ciConfig/types.tsx
+++ b/src/components/ciConfig/types.tsx
@@ -60,7 +60,6 @@ export interface CIConfigState {
 }
 
 export interface ProcessedWorkflowsType {
-    processing: boolean
     workflows: WorkflowType[]
 }
 
@@ -97,8 +96,6 @@ export interface CIConfigDiffViewProps {
     parentReloading: boolean
     ciConfig: CiPipelineResult
     configOverridenPipelines: CiPipeline[]
-    configOverrideWorkflows: ConfigOverrideWorkflowDetails[]
-    processedWorkflows: ProcessedWorkflowsType
     toggleConfigOverrideDiffModal: () => void
     reload: (skipPageReload?: boolean) => Promise<void>
     gitMaterials: any
@@ -112,7 +109,6 @@ export interface CIConfigFormProps {
     reload: (skipPageReload?: boolean) => Promise<void>
     appId: string
     selectedCIPipeline: CIPipelineDataType
-    configOverrideWorkflows: ConfigOverrideWorkflowDetails[]
     configOverrideView: boolean
     allowOverride: boolean
     updateDockerConfigOverride: (key: string, value: CIBuildConfigType | boolean | string) => void


### PR DESCRIPTION
# Description
Separating out component-names api call from ciConfig and moving it to modal on mount to save the state in case of error.
Fixes # (issue)
