### PR TITLE
fix: build env custom key

### DIFF
--- a/src/components/ciConfig/CIBuildpackBuildOptions.tsx
+++ b/src/components/ciConfig/CIBuildpackBuildOptions.tsx
@@ -428,7 +428,7 @@ export default function CIBuildpackBuildOptions({
          * - Else remove empty arg from buildEnvArgs array & proceed
          */
         if (_buildEnvArgs.length === 1 && !_buildEnvArgs[0].k && version !== AUTO_DETECT) {
-            if (isInitCall) {
+            if (isInitCall && builder.BuilderLangEnvParam) {
                 _buildEnvArgs[0].k = builder.BuilderLangEnvParam
                 _buildEnvArgs[0].v = version
                 setBuildEnvArgs(_buildEnvArgs)

--- a/src/components/v2/appDetails/k8Resource/nodeType/nodeType.scss
+++ b/src/components/v2/appDetails/k8Resource/nodeType/nodeType.scss
@@ -70,7 +70,7 @@
     .resource-action-tabs__clipboard {
         &:hover {
             path {
-                stroke: var(--B500);
+                fill: var(--B500);
             }
         }
     }


### PR DESCRIPTION
# Description
In case of build pack, if we set custom builder and save modal, then on re-opening we had a arg with no key but value as version so would removing the value as well.
Fixes # (issue)
