### PR TITLE
fix: align select text to end for ci materials

### DIFF
--- a/src/components/common/GitCommitInfoGeneric.tsx
+++ b/src/components/common/GitCommitInfoGeneric.tsx
@@ -256,7 +256,7 @@ export default function GitCommitInfoGeneric({
                             {_webhookData.data['git url'] ? (
                                 <a
                                     href={`${_webhookData.data['git url']}`}
-                                    target="_blank noopener noreferrer"
+                                    target="_blank"
                                     rel="noopener noreferer"
                                     className="dc__no-decor cb-5"
                                 >

--- a/src/components/common/GitCommitInfoGeneric.tsx
+++ b/src/components/common/GitCommitInfoGeneric.tsx
@@ -257,7 +257,7 @@ export default function GitCommitInfoGeneric({
                                 <a
                                     href={`${_webhookData.data['git url']}`}
                                     target="_blank"
-                                    rel="noopener noreferer"
+                                    rel="noopener noreferrer"
                                     className="dc__no-decor cb-5"
                                 >
                                     View git url

--- a/src/components/common/GitCommitInfoGeneric.tsx
+++ b/src/components/common/GitCommitInfoGeneric.tsx
@@ -256,7 +256,7 @@ export default function GitCommitInfoGeneric({
                             {_webhookData.data['git url'] ? (
                                 <a
                                     href={`${_webhookData.data['git url']}`}
-                                    target="_blank"
+                                    target="_blank noopener noreferrer"
                                     rel="noopener noreferer"
                                     className="dc__no-decor cb-5"
                                 >
@@ -265,7 +265,7 @@ export default function GitCommitInfoGeneric({
                             ) : null}
                         </div>
                         {selectedCommitInfo ? (
-                            <div className="material-history__select-text material-history__header">
+                            <div className="material-history__select-text flexbox dc__align-items-center dc__content-end fs-12">
                                 {_lowerCaseCommitInfo.isselected ? <Check className="dc__align-right" /> : 'Select'}
                             </div>
                         ) : null}


### PR DESCRIPTION
# Description
Fixed alignment issue selecting commit from select material modal, by aligning select to left.

Fixes https://github.com/devtron-labs/devtron/issues/4505

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Dev testing

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


