### PR TITLE
fix: restrict width of xterm to make it scrollable

### DIFF
--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/Terminal.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/Terminal.tsx
@@ -43,6 +43,18 @@ export default function TerminalView({
 
     const [myDivRef] = useHeightObserver(resizeSocket)
 
+    // To fix the scrollbar issue with Xterm in edit mode, we need to restrict the width and height of the xterm-accessibility div as same as xterm-screen div
+    // CON: In case of resize, we need to call this function again
+    const restrictXtermAccessibilityWidth = () => {
+        const xtermScreen = document.querySelector('.xterm-screen') as HTMLElement
+        const xtermAccessibility = document.querySelector('.xterm-accessibility') as HTMLElement
+
+        if (xtermScreen && xtermAccessibility) {
+            xtermAccessibility.style.width = xtermScreen.clientWidth + 'px'
+            xtermAccessibility.style.height = xtermScreen.clientHeight + 'px'
+        }
+    }
+
     useEffect(() => {
         if (!terminalRef.current) {
             elementDidMount('#terminal-id').then(() => {
@@ -51,6 +63,7 @@ export default function TerminalView({
         }
         if (sessionId && terminalRef.current) {
             setIsReconnection(true)
+            restrictXtermAccessibilityWidth()
             postInitialize(sessionId)
         } else {
             setSocketConnection(SocketConnectionType.DISCONNECTED)

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/Terminal.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/Terminal.tsx
@@ -10,6 +10,7 @@ import { CLUSTER_STATUS, SocketConnectionType } from '../../../../../../ClusterN
 import { TERMINAL_STATUS } from './constants'
 import './terminal.scss'
 import { TerminalViewType } from './terminal.type'
+import { restrictXtermAccessibilityWidth } from './terminal.utils'
 
 let clusterTimeOut
 
@@ -42,18 +43,6 @@ export default function TerminalView({
     }
 
     const [myDivRef] = useHeightObserver(resizeSocket)
-
-    // To fix the scrollbar issue with Xterm in edit mode, we need to restrict the width and height of the xterm-accessibility div as same as xterm-screen div
-    // CON: In case of resize, we need to call this function again
-    const restrictXtermAccessibilityWidth = () => {
-        const xtermScreen = document.querySelector('.xterm-screen') as HTMLElement
-        const xtermAccessibility = document.querySelector('.xterm-accessibility') as HTMLElement
-
-        if (xtermScreen && xtermAccessibility) {
-            xtermAccessibility.style.width = xtermScreen.clientWidth + 'px'
-            xtermAccessibility.style.height = xtermScreen.clientHeight + 'px'
-        }
-    }
 
     useEffect(() => {
         if (!terminalRef.current) {

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/terminal.utils.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/terminal.utils.tsx
@@ -320,3 +320,15 @@ export default function terminalStripTypeData(elementData) {
             return null
     }
 }
+
+// To fix the scrollbar issue with Xterm in edit mode, we need to restrict the width and height of the xterm-accessibility div as same as xterm-screen div
+// CON: In case of resize, we need to call this function again
+export const restrictXtermAccessibilityWidth = () => {
+    const xtermScreen = document.querySelector('.xterm-screen') as HTMLElement
+    const xtermAccessibility = document.querySelector('.xterm-accessibility') as HTMLElement
+
+    if (xtermScreen && xtermAccessibility) {
+        xtermAccessibility.style.width = xtermScreen.clientWidth + 'px'
+        xtermAccessibility.style.height = xtermScreen.clientHeight + 'px'
+    }
+}


### PR DESCRIPTION
# Description
In terminal, we are using editable xterm component which covers scrollbar, so using js we are restricting its width same as readonly editor so that it doesn't overlap with scrollbar .

Fixes https://github.com/devtron-labs/devtron/issues/4519
