### PR TITLE
fix: disable scan validation on job in CIPipeline

### DIFF
--- a/src/components/CIPipelineN/CIPipeline.tsx
+++ b/src/components/CIPipelineN/CIPipeline.tsx
@@ -559,7 +559,7 @@ export default function CIPipeline({
         validateStage(BuildStageVariable.Build, formData)
         validateStage(BuildStageVariable.PostBuild, formData)
         const scanValidation =
-            !isSecurityModuleInstalled || formData.scanEnabled || !window._env_.FORCE_SECURITY_SCANNING
+            isJobCard || !isSecurityModuleInstalled || formData.scanEnabled || !window._env_.FORCE_SECURITY_SCANNING
         if (!scanValidation) {
             setApiInProgress(false)
             toast.error('Scanning is mandatory, please enable scanning')
@@ -612,7 +612,7 @@ export default function CIPipeline({
             {
                 ...formData,
                 materials: _materials,
-                scanEnabled: isSecurityModuleInstalled ? formData.scanEnabled : false,
+                scanEnabled: !isJobCard && isSecurityModuleInstalled ? formData.scanEnabled : false,
             },
             _ciPipeline,
             _materials,


### PR DESCRIPTION
# Description

If we force enable security scanning of images, some jobs that don't have anything to do with images will throw errors in the logs when the job is triggered. Therefore security scanning is disabled in case of jobs even when enforced by the FORCE_SECURITY_CHECK env variable. 

fixes https://github.com/devtron-labs/devtron/issues/4757

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


