### PR TITLE
fix: retain search on reload in nodes tab of ResourceBrowser & show correct k8sVersion filter options

### DIFF
--- a/src/components/ClusterNodes/ColumnSelector.tsx
+++ b/src/components/ClusterNodes/ColumnSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useCallback } from 'react'
 import ReactSelect, { components, MultiValue } from 'react-select'
 import { Option } from '@devtron-labs/devtron-fe-common-lib'
 import { ColumnMetadataType } from './types'
@@ -86,6 +86,11 @@ export default function ColumnSelector() {
         setSelectedColumns(appliedColumns)
     }, [])
 
+    const renderMenuList = useCallback(
+        (props) => <MenuList {...props} selectRef={selectRef} />,
+        [selectRef]
+    )
+
     const handleMenuState = (menuOpenState: boolean): void => {
         if (menuOpenState) {
             setSelectedColumns(appliedColumns)
@@ -127,7 +132,7 @@ export default function ColumnSelector() {
                 ValueContainer,
                 IndicatorSeparator: null,
                 ClearIndicator: null,
-                MenuList: (props) => <MenuList {...props} selectRef={selectRef} />,
+                MenuList: renderMenuList,
             }}
             styles={{
                 ...containerImageSelectStyles,

--- a/src/components/ClusterNodes/NodeDetailsList.tsx
+++ b/src/components/ClusterNodes/NodeDetailsList.tsx
@@ -7,7 +7,7 @@ import { getNodeList } from './clusterNodes.service'
 import 'react-mde/lib/styles/css/react-mde-all.css'
 import { Pagination } from '../common'
 import { showError, Progressing, ConditionalWrap, ErrorScreenManager } from '@devtron-labs/devtron-fe-common-lib'
-import { ColumnMetadataType, TEXT_COLOR_CLASS, NodeDetail } from './types'
+import { ColumnMetadataType, TEXT_COLOR_CLASS, NodeDetail, SearchTextType } from './types'
 import { ReactComponent as Error } from '../../assets/icons/ic-error-exclamation.svg'
 import { OptionType } from '../app/types'
 import NodeListSearchFilter from './NodeListSearchFilter'
@@ -35,9 +35,9 @@ export default function NodeDetailsList({
     const history = useHistory()
     const urlParams = new URLSearchParams(location.search)
     const k8sVersion = urlParams.get('k8sversion') ? decodeURIComponent(urlParams.get('k8sversion')) : ''
-    const name = decodeURIComponent(urlParams.get('name') || '')
-    const label = decodeURIComponent(urlParams.get('label') || '')
-    const group = decodeURIComponent(urlParams.get('nodeGroup') || '')
+    const name = decodeURIComponent(urlParams.get(NODE_SEARCH_TEXT.NAME) || '')
+    const label = decodeURIComponent(urlParams.get(NODE_SEARCH_TEXT.LABEL) || '')
+    const group = decodeURIComponent(urlParams.get(NODE_SEARCH_TEXT.NODE_GROUP) || '')
     const [clusterDetailsLoader, setClusterDetailsLoader] = useState(false)
     const [errorResponseCode, setErrorResponseCode] = useState<number>()
     const [searchText, setSearchText] = useState(name || label || group || '')
@@ -49,7 +49,7 @@ export default function NodeDetailsList({
     )
 
     const initialSeachType = getInitialSearchType(name, label, group)
-    const [selectedSearchTextType, setSelectedSearchTextType] = useState<string>(initialSeachType)
+    const [selectedSearchTextType, setSelectedSearchTextType] = useState<SearchTextType | ''>(initialSeachType)
 
     const [sortByColumn, setSortByColumn] = useState<ColumnMetadataType>(COLUMN_METADATA[0])
     const [sortOrder, setSortOrder] = useState<string>(OrderBy.ASC)
@@ -57,7 +57,7 @@ export default function NodeDetailsList({
     const [appliedColumns, setAppliedColumns] = useState<MultiValue<ColumnMetadataType>>([])
     const [fixedNodeNameColumn, setFixedNodeNameColumn] = useState(false)
 
-    function getInitialSearchType(name: string, label: string, group: string): string {
+    function getInitialSearchType(name: string, label: string, group: string): SearchTextType | '' {
         if (name) {
             return NODE_SEARCH_TEXT.NAME
         }

--- a/src/components/ClusterNodes/NodeDetailsList.tsx
+++ b/src/components/ClusterNodes/NodeDetailsList.tsx
@@ -37,7 +37,7 @@ export default function NodeDetailsList({
     const k8sVersion = urlParams.get('k8sversion') ? decodeURIComponent(urlParams.get('k8sversion')) : ''
     const name = decodeURIComponent(urlParams.get('name') || '')
     const label = decodeURIComponent(urlParams.get('label') || '')
-    const group = decodeURIComponent(urlParams.get('group') || '')
+    const group = decodeURIComponent(urlParams.get('nodeGroup') || '')
     const [clusterDetailsLoader, setClusterDetailsLoader] = useState(false)
     const [errorResponseCode, setErrorResponseCode] = useState<number>()
     const [searchText, setSearchText] = useState(name || label || group || '')

--- a/src/components/ClusterNodes/constants.ts
+++ b/src/components/ClusterNodes/constants.ts
@@ -309,7 +309,7 @@ export const NODE_SEARCH_TEXT = {
     LABEL: 'label',
     LABELS: 'labels',
     NODE_GROUP: 'nodeGroup',
-}
+} as const
 
 export const clusterImageSelect = {
     ...clusterSelectStyle,
@@ -327,9 +327,9 @@ export const clusterImageSelect = {
 }
 
 export const SEARCH_OPTION_LABEL = {
-    NAME: 'name',
-    LABEL: 'label',
-    NODE_GROUP: 'nodeGroup',
+    NAME: NODE_SEARCH_TEXT.NAME,
+    LABEL: NODE_SEARCH_TEXT.LABEL,
+    NODE_GROUP: NODE_SEARCH_TEXT.NODE_GROUP,
     NODE_GROUP_TEXT: 'node group',
 }
 

--- a/src/components/ClusterNodes/types.ts
+++ b/src/components/ClusterNodes/types.ts
@@ -2,7 +2,7 @@ import React from 'react'
 import { MultiValue } from 'react-select'
 import { ResponseType } from '@devtron-labs/devtron-fe-common-lib'
 import { LabelTag, OptionType } from '../app/types'
-import { CLUSTER_PAGE_TAB } from './constants'
+import { CLUSTER_PAGE_TAB, NODE_SEARCH_TEXT } from './constants'
 import { EditModeType } from '../v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/constants'
 import { ApiResourceGroupType, ClusterOptionType, K8SObjectMapType } from '../ResourceBrowser/Types'
 
@@ -410,3 +410,5 @@ export interface ClusterOverviewProps {
         new: AbortController
     }
 }
+
+export type SearchTextType = (typeof NODE_SEARCH_TEXT)[keyof typeof NODE_SEARCH_TEXT]

--- a/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceBrowser/ResourceList/ResourceList.tsx
@@ -843,7 +843,7 @@ export default function ResourceList() {
                 <NodeDetailsList
                     clusterId={clusterId}
                     isSuperAdmin={superAdminRef.current}
-                    nodeK8sVersions={clusterCapacityData?.nodeK8sVersions}
+                    nodeK8sVersions={clusterCapacityData?.nodeK8sVersions || selectedTerminal?.nodeK8sVersions}
                     renderCallBackSync={renderRefreshBar}
                     addTab={addTab}
                     syncError={!hideSyncWarning}


### PR DESCRIPTION
# Description

This PR fixes the issue that caused search to not be retained on page refresh on "Nodes" tab of "Resource Browser".
Additionally it also fixes the issue where the k8sVersion filter options are not shown unless we move to clusterOverview first.

Fixes https://github.com/devtron-labs/devtron/issues/4774

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


