### PR TITLE
fix: security scan modal stop propagation

### DIFF
--- a/src/components/common/security/ScanDetailsModal.tsx
+++ b/src/components/common/security/ScanDetailsModal.tsx
@@ -238,9 +238,9 @@ export class ScanDetailsModal extends Component<ScanDetailsModalProps, ScanDetai
     render() {
         return (
             <Drawer position="right" width="800px" onEscape={this.props.close}>
-                <div className="modal-body--scan-details">
+                <div className="modal-body--scan-details" ref={this.scanDetailsRef}>
                     {this.renderHeader()}
-                    <div className="trigger-modal__body trigger-modal__body--security-scan" ref={this.scanDetailsRef}>
+                    <div className="trigger-modal__body trigger-modal__body--security-scan">
                         {this.state.view === ViewType.LOADING ? (
                             <Progressing pageLoader />
                         ) : this.state.view === ViewType.ERROR ? (

--- a/src/components/security/SecurityScansTab.tsx
+++ b/src/components/security/SecurityScansTab.tsx
@@ -498,7 +498,8 @@ export class SecurityScansTab extends Component<RouteComponentProps<{}>, Securit
                                 <tr
                                     key={scan.name}
                                     className="table__row"
-                                    onClick={() => {
+                                    onClick={(event) => {
+                                        event.stopPropagation()
                                         this.setState({
                                             name: scan.name,
                                             uniqueId: {


### PR DESCRIPTION
# Description
Security scanning modal used to get closed on clicking on its header and we were not able to open it through security tabs so had to add stopPropagation

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


