### PR TITLE
fix: figure correct bitbucket toggle (cloud or data center) state from config api response

### DIFF
--- a/src/components/gitOps/GitOpsConfiguration.tsx
+++ b/src/components/gitOps/GitOpsConfiguration.tsx
@@ -199,6 +199,12 @@ class GitOpsConfiguration extends Component<GitOpsProps, GitOpsState> {
                     host: GitHost[this.state.providerTab],
                     provider: GitProvider.GITHUB,
                 }
+                const isBitbucketCloud = response.result?.reduce((acc, item) => {
+                    if (item.provider !== 'BITBUCKET_CLOUD' && item.provider !== 'BITBUCKET_DC') {
+                        return acc
+                    }
+                    return item.provider === 'BITBUCKET_CLOUD'
+                }, true)
                 this.setState({
                     gitList: response.result || [],
                     saveLoading: false,
@@ -209,7 +215,7 @@ class GitOpsConfiguration extends Component<GitOpsProps, GitOpsState> {
                         ...form,
                         token: form.id && form.token === '' ? DEFAULT_SECRET_PLACEHOLDER : form.token,
                     },
-                    isBitbucketCloud: form.provider === GitProvider.BITBUCKET_CLOUD,
+                    isBitbucketCloud,
                     isError: DefaultShortGitOps,
                     isFormEdited: false,
                     allowCustomGitRepo: form.allowCustomRepository,
@@ -236,7 +242,7 @@ class GitOpsConfiguration extends Component<GitOpsProps, GitOpsState> {
             ...DefaultGitOpsConfig,
             ...DefaultShortGitOps,
             host: GitHost[newGitOps],
-            provider: newGitOps,
+            provider: gitListKey,
         }
         this.setState({
             providerTab: form.provider === 'BITBUCKET_DC' ? 'BITBUCKET_CLOUD' : form.provider,
@@ -246,7 +252,6 @@ class GitOpsConfiguration extends Component<GitOpsProps, GitOpsState> {
             },
             isError: DefaultShortGitOps,
             isFormEdited: false,
-            isBitbucketCloud: this.state.form.provider === GitProvider.BITBUCKET_CLOUD,
             validationStatus: VALIDATION_STATUS.DRY_RUN,
             isUrlValidationError: false,
         })


### PR DESCRIPTION
# Description

This pr fixes the logic in deciding the state of the Bitbucket toggle (that toggles between cloud and data center).

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


