### PR TITLE
fix: use active state to determine correct toggle state

### DIFF
--- a/src/components/gitOps/GitOpsConfiguration.tsx
+++ b/src/components/gitOps/GitOpsConfiguration.tsx
@@ -203,7 +203,7 @@ class GitOpsConfiguration extends Component<GitOpsProps, GitOpsState> {
                     if (item.provider !== 'BITBUCKET_CLOUD' && item.provider !== 'BITBUCKET_DC') {
                         return acc
                     }
-                    return item.provider === 'BITBUCKET_CLOUD'
+                    return item.provider === 'BITBUCKET_CLOUD' && item.active
                 }, true)
                 this.setState({
                     gitList: response.result || [],


### PR DESCRIPTION
# Description

fixes the issue where even if Bitbucket Data Center is set as default the toggle is switched to Bitbucket Cloud.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


