### PR TITLE
fix: resource tree tabs - hides when scroll to page bottom fix

### DIFF
--- a/src/components/v2/appDetails/k8Resource/K8Resource.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/K8Resource.component.tsx
@@ -64,7 +64,7 @@ export default function K8ResourceComponent({
                             isDevtronApp={isDevtronApp}
                         />
                     </div>
-                    <div className="flex-grow-1-imp dc__overflow-y-auto p-0" data-testid="k8-resources-node-details">
+                    <div className="flex-grow-1-imp p-0" data-testid="k8-resources-node-details">
                         <NodeComponent
                             handleFocusTabs={handleFocusTabs}
                             externalLinks={externalLinks}

--- a/src/components/v2/appDetails/k8Resource/NodeTreeTabList.scss
+++ b/src/components/v2/appDetails/k8Resource/NodeTreeTabList.scss
@@ -17,7 +17,7 @@
 .resource-tree-wrapper {
     box-shadow: inset 0 -1px 0 0 var(--N200);
     background-color: white;
-    padding-top: 12px;
+    padding-top: 8px;
 
     .resource-tree-tab {
         border-top: 1px solid var(--N200);

--- a/src/components/v2/appDetails/k8Resource/NodeTreeTabList.tsx
+++ b/src/components/v2/appDetails/k8Resource/NodeTreeTabList.tsx
@@ -116,8 +116,8 @@ export default function NodeTreeTabList({ logSearchTerms, setLogSearchTerms, tab
     return (
         <div
             data-testid="resource-tree-wrapper"
-            className="resource-tree-wrapper flexbox pl-20 pr-20"
-            style={{ outline: 'none' }}
+            className="resource-tree-wrapper flexbox pl-20 pr-20 dc__position-sticky dc__zi-10"
+            style={{ outline: 'none', top: '77px' }}
             tabIndex={0}
             ref={tabRef}
         >

--- a/src/components/v2/appDetails/k8Resource/k8resources.scss
+++ b/src/components/v2/appDetails/k8Resource/k8resources.scss
@@ -22,8 +22,7 @@
 }
 
 .resource-node-wrapper {
-    min-height: 600px;
-    height: calc(100vh - 168px);
+    min-height: calc(100vh - 168px);
 }
 
 .node-container-fluid {

--- a/src/components/v2/appDetails/k8Resource/k8resources.scss
+++ b/src/components/v2/appDetails/k8Resource/k8resources.scss
@@ -23,7 +23,7 @@
 
 .resource-node-wrapper {
     min-height: 600px;
-    height: calc(100vh - 288px);
+    height: calc(100vh - 168px);
 }
 
 .node-container-fluid {

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetail.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetail.component.tsx
@@ -343,9 +343,12 @@ const NodeDetailComponent = ({
                                             tab.toLowerCase() === selectedTabName.toLowerCase()
                                                 ? 'default-tab-row cb-5'
                                                 : 'cn-7'
-                                        } pt-6 pb-6 cursor pl-8 pr-8 top`}
+                                        } py-6 px-8 top`}
                                     >
-                                        <NavLink to={`${url}/${tab.toLowerCase()}`} className=" dc__no-decor flex left">
+                                        <NavLink
+                                            to={`${url}/${tab.toLowerCase()}`}
+                                            className=" dc__no-decor flex left cursor"
+                                        >
                                             <span
                                                 data-testid={`${tab.toLowerCase()}-nav-link`}
                                                 className={`${

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetail.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetail.component.tsx
@@ -328,7 +328,9 @@ const NodeDetailComponent = ({
 
     return (
         <>
-            <div className="w-100 pr-20 pl-20 bcn-0 flex dc__border-bottom dc__content-space">
+            <div
+                className={`w-100 pr-20 pl-20 bcn-0 flex dc__border-bottom dc__content-space ${!isResourceBrowserView ? 'node-detail__sticky' : ''}`}
+            >
                 <div className="flex left">
                     <div data-testid="app-resource-containor-header" className="flex left">
                         {tabs &&
@@ -397,11 +399,7 @@ const NodeDetailComponent = ({
             {renderPodTerminal()}
 
             {fetchingResource || (isResourceBrowserView && (loadingResources || !selectedResource)) ? (
-                <MessageUI
-                    msg=""
-                    icon={MsgUIType.LOADING}
-                    size={24}
-                />
+                <MessageUI msg="" icon={MsgUIType.LOADING} size={24} />
             ) : (
                 <Switch>
                     <Route path={`${path}/${NodeDetailTab.MANIFEST}`}>

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Events.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Events.component.tsx
@@ -84,13 +84,11 @@ const EventsComponent = ({
     const renderContent = () => {
         if (isDeleted) {
             return (
-                <div>
                     <MessageUI
                         msg={MESSAGING_UI.NO_RESOURCE}
                         size={32}
                         minHeight={isResourceBrowserView ? '200px' : ''}
                     />
-                </div>
             )
         }
 

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/EventsTable.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/EventsTable.tsx
@@ -36,7 +36,9 @@ export const EventsTable = ({ loading, eventsList, isResourceBrowserView, errorV
         }
         if (eventsList && eventsList.length > 0) {
             return (
-                <div data-testid="app-events-container" className="cn-0 h-100">
+                <div data-testid="app-events-container" className="cn-0 dc__overflow-auto" style={{
+                    height: isResourceBrowserView ? 'calc(100vh - 119px)' : 'calc(100vh - 155px)'
+                }}>
                     {errorValue?.status === TERMINAL_STATUS.TERMINATED && (
                         <div className="pl-20 h-24 flex left pr-20 w-100 bcr-7 cn-0">
                             {TERMINAL_TEXT.POD_TERMINATED}&nbsp; {errorValue.errorReason}&nbsp;
@@ -47,6 +49,7 @@ export const EventsTable = ({ loading, eventsList, isResourceBrowserView, errorV
                     )}
                     <table className="table pl-20">
                         <thead
+                            className='dc__position-sticky dc__top-0'
                             style={{
                                 minHeight: isResourceBrowserView ? '200px' : '600px',
                                 background: 'var(--terminal-bg)',

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
@@ -477,7 +477,7 @@ const LogsComponent = ({
         if (isLogAnalyzer) {
             return 'calc(100vh - 120px)'
         } else {
-            return isResourceBrowserView ? 'calc(100vh - 151px)' : 'calc(100vh - 155px)'
+            return isResourceBrowserView ? 'calc(100vh - 151px)' : 'calc(100vh - 187px)'
         }
     }
 

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Logs.component.tsx
@@ -107,7 +107,7 @@ const LogsComponent = ({
     const [newFilteredLogs, setNewFilteredLogs] = useState<boolean>(false)
     const [showCustomOptionsModal, setShowCustomOptionsMoadal] = useState(false)
     const [downloadInProgress, setDownloadInProgress] = useState(false)
-    const {isSuperAdmin} = useMainContext()
+    const { isSuperAdmin } = useMainContext()
     const getPrevContainerLogs = () => {
         setPrevContainer(!prevContainer)
     }
@@ -473,6 +473,14 @@ const LogsComponent = ({
         ]
     }
 
+    const getLogsContainerHeight = () => {
+        if (isLogAnalyzer) {
+            return 'calc(100vh - 120px)'
+        } else {
+            return isResourceBrowserView ? 'calc(100vh - 151px)' : 'calc(100vh - 155px)'
+        }
+    }
+
     return isDeleted ? (
         <MessageUI
             msg="This resource no longer exists"
@@ -771,7 +779,7 @@ const LogsComponent = ({
                         style={{
                             gridColumn: '1 / span 2',
                             background: '#0b0f22',
-                            height: isResourceBrowserView ? 'calc(100vh - 151px)' : 'calc(100vh - 77px)',
+                            height: getLogsContainerHeight(),
                         }}
                         className="flex flex-grow-1 column log-viewer-container"
                     >

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Manifest.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/Manifest.component.tsx
@@ -497,7 +497,7 @@ const ManifestComponent = ({
                         isResourceBrowserView ||
                         (appDetails.deploymentAppType === DeploymentAppTypes.GITOPS &&
                             appDetails.deploymentAppDeleteRequest)) && (
-                        <div className="flex left pl-20 pr-20 dc__border-bottom manifest-tabs-row">
+                        <div className={`flex left pl-20 pr-20 dc__border-bottom manifest-tabs-row ${!isResourceBrowserView ? 'manifest-tabs-row__position-sticky': ''}`}>
                             {tabs.map((tab: iLink, index) => {
                                 return (!showDesiredAndCompareManifest &&
                                     (tab.name == 'Helm generated manifest' || tab.name == 'Compare')) ||

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/nodeDetailTab.scss
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/nodeDetailTab.scss
@@ -191,6 +191,13 @@
 
 .manifest-tabs-row {
     height: 32px;
+    background-color: inherit;
+    
+    &__position-sticky {
+        position: sticky;
+        top: 155px;
+        z-index: 10;
+    }
 }
 
 .edit-icon {

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/terminal.scss
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/terminal.scss
@@ -17,7 +17,7 @@
 .k8s-resource-view-container {
     display: flex;
     flex-direction: column;
-    height: calc(100vh - 118px);
+    height: calc(100vh - 119px);
 }
 
 .terminal-view-container {

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/terminal.scss
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/terminal.scss
@@ -23,7 +23,7 @@
 .terminal-view-container {
     display: flex;
     flex-direction: column;
-    height: calc(100vh - 146px);
+    height: calc(100vh - 155px);
 }
 
 .terminal-view-wrapper {

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/nodeDetail.css
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/nodeDetail.css
@@ -56,3 +56,9 @@
     border-top-right-radius: 4px;
     margin: 0;
 }
+
+.node-detail__sticky {
+    position: sticky;
+    top: 120px;
+    z-index: 10;
+}

--- a/src/components/v2/common/message.ui.tsx
+++ b/src/components/v2/common/message.ui.tsx
@@ -64,7 +64,7 @@ const MessageUI: React.FC<MsgUIProps> = ({
     return (
         <div
             data-testid={dataTestId}
-            className={`dc__text-center h-100 flexbox flex-grow-1 dc__gap-8 dc__align-items-center dc__content-center ${theme || 'dark'}-background w-100 `}
+            className={`dc__text-center w-100 h-100 flexbox-col dc__content-center ${theme || 'dark'}-background`}
         >
             <div>
                 {(() => {


### PR DESCRIPTION
# Description

In resources tree tabs, when page is scrolled to the bottom the tabs hide behind the header.

# Expectation

The tabs should stick on the top of the page under header and the rest of the content should scroll without UI breaking.
 
Fixes https://github.com/devtron-labs/devtron/issues/5298

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


