### PR TITLE
fix: validateStage function now accepts an optional pluginDataStore

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "homepage": "/dashboard",
     "dependencies": {
-        "@devtron-labs/devtron-fe-common-lib": "0.1.7-beta-1",
+        "@devtron-labs/devtron-fe-common-lib": "0.1.7-beta-5",
         "@esbuild-plugins/node-globals-polyfill": "0.2.3",
         "@rjsf/core": "^5.13.3",
         "@rjsf/utils": "^5.13.3",

--- a/src/components/CIPipelineN/CIPipeline.tsx
+++ b/src/components/CIPipelineN/CIPipeline.tsx
@@ -395,7 +395,12 @@ export default function CIPipeline({
         return { index: stepsLength + 1, calculatedStageVariables: _inputVariablesListPerTask }
     }
 
-    const validateStage = (stageName: string, _formData: PipelineFormType, formDataErrorObject?): void => {
+    const validateStage = (
+        stageName: string,
+        _formData: PipelineFormType,
+        formDataErrorObject?: PipelineFormDataErrorType,
+        clonedPluginDataStore: typeof pluginDataStore = pluginDataStore,
+    ): void => {
         const _formDataErrorObj = {
             ...(formDataErrorObject ?? formDataErrorObj),
             name: validationRules.name(_formData.name),
@@ -432,7 +437,7 @@ export default function CIPipeline({
                 isStageValid = isStageValid && _formDataErrorObj[stageName].steps[i].isValid
             }
             if (mandatoryPluginData?.pluginData?.length && validatePlugins) {
-                setMandatoryPluginData(validatePlugins(formData, mandatoryPluginData.pluginData, pluginDataStore))
+                setMandatoryPluginData(validatePlugins(_formData, mandatoryPluginData.pluginData, clonedPluginDataStore))
             }
             _formDataErrorObj[stageName].isValid = isStageValid
         }

--- a/src/components/CIPipelineN/PluginDetailHeader.tsx
+++ b/src/components/CIPipelineN/PluginDetailHeader.tsx
@@ -49,7 +49,7 @@ const PluginDetailHeader = ({ handlePluginVersionChange }: PluginDetailHeaderPro
                         className: 'p-2 dc__no-shrink',
                     }}
                 />
-                <h4 className="cn-9 fs-14 fw-4 lh-24 dc__truncate dc__mxw-155">{name}</h4>
+                <h4 className="cn-9 fs-14 fw-4 lh-24 dc__truncate dc__mxw-155 m-0">{name}</h4>
 
                 <ReactSelect<PluginVersionSelectOptionType, false>
                     options={options}

--- a/src/components/CIPipelineN/TaskDetailComponent.tsx
+++ b/src/components/CIPipelineN/TaskDetailComponent.tsx
@@ -37,6 +37,7 @@ import { TaskTypeDetailComponent } from './TaskTypeDetailComponent'
 import { ValidationRules } from '../ciPipeline/validationRules'
 import { pipelineContext } from '../workflowEditor/workflowEditor'
 import { PluginDetailHeaderProps, TaskDetailComponentParamsType } from './types'
+import { filterInvalidConditionDetails } from '@Components/cdPipeline/cdpipeline.util'
 
 export const TaskDetailComponent = () => {
     const {
@@ -145,15 +146,18 @@ export const TaskDetailComponent = () => {
             pluginId,
             inputVariables: newInputVariables,
             outputVariables: newPluginVersionData.outputVariables,
-            // Clearing conditionDetails if inputVariables length is 0
-            ...(!newInputVariables.length && { conditionDetails: []}),
+            conditionDetails: filterInvalidConditionDetails(
+                _formData[activeStageName].steps[selectedTaskIndex].pluginRefStepDetail.conditionDetails,
+                newInputVariables.length,
+                newPluginVersionData.outputVariables.length,
+            )
         } as StepType['pluginRefStepDetail']
         _formData[activeStageName].steps[selectedTaskIndex].description = newPluginVersionData.description
         _formData[activeStageName].steps[selectedTaskIndex].name = newPluginVersionData.name
 
         calculateLastStepDetail(false, _formData, activeStageName)
-        validateStage(BuildStageVariable.PreBuild, _formData, undefined , clonedPluginDataStore)
-        validateStage(BuildStageVariable.PostBuild, _formData, undefined , clonedPluginDataStore)
+        validateStage(BuildStageVariable.PreBuild, _formData, undefined, clonedPluginDataStore)
+        validateStage(BuildStageVariable.PostBuild, _formData, undefined, clonedPluginDataStore)
 
         return _formData
     }
@@ -176,7 +180,11 @@ export const TaskDetailComponent = () => {
             })
             const clonedPluginDataStore = getUpdatedPluginStore(pluginDataStore, parentPluginStore, pluginVersionStore)
             const newPluginVersionData = clonedPluginDataStore.pluginVersionStore[pluginId]
-            const _formData = getFormDataWithReplacedPluginVersion(newPluginVersionData, pluginId, clonedPluginDataStore)
+            const _formData = getFormDataWithReplacedPluginVersion(
+                newPluginVersionData,
+                pluginId,
+                clonedPluginDataStore,
+            )
 
             handlePluginDataStoreUpdate(clonedPluginDataStore)
             setFormData(_formData)

--- a/src/components/CIPipelineN/TaskDetailComponent.tsx
+++ b/src/components/CIPipelineN/TaskDetailComponent.tsx
@@ -103,6 +103,7 @@ export const TaskDetailComponent = () => {
     const getFormDataWithReplacedPluginVersion = (
         newPluginVersionData: PluginDataStoreType['pluginVersionStore'][0],
         pluginId: number,
+        clonedPluginDataStore: typeof pluginDataStore,
     ): typeof formData => {
         const _formData = structuredClone(formData)
 
@@ -144,13 +145,15 @@ export const TaskDetailComponent = () => {
             pluginId,
             inputVariables: newInputVariables,
             outputVariables: newPluginVersionData.outputVariables,
-        }
+            // Clearing conditionDetails if inputVariables length is 0
+            ...(!newInputVariables.length && { conditionDetails: []}),
+        } as StepType['pluginRefStepDetail']
         _formData[activeStageName].steps[selectedTaskIndex].description = newPluginVersionData.description
         _formData[activeStageName].steps[selectedTaskIndex].name = newPluginVersionData.name
 
         calculateLastStepDetail(false, _formData, activeStageName)
-        validateStage(BuildStageVariable.PreBuild, _formData)
-        validateStage(BuildStageVariable.PostBuild, _formData)
+        validateStage(BuildStageVariable.PreBuild, _formData, undefined , clonedPluginDataStore)
+        validateStage(BuildStageVariable.PostBuild, _formData, undefined , clonedPluginDataStore)
 
         return _formData
     }
@@ -158,7 +161,7 @@ export const TaskDetailComponent = () => {
     const handlePluginVersionChange: PluginDetailHeaderProps['handlePluginVersionChange'] = async (pluginId) => {
         if (pluginDataStore.pluginVersionStore[pluginId]) {
             const newPluginVersionData = pluginDataStore.pluginVersionStore[pluginId]
-            const _formData = getFormDataWithReplacedPluginVersion(newPluginVersionData, pluginId)
+            const _formData = getFormDataWithReplacedPluginVersion(newPluginVersionData, pluginId, pluginDataStore)
             setFormData(_formData)
             return
         }
@@ -173,7 +176,7 @@ export const TaskDetailComponent = () => {
             })
             const clonedPluginDataStore = getUpdatedPluginStore(pluginDataStore, parentPluginStore, pluginVersionStore)
             const newPluginVersionData = clonedPluginDataStore.pluginVersionStore[pluginId]
-            const _formData = getFormDataWithReplacedPluginVersion(newPluginVersionData, pluginId)
+            const _formData = getFormDataWithReplacedPluginVersion(newPluginVersionData, pluginId, clonedPluginDataStore)
 
             handlePluginDataStoreUpdate(clonedPluginDataStore)
             setFormData(_formData)

--- a/src/components/CIPipelineN/TaskTitle.tsx
+++ b/src/components/CIPipelineN/TaskTitle.tsx
@@ -71,9 +71,9 @@ const TaskTitle = ({ taskDetail }: TaskTitleProps) => {
 
                 <div className="icon-dim-8 dc__transparent dc__no-shrink dc__position-abs dc__bottom-0 dc__right-0 flex">
                     <ActivityIndicator
-                        rootClassName="dc__no-shrink"
+                        rootClassName="dc__no-shrink en-1"
                         backgroundColorClass="bcg-5"
-                        iconSizeClass="icon-dim-6"
+                        iconSizeClass="icon-dim-8"
                     />
                 </div>
             </div>

--- a/src/components/CIPipelineN/TaskTitle.tsx
+++ b/src/components/CIPipelineN/TaskTitle.tsx
@@ -71,7 +71,7 @@ const TaskTitle = ({ taskDetail }: TaskTitleProps) => {
 
                 <div className="icon-dim-8 dc__transparent dc__no-shrink dc__position-abs dc__bottom-0 dc__right-0 flex">
                     <ActivityIndicator
-                        rootClassName="dc__no-shrink en-1"
+                        rootClassName="dc__no-shrink en-1 bw-1_5"
                         backgroundColorClass="bcg-5"
                         iconSizeClass="icon-dim-8"
                     />

--- a/src/components/CIPipelineN/ciPipeline.utils.tsx
+++ b/src/components/CIPipelineN/ciPipeline.utils.tsx
@@ -309,10 +309,13 @@ export const pluginVersionSelectStyle: StylesConfig<PluginVersionSelectOptionTyp
         state.menuIsOpen
             ? {
                   ...commonSelectStyles.control(base, state),
+                  minHeight: '20px',
+                  height: '28px',
               }
             : {
                   border: 'none',
                   minHeight: '20px',
+                  height: '28px',
                   display: 'grid',
                   gridTemplateColumns: 'auto 24px',
                   justifyContent: 'flex-start',

--- a/src/components/cdPipeline/cdpipeline.util.tsx
+++ b/src/components/cdPipeline/cdpipeline.util.tsx
@@ -394,3 +394,34 @@ export const handleDeleteCDNodePipeline = (
 ) => {
     handleDeletePipeline(DELETE_ACTION.DELETE, deleteCD, deploymentAppType)
 }
+
+export const filterInvalidConditionDetails = (
+    conditionDetails: StepType['pluginRefStepDetail']['conditionDetails'],
+    inputVariableCount: number,
+    outputVariableCount: number,
+): StepType['pluginRefStepDetail']['conditionDetails'] => {
+    if (!inputVariableCount && !outputVariableCount) {
+        return []
+    }
+
+    return (
+        conditionDetails?.filter((conditionDetail) => {
+            const isInputVariableCondition =
+                conditionDetail.conditionType === ConditionType.TRIGGER ||
+                conditionDetail.conditionType === ConditionType.SKIP
+            const isOutputVariableCondition =
+                conditionDetail.conditionType === ConditionType.PASS ||
+                conditionDetail.conditionType === ConditionType.FAIL
+
+            if (isInputVariableCondition && !inputVariableCount) {
+                return false
+            }
+
+            if (isOutputVariableCondition && !outputVariableCount) {
+                return false
+            }
+
+            return true
+        }) || []
+    )
+}

--- a/src/components/scopedVariables/utils.tsx
+++ b/src/components/scopedVariables/utils.tsx
@@ -69,7 +69,6 @@ export const validator: ValidatorType = ({ data, type }) => {
             try {
                 const parsedData = yaml.parse(data)
                 if (parsedData && typeof parsedData === 'object') {
-                    debugger
                     const data = YAMLStringify(parsedData, { simpleKeys: true })
                     return {
                         status: FileReaderStatus.SUCCESS,

--- a/src/components/workflowEditor/types.ts
+++ b/src/components/workflowEditor/types.ts
@@ -294,7 +294,7 @@ export interface PipelineContext {
     setFormDataErrorObj: React.Dispatch<React.SetStateAction<PipelineFormDataErrorType>>
     validateTask: (taskData: StepType, taskErrorobj: TaskErrorObj) => void
     setSelectedTaskIndex: React.Dispatch<React.SetStateAction<number>>
-    validateStage: (stageName: string, _formData: PipelineFormType, formDataErrorObject?: any) => void
+    validateStage: (stageName: string, _formData: PipelineFormType, formDataErrorObject?: any, clonedPluginDataStore?: PluginDataStoreType) => void
     isCdPipeline?: boolean
     configMapAndSecrets?: {
         label: string

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -4742,3 +4742,7 @@ textarea::placeholder {
 .dc__modal-gradient {
     background: linear-gradient(14deg, var(--N50) 48.93%, #D4E6F7 80.3%);
 }
+
+.bw-1_5 {
+    border-width: 1.5px;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,10 +993,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@devtron-labs/devtron-fe-common-lib@0.1.7-beta-1":
-  version "0.1.7-beta-1"
-  resolved "https://registry.yarnpkg.com/@devtron-labs/devtron-fe-common-lib/-/devtron-fe-common-lib-0.1.7-beta-1.tgz#654ba4adf504cb0d916dc40d05a37b3a2843163e"
-  integrity sha512-cgJ89DejupEx95g2uX7KaLZ8uIoDd8Euzkujjp2ICnMAbpARhd4+ykRl8ZSgsz6UcqP2gXxwtkOkRenw8ltC9A==
+"@devtron-labs/devtron-fe-common-lib@0.1.7-beta-5":
+  version "0.1.7-beta-5"
+  resolved "https://registry.yarnpkg.com/@devtron-labs/devtron-fe-common-lib/-/devtron-fe-common-lib-0.1.7-beta-5.tgz#292839d6fe14dd659782f454c4e4056a0994061e"
+  integrity sha512-69Kfa29jd333teRkXgVKXsL3F5tBdfsqIgB+meWe774equLz7WdomyJDN+azd+EALLeM7zTn8GA4OR/Sbvrrdg==
   dependencies:
     "@types/react-dates" "^21.8.6"
     ansi_up "^5.2.1"


### PR DESCRIPTION
# Description
This PR adds:
- removal of conditionDetails in case of no input variables.
- send optional updated plugin data store in validateStage and fix mandatory plugin validation by sending updated form data instead of previous form data

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


