### PR TITLE
chore: update fe-common-lib dependency to version 0.2.6-beta-10

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "homepage": "/dashboard",
     "dependencies": {
-        "@devtron-labs/devtron-fe-common-lib": "0.2.6-beta-9",
+        "@devtron-labs/devtron-fe-common-lib": "0.2.6-beta-10",
         "@esbuild-plugins/node-globals-polyfill": "0.2.3",
         "@rjsf/core": "^5.13.3",
         "@rjsf/utils": "^5.13.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,10 +1064,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@devtron-labs/devtron-fe-common-lib@0.2.6-beta-9":
-  version "0.2.6-beta-9"
-  resolved "https://registry.yarnpkg.com/@devtron-labs/devtron-fe-common-lib/-/devtron-fe-common-lib-0.2.6-beta-9.tgz#0f29747ed40d7073c2962df707d61dd9b05146e1"
-  integrity sha512-mxOcUOVm56PMSCJuktd62AsnZNLjNO4RBE3L8ooiQJG+vjfxU/LJls1gakkrz+DMWCEPfiivvgyqrS8Yqfq4eQ==
+"@devtron-labs/devtron-fe-common-lib@0.2.6-beta-10":
+  version "0.2.6-beta-10"
+  resolved "https://registry.yarnpkg.com/@devtron-labs/devtron-fe-common-lib/-/devtron-fe-common-lib-0.2.6-beta-10.tgz#2a2ab1b485ec6026bbb28bd36c0ef5a995d8d6f5"
+  integrity sha512-2CEgBke2LziDAWiCQNI+7I1mET+K6ojsZChUoOA39tg6tmWmRNXeUo2gDtk59IZsEFL1vREZyM2JM6SBGKLQHw==
   dependencies:
     "@types/react-dates" "^21.8.6"
     ansi_up "^5.2.1"


### PR DESCRIPTION
chore: update fe-common-lib dependency to version 0.2.6-beta-10