### PR TITLE
fix: sync selected k8s version from url

### DIFF
--- a/src/components/ClusterNodes/NodeDetailsList.tsx
+++ b/src/components/ClusterNodes/NodeDetailsList.tsx
@@ -133,10 +133,11 @@ export default function NodeDetailsList({ isSuperAdmin, renderRefreshBar, addTab
         const qs = queryString.parse(location.search)
         const offset = Number(qs['offset'])
         setNodeListOffset(offset || 0)
-        if (k8sVersion && k8sVersion !== selectedVersion.value) {
-            setSelectedVersion({ label: `K8s version: ${k8sVersion}`, value: k8sVersion })
+        const version = qs['k8sversion']
+        if (version && typeof version === 'string' && selectedVersion.value !== version) {
+            setSelectedVersion({ label: `K8s version: ${version}`, value: version })
         }
-    }, [location.search, k8sVersion])
+    }, [location.search])
 
     useEffect(() => {
         if (filteredFlattenNodeList) {

--- a/src/components/ClusterNodes/NodeDetailsList.tsx
+++ b/src/components/ClusterNodes/NodeDetailsList.tsx
@@ -133,7 +133,10 @@ export default function NodeDetailsList({ isSuperAdmin, renderRefreshBar, addTab
         const qs = queryString.parse(location.search)
         const offset = Number(qs['offset'])
         setNodeListOffset(offset || 0)
-    }, [location.search])
+        if (k8sVersion && k8sVersion !== selectedVersion.value) {
+            setSelectedVersion({ label: `K8s version: ${k8sVersion}`, value: k8sVersion })
+        }
+    }, [location.search, k8sVersion])
 
     useEffect(() => {
         if (filteredFlattenNodeList) {


### PR DESCRIPTION
# Description

When navigating from cluster overview by selecting a node version with an error, the node version is appended to the url but the node details list page does not sync its state with that present in the url.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


