### PR TITLE
fix: override ignore tags for terminal shortcut

### DIFF
--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/Terminal.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/Terminal.tsx
@@ -20,7 +20,12 @@ import { FitAddon } from 'xterm-addon-fit'
 import * as XtermWebfont from 'xterm-webfont'
 import SockJS from 'sockjs-client'
 import moment from 'moment'
-import { useMainContext, LogResizeButton, IS_PLATFORM_MAC_OS } from '@devtron-labs/devtron-fe-common-lib'
+import {
+    useMainContext,
+    LogResizeButton,
+    IS_PLATFORM_MAC_OS,
+    UseRegisterShortcutProvider,
+} from '@devtron-labs/devtron-fe-common-lib'
 import CopyToast, { handleSelectionChange } from '../CopyToast'
 import { elementDidMount } from '../../../../../../common/helpers/Helpers'
 import { CLUSTER_STATUS, SocketConnectionType } from '../../../../../../ClusterNodes/constants'
@@ -270,41 +275,45 @@ export default function TerminalView({
         }
     }, [clearTerminal])
 
+    // NOTE: by default events from textarea are also ignored
+    // since terminal is a textarea we need to override the ignoreTags property
     return (
-        <div
-            className={`${isSuperAdmin && !isResourceBrowserView ? 'pb-28' : ''} terminal-wrapper`}
-            data-testid={dataTestId}
-        >
-            {renderConnectionStrip()}
-            {fullScreenView && (
-                <div className="w-100 flexbox dc__gap-6 dc__align-items-center px-12 py-4 terminal-wrapper__metadata">
-                    <ICDevtronLogo className="fcn-0 icon-dim-16 dc__no-shrink" />
-                    {Object.entries(metadata).map(([key, value], index, arr) => (
-                        <React.Fragment key={key}>
-                            <span className="dc__first-letter-capitalize fs-12 cn-0 lh-20">
-                                {key}:&nbsp;{value || '-'}
-                            </span>
-                            {index < arr.length - 1 && <div className="dc__divider h12" />}
-                        </React.Fragment>
-                    ))}
-                </div>
-            )}
+        <UseRegisterShortcutProvider ignoreTags={['input']}>
             <div
-                ref={termDivRef}
-                id="terminal-id"
-                data-testid="terminal-editor-container"
-                className={`mt-8 mb-4 terminal-component ${
-                    fullScreenView ? 'terminal-component--fullscreen' : ''
-                } ml-20 ${!isResourceBrowserView && !fullScreenView && isSuperAdmin ? 'terminal-component__zoom--bottom-41' : ''}`}
+                className={`${isSuperAdmin && !isResourceBrowserView ? 'pb-28' : ''} terminal-wrapper`}
+                data-testid={dataTestId}
             >
-                <CopyToast showCopyToast={popupText} />
-                <LogResizeButton
-                    shortcutCombo={[IS_PLATFORM_MAC_OS ? 'Meta' : 'Control', 'Shift', 'F']}
-                    showOnlyWhenPathIncludesLogs={false}
-                    fullScreenView={fullScreenView}
-                    setFullScreenView={handleToggleFullscreen}
-                />
+                {renderConnectionStrip()}
+                {fullScreenView && (
+                    <div className="w-100 flexbox dc__gap-6 dc__align-items-center px-12 py-4 terminal-wrapper__metadata">
+                        <ICDevtronLogo className="fcn-0 icon-dim-16 dc__no-shrink" />
+                        {Object.entries(metadata).map(([key, value], index, arr) => (
+                            <React.Fragment key={key}>
+                                <span className="dc__first-letter-capitalize fs-12 cn-0 lh-20">
+                                    {key}:&nbsp;{value || '-'}
+                                </span>
+                                {index < arr.length - 1 && <div className="dc__divider h12" />}
+                            </React.Fragment>
+                        ))}
+                    </div>
+                )}
+                <div
+                    ref={termDivRef}
+                    id="terminal-id"
+                    data-testid="terminal-editor-container"
+                    className={`mt-8 mb-4 terminal-component ${
+                        fullScreenView ? 'terminal-component--fullscreen' : ''
+                    } ml-20 ${!isResourceBrowserView && !fullScreenView && isSuperAdmin ? 'terminal-component__zoom--bottom-41' : ''}`}
+                >
+                    <CopyToast showCopyToast={popupText} />
+                    <LogResizeButton
+                        shortcutCombo={[IS_PLATFORM_MAC_OS ? 'Meta' : 'Control', 'Shift', 'F']}
+                        showOnlyWhenPathIncludesLogs={false}
+                        fullScreenView={fullScreenView}
+                        setFullScreenView={handleToggleFullscreen}
+                    />
+                </div>
             </div>
-        </div>
+        </UseRegisterShortcutProvider>
     )
 }


### PR DESCRIPTION
# Description

Issue: currently once we enter fullscreen for terminal we can't exit it using the shortcut since the terminal is a `textarea`. Therefore override the ignoreTags property only in the case of terminal.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


