### PR TITLE
fix: stop unsaved changes prompt in case of readme click

### DIFF
--- a/src/Pages/Applications/DevtronApps/Details/AppConfigurations/MainContent/DeploymentTemplate/DeploymentTemplate.tsx
+++ b/src/Pages/Applications/DevtronApps/Details/AppConfigurations/MainContent/DeploymentTemplate/DeploymentTemplate.tsx
@@ -36,7 +36,7 @@ import {
     ResponseType,
     API_STATUS_CODES,
 } from '@devtron-labs/devtron-fe-common-lib'
-import { Prompt, useParams } from 'react-router-dom'
+import { Prompt, useLocation, useParams } from 'react-router-dom'
 import YAML from 'yaml'
 import { FloatingVariablesSuggestions, importComponentFromFELibrary } from '@Components/common'
 import { getModuleInfo } from '@Components/v2/devtronStackManager/DevtronStackManager.service'
@@ -122,6 +122,7 @@ const DeploymentTemplate = ({
 }: DeploymentTemplateProps) => {
     // If envId is there, then it is from envOverride
     const { appId, envId } = useParams<BaseURLParams>()
+    const location = useLocation()
     const { isSuperAdmin } = useMainContext()
 
     const [state, dispatch] = useReducer<Reducer<DeploymentTemplateStateType, DeploymentTemplateActionState>>(
@@ -1228,6 +1229,8 @@ const DeploymentTemplate = ({
             showApprovalPendingEditorInCompareView,
         })?.isAppMetricsEnabled
 
+    const getPromptMessage = ({ pathname }) => location.pathname === pathname || DEFAULT_ROUTE_PROMPT_MESSAGE
+
     const toolbarPopupConfig: ConfigToolbarProps['popupConfig'] = {
         menuConfig: getConfigToolbarPopupConfig({
             lockedConfigData: {
@@ -1650,7 +1653,7 @@ const DeploymentTemplate = ({
                 )}
             </div>
 
-            <Prompt when={areChangesPresent} message={DEFAULT_ROUTE_PROMPT_MESSAGE} />
+            <Prompt when={areChangesPresent} message={getPromptMessage} />
         </>
     )
 }


### PR DESCRIPTION
# Description
fix: stop unsaved changes prompt in case of readme click
Fixes https://github.com/devtron-labs/sprint-tasks/issues/1145

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


