### PR TITLE
fix: add toast and lock diff modal after isLockConfigError is true while updating draft

### DIFF
--- a/src/Pages/Applications/DevtronApps/Details/AppConfigurations/MainContent/DeploymentTemplate/DeploymentTemplate.tsx
+++ b/src/Pages/Applications/DevtronApps/Details/AppConfigurations/MainContent/DeploymentTemplate/DeploymentTemplate.tsx
@@ -1070,6 +1070,13 @@ const DeploymentTemplate = ({
         return isUpdateView ? 'Updated override' : 'Overridden'
     }
 
+    const handleShowLockConfigChangesToast = () => {
+        ToastManager.showToast({
+            variant: ToastVariantType.error,
+            description: 'Changes in locked keys are only allowed via super-admin.',
+        })
+    }
+
     const handleSaveTemplate = async () => {
         dispatch({
             type: DeploymentTemplateActionType.INITIATE_SAVE,
@@ -1082,10 +1089,7 @@ const DeploymentTemplate = ({
             const isLockConfigError = !!response?.result?.isLockConfigError
 
             if (isLockConfigError && showLockedTemplateDiffModal) {
-                ToastManager.showToast({
-                    variant: ToastVariantType.error,
-                    description: 'Changes in locked keys are not allowed.',
-                })
+                handleShowLockConfigChangesToast()
             }
 
             dispatch({
@@ -1431,6 +1435,16 @@ const DeploymentTemplate = ({
         dispatch({
             type: DeploymentTemplateActionType.CLEAR_POPUP_NODE,
         })
+    }
+
+    const handleProcessSaveDraftResponse = (response: ResponseType) => {
+        if (response?.result?.isLockConfigError) {
+            handleShowLockConfigChangesToast()
+
+            dispatch({
+                type: DeploymentTemplateActionType.LOCK_CHANGES_DETECTED_FROM_DRAFT_API,
+            })
+        }
     }
 
     const getIsAppMetricsEnabledForCTA = (): boolean => !!currentViewEditorState?.isAppMetricsEnabled
@@ -1859,6 +1873,7 @@ const DeploymentTemplate = ({
                         reload={handleReload}
                         showAsModal={!showLockedTemplateDiffModal}
                         saveEligibleChangesCb={showLockedTemplateDiffModal}
+                        handleProcessSaveResponse={handleProcessSaveDraftResponse}
                     />
                 )}
             </div>

--- a/src/Pages/Applications/DevtronApps/Details/AppConfigurations/MainContent/DeploymentTemplate/deploymentTemplateReducer.ts
+++ b/src/Pages/Applications/DevtronApps/Details/AppConfigurations/MainContent/DeploymentTemplate/deploymentTemplateReducer.ts
@@ -86,6 +86,7 @@ export enum DeploymentTemplateActionType {
     INITIATE_LOADING_CURRENT_EDITOR_MERGED_TEMPLATE = 'INITIATE_LOADING_CURRENT_EDITOR_MERGED_TEMPLATE',
     LOAD_CURRENT_EDITOR_MERGED_TEMPLATE = 'LOAD_CURRENT_EDITOR_MERGED_TEMPLATE',
     CURRENT_EDITOR_MERGED_TEMPLATE_FETCH_ERROR = 'CURRENT_EDITOR_MERGED_TEMPLATE_ERROR',
+    LOCK_CHANGES_DETECTED_FROM_DRAFT_API = 'LOCK_CHANGES_DETECTED_FROM_DRAFT_API',
 }
 
 type DeploymentTemplateNoPayloadActions =
@@ -115,6 +116,7 @@ type DeploymentTemplateNoPayloadActions =
     | DeploymentTemplateActionType.CLOSE_SAVE_CHANGES_MODAL
     | DeploymentTemplateActionType.CLOSE_LOCKED_DIFF_MODAL
     | DeploymentTemplateActionType.UPDATE_CONFIG_HEADER_TAB
+    | DeploymentTemplateActionType.LOCK_CHANGES_DETECTED_FROM_DRAFT_API
 
 interface LoadMergedTemplateBasePayloadType {
     editorStates: ConfigEditorStatesType[]
@@ -919,6 +921,16 @@ export const deploymentTemplateReducer = (
                 ...getEditorStatesFromMergedTemplates(state, editorStates, mergedTemplateObjects),
             }
         }
+
+        case DeploymentTemplateActionType.LOCK_CHANGES_DETECTED_FROM_DRAFT_API:
+            return {
+                ...state,
+                showSaveChangesModal: false,
+                lockedDiffModalState: {
+                    showLockedTemplateDiffModal: true,
+                    showLockedDiffForApproval: false,
+                },
+            }
 
         default:
             return state


### PR DESCRIPTION
# Description
fix: add toast and lock diff modal after isLockConfigError is true while updating draft

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


