### PR TITLE
misc: remove issue status dependency in pr-validator

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -11,3 +11,4 @@ types:
   - doc
   - release
   - misc
+  - sync

--- a/.github/workflows/pr-issue-validator.yaml
+++ b/.github/workflows/pr-issue-validator.yaml
@@ -34,7 +34,7 @@ jobs:
       run: |
         set -x    
         # Skip validation for documentation or chore PRs
-        if [[ "$TITLE" =~ ^(doc:|docs:|chore:|misc:|release:) ]]; then
+        if [[ "$TITLE" =~ ^(doc:|docs:|chore:|misc:|release:|sync:) ]]; then
           echo "Skipping validation for docs/chore PR."
           echo "PR NUMBER-: $PRNUM "
           gh pr edit $PRNUM --remove-label "PR:Issue-verification-failed"
@@ -106,21 +106,31 @@ jobs:
             --header "authorization: Bearer ${{ secrets.GH_PR_VALIDATOR_TOKEN }}" \
             "$issue_api_url" | jq '.state'|tr -d \")
           # Check if the issue is still open.
-          if [[ "$issue_status" == open ]]; then
-            echo "Issue #$issue_num is opened."
+          # if [[ "$issue_status" == open ]]; then
+            # echo "Issue #$issue_num is opened."
+            if [[ $forked == true ]]; then
+              echo "PR:Ready-to-Review, exiting gracefully"
+              exit 0
+            fi
             # Remove the 'Issue-verification-failed' label (if present) and add 'Ready-to-Review'.
             gh pr edit $PRNUM --remove-label "PR:Issue-verification-failed"
             gh pr edit $PRNUM --add-label "PR:Ready-to-Review"
-          else
-            echo "Issue #$issue_num is closed. Please link an open issue to proceed."
+            echo "PR:Ready-to-Review, exiting gracefully"
+            exit 0
+          # else
+            # echo "Issue #$issue_num is closed. Please link an open issue to proceed."
+              # if [[ $forked == true ]]; then
+                # echo "PR:Ready-to-Review, exiting gracefully"
+                # exit 0
+              # fi
             # Add a comment to the PR indicating the issue is not linked correctly.
-            gh pr comment $PRNUM --body "PR is  linked to a closed issue. Please link an open issue to proceed."
+            # gh pr comment $PRNUM --body "PR is  linked to a closed issue. Please link an open issue to proceed."
 
             # Add the 'Issue-verification-failed' label and remove 'Ready-to-Review'.
-            gh pr edit $PRNUM --add-label "PR:Issue-verification-failed"
-            gh pr edit $PRNUM --remove-label "PR:Ready-to-Review"
-            exit 1
-          fi
+            # gh pr edit $PRNUM --add-label "PR:Issue-verification-failed"
+            # gh pr edit $PRNUM --remove-label "PR:Ready-to-Review"
+            # exit 1
+          #fi
         else
           echo "Issue not found. Invalid URL or issue number."
           # Add a comment to the PR indicating the issue is not linked correctly.


### PR DESCRIPTION
1. added `sync` to semantic.yaml and pr validator 
2. removed issue status dependency in pr-validator