### PR TITLE
fix: retain bulk selection in resource browser if there is search text change and only clear it if resource list call is re-called

### DIFF
--- a/src/components/ClusterNodes/NodeActions/DeleteNodeModal.tsx
+++ b/src/components/ClusterNodes/NodeActions/DeleteNodeModal.tsx
@@ -43,7 +43,7 @@ export default function DeleteNodeModal({ name, version, kind, closePopup, handl
                 variant: ToastVariantType.success,
                 description: DELETE_NODE_MODAL_MESSAGING.initiated,
             })
-            handleClearBulkSelection?.()
+            handleClearBulkSelection()
             closePopup(true)
         } catch (err) {
             showError(err)

--- a/src/components/ClusterNodes/NodeActions/DeleteNodeModal.tsx
+++ b/src/components/ClusterNodes/NodeActions/DeleteNodeModal.tsx
@@ -18,10 +18,10 @@ import { useState } from 'react'
 import { showError, DeleteDialog, InfoColourBar, ToastVariantType, ToastManager, deleteNodeCapacity } from '@devtron-labs/devtron-fe-common-lib'
 import { useParams } from 'react-router-dom'
 import { ReactComponent as Help } from '../../../assets/icons/ic-help.svg'
-import { NodeActionModalPropType } from '../types'
+import { DeleteNodeModalProps } from '../types'
 import { DELETE_NODE_MODAL_MESSAGING } from '../constants'
 
-export default function DeleteNodeModal({ name, version, kind, closePopup }: NodeActionModalPropType) {
+export default function DeleteNodeModal({ name, version, kind, closePopup, handleClearBulkSelection }: DeleteNodeModalProps) {
     const { clusterId } = useParams<{ clusterId: string }>()
     const [apiCallInProgress, setAPICallInProgress] = useState(false)
 
@@ -43,6 +43,7 @@ export default function DeleteNodeModal({ name, version, kind, closePopup }: Nod
                 variant: ToastVariantType.success,
                 description: DELETE_NODE_MODAL_MESSAGING.initiated,
             })
+            handleClearBulkSelection?.()
             closePopup(true)
         } catch (err) {
             showError(err)

--- a/src/components/ClusterNodes/NodeDetails.tsx
+++ b/src/components/ClusterNodes/NodeDetails.tsx
@@ -35,6 +35,7 @@ import {
     ToastVariantType,
     ResourceDetail,
     CodeEditorThemesKeys,
+    noop,
 } from '@devtron-labs/devtron-fe-common-lib'
 import { useParams, useLocation, useHistory } from 'react-router-dom'
 import YAML from 'yaml'
@@ -708,6 +709,7 @@ const NodeDetails = ({ addTab, lowercaseKindToResourceGroupMap, updateTabUrl }: 
                                             selectedResource={selectedResource}
                                             getResourceListData={getPodListData}
                                             handleResourceClick={handleResourceClick}
+                                            handleClearBulkSelection={noop}
                                         />
                                     </div>
                                     <span>{pod.cpu.requestPercentage || '-'}</span>
@@ -1076,6 +1078,7 @@ const NodeDetails = ({ addTab, lowercaseKindToResourceGroupMap, updateTabUrl }: 
                             version={nodeDetail.version}
                             kind={nodeDetail.kind}
                             closePopup={hideDeleteNodeModal}
+                            handleClearBulkSelection={noop}
                         />
                     )}
                     {showEditTaints && (

--- a/src/components/ClusterNodes/types.ts
+++ b/src/components/ClusterNodes/types.ts
@@ -27,7 +27,7 @@ import { UpdateTabUrlParamsType, UseTabsReturnType } from '@Components/common/Dy
 import { LabelTag, OptionType } from '../app/types'
 import { CLUSTER_PAGE_TAB } from './constants'
 import { EditModeType } from '../v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/terminal/constants'
-import { ClusterOptionType, K8SResourceListType } from '../ResourceBrowser/Types'
+import { ClusterOptionType, K8SResourceListType, ResourceBrowserActionMenuType } from '../ResourceBrowser/Types'
 
 export enum ERROR_TYPE {
     VERSION_ERROR = 'K8s Version diff',
@@ -175,6 +175,10 @@ export interface TaintErrorObj {
 export interface NodeActionModalPropType extends NodeActionRequest {
     closePopup: (refreshData?: boolean) => void
 }
+
+export interface DeleteNodeModalProps
+    extends NodeActionModalPropType,
+        Pick<ResourceBrowserActionMenuType, 'handleClearBulkSelection'> {}
 
 export interface CordonNodeModalType extends NodeActionModalPropType {
     unschedulable: boolean

--- a/src/components/ResourceBrowser/ResourceList/BaseResourceList.tsx
+++ b/src/components/ResourceBrowser/ResourceList/BaseResourceList.tsx
@@ -239,10 +239,6 @@ const BaseResourceListContent = ({
                 return acc
             }, {}) as Record<string, K8sResourceDetailDataType>) ?? {},
         )
-
-        handleBulkSelection({
-            action: BulkSelectionEvents.CLEAR_ALL_SELECTIONS,
-        })
     }, [resourceListOffset, filteredResourceList, pageSize])
 
     useEffect(
@@ -456,12 +452,14 @@ const BaseResourceListContent = ({
                                         }}
                                         handleResourceClick={handleResourceClick}
                                         hideDeleteResource={hideDeleteResource}
+                                        handleClearBulkSelection={handleClearBulkSelection}
                                     />
                                 ) : (
                                     <NodeActionsMenu
                                         getNodeListData={reloadResourceListData as () => Promise<void>}
                                         addTab={addTab}
                                         nodeData={resourceData}
+                                        handleClearBulkSelection={handleClearBulkSelection}
                                     />
                                 ))}
                         </div>

--- a/src/components/ResourceBrowser/ResourceList/DeleteResourcePopup.tsx
+++ b/src/components/ResourceBrowser/ResourceList/DeleteResourcePopup.tsx
@@ -37,6 +37,7 @@ const DeleteResourcePopup: React.FC<DeleteResourcePopupType> = ({
     getResourceListData,
     toggleDeleteDialog,
     removeTabByIdentifier,
+    handleClearBulkSelection,
 }) => {
     const { push } = useHistory()
     const [apiCallInProgress, setApiCallInProgress] = useState(false)
@@ -63,6 +64,7 @@ const DeleteResourcePopup: React.FC<DeleteResourcePopupType> = ({
                 description: 'Resource deleted successfully',
             })
             await getResourceListData()
+            handleClearBulkSelection?.()
             toggleDeleteDialog()
             if (removeTabByIdentifier) {
                 removeTabByIdentifier(

--- a/src/components/ResourceBrowser/ResourceList/DeleteResourcePopup.tsx
+++ b/src/components/ResourceBrowser/ResourceList/DeleteResourcePopup.tsx
@@ -64,7 +64,7 @@ const DeleteResourcePopup: React.FC<DeleteResourcePopupType> = ({
                 description: 'Resource deleted successfully',
             })
             await getResourceListData()
-            handleClearBulkSelection?.()
+            handleClearBulkSelection()
             toggleDeleteDialog()
             if (removeTabByIdentifier) {
                 removeTabByIdentifier(

--- a/src/components/ResourceBrowser/ResourceList/NodeActionsMenu.tsx
+++ b/src/components/ResourceBrowser/ResourceList/NodeActionsMenu.tsx
@@ -36,7 +36,7 @@ import EditTaintsModal from '../../ClusterNodes/NodeActions/EditTaintsModal'
 import { K8S_EMPTY_GROUP } from '../Constants'
 
 // TODO: This should be commoned out with ResourceBrowserActionMenu to have consistent styling
-const NodeActionsMenu = ({ nodeData, getNodeListData, addTab }: NodeActionsMenuProps) => {
+const NodeActionsMenu = ({ nodeData, getNodeListData, addTab, handleClearBulkSelection }: NodeActionsMenuProps) => {
     const history = useHistory()
     const { url } = useRouteMatch()
     const location = useLocation()
@@ -125,7 +125,15 @@ const NodeActionsMenu = ({ nodeData, getNodeListData, addTab }: NodeActionsMenuP
         }
 
         if (showDeleteNodeDialog) {
-            return <DeleteNodeModal name={name} version={version} kind={kind} closePopup={hideDeleteNodeModal} />
+            return (
+                <DeleteNodeModal
+                    name={name}
+                    version={version}
+                    kind={kind}
+                    closePopup={hideDeleteNodeModal}
+                    handleClearBulkSelection={handleClearBulkSelection}
+                />
+            )
         }
 
         if (showEditTaintNodeDialog) {

--- a/src/components/ResourceBrowser/ResourceList/ResourceBrowserActionMenu.tsx
+++ b/src/components/ResourceBrowser/ResourceList/ResourceBrowserActionMenu.tsx
@@ -64,6 +64,7 @@ const ResourceBrowserActionMenu: React.FC<ResourceBrowserActionMenuType> = ({
     handleResourceClick,
     removeTabByIdentifier,
     hideDeleteResource,
+    handleClearBulkSelection,
 }) => {
     const { installedModuleMap } = useMainContext()
 
@@ -185,6 +186,7 @@ const ResourceBrowserActionMenu: React.FC<ResourceBrowserActionMenuType> = ({
                     getResourceListData={getResourceListData}
                     toggleDeleteDialog={toggleDeleteDialog}
                     removeTabByIdentifier={removeTabByIdentifier}
+                    handleClearBulkSelection={handleClearBulkSelection}
                 />
             )}
 

--- a/src/components/ResourceBrowser/Types.ts
+++ b/src/components/ResourceBrowser/Types.ts
@@ -135,7 +135,7 @@ export interface ResourceBrowserActionMenuType {
     resourceData: K8sResourceDetailDataType
     selectedResource: ApiResourceGroupType
     handleResourceClick: (e: React.MouseEvent<HTMLButtonElement>) => void
-    handleClearBulkSelection?: () => void
+    handleClearBulkSelection: () => void
     removeTabByIdentifier?: UseTabsReturnType['removeTabByIdentifier']
     getResourceListData?: () => Promise<void>
     /**

--- a/src/components/ResourceBrowser/Types.ts
+++ b/src/components/ResourceBrowser/Types.ts
@@ -135,6 +135,7 @@ export interface ResourceBrowserActionMenuType {
     resourceData: K8sResourceDetailDataType
     selectedResource: ApiResourceGroupType
     handleResourceClick: (e: React.MouseEvent<HTMLButtonElement>) => void
+    handleClearBulkSelection?: () => void
     removeTabByIdentifier?: UseTabsReturnType['removeTabByIdentifier']
     getResourceListData?: () => Promise<void>
     /**
@@ -148,7 +149,12 @@ export interface ResourceBrowserActionMenuType {
 export interface DeleteResourcePopupType
     extends Pick<
         ResourceBrowserActionMenuType,
-        'clusterId' | 'resourceData' | 'selectedResource' | 'getResourceListData' | 'removeTabByIdentifier'
+        | 'clusterId'
+        | 'resourceData'
+        | 'selectedResource'
+        | 'getResourceListData'
+        | 'removeTabByIdentifier'
+        | 'handleClearBulkSelection'
     > {
     toggleDeleteDialog: () => void
 }
@@ -293,6 +299,7 @@ export interface NodeActionsMenuProps {
     addTab: UseTabsReturnType['addTab']
     nodeData: K8sResourceDetailDataType
     getNodeListData: () => void
+    handleClearBulkSelection: () => void
 }
 
 export interface GetResourceDataType {

--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetail.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetail.component.tsx
@@ -31,6 +31,7 @@ import {
     ToastManager,
     ToastVariantType,
     OptionsBase,
+    noop,
 } from '@devtron-labs/devtron-fe-common-lib'
 import { ReactComponent as ICArrowsLeftRight } from '@Icons/ic-arrows-left-right.svg'
 import { ReactComponent as ICPencil } from '@Icons/ic-pencil.svg'
@@ -627,6 +628,7 @@ const NodeDetailComponent = ({
                     getResourceListData={getContainersFromManifest}
                     toggleDeleteDialog={toggleDeleteDialog}
                     removeTabByIdentifier={removeTabByIdentifier}
+                    handleClearBulkSelection={noop}
                 />
             )}
         </>


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes https://github.com/devtron-labs/sprint-tasks/issues/1825

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


