### PR TITLE
fix: cm/cs name should not be editable on app override.

### DIFF
--- a/src/Pages/Shared/ConfigMapSecret/ConfigMapSecretContainer.tsx
+++ b/src/Pages/Shared/ConfigMapSecret/ConfigMapSecretContainer.tsx
@@ -53,6 +53,7 @@ import {
     FloatingVariablesSuggestions,
     UseFormErrorHandler,
     UseFormSubmitHandler,
+    isNullOrUndefined,
 } from '@devtron-labs/devtron-fe-common-lib'
 
 import { URLS } from '@Config/routes'
@@ -854,7 +855,7 @@ export const ConfigMapSecretContainer = ({
             />
         ) : (
             <ConfigMapSecretForm
-                isCreateView={!id}
+                isCreateView={isNullOrUndefined(id)}
                 cmSecretStateLabel={cmSecretStateLabel}
                 componentType={componentType}
                 configMapSecretData={configMapSecretData}

--- a/src/Pages/Shared/ConfigMapSecret/ConfigMapSecretProtected.tsx
+++ b/src/Pages/Shared/ConfigMapSecret/ConfigMapSecretProtected.tsx
@@ -32,6 +32,7 @@ import {
     getConfigMapSecretPayload,
     getConfigMapSecretReadOnlyValues,
     ConfigMapSecretReadyOnly,
+    isNullOrUndefined,
 } from '@devtron-labs/devtron-fe-common-lib'
 
 import { CompareConfigView, CompareConfigViewProps, NoPublishedVersionEmptyState } from '@Pages/Applications'
@@ -227,7 +228,7 @@ export const ConfigMapSecretProtected = ({
         <ConfigMapSecretForm
             configMapSecretData={configMapSecretData}
             inheritedConfigMapSecretData={inheritedConfigMapSecretData}
-            isCreateView={!id}
+            isCreateView={isNullOrUndefined(id)}
             componentType={componentType}
             cmSecretStateLabel={
                 selectedProtectionViewTab === ProtectConfigTabsType.EDIT_DRAFT &&


### PR DESCRIPTION
# Description
fix: cm/cs name should not be editable on app override.

Fixes https://github.com/devtron-labs/sprint-tasks/issues/1858

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


