### PR TITLE
fix: helm chart deployment type

### DIFF
--- a/src/components/app/details/appDetails/AppDetails.tsx
+++ b/src/components/app/details/appDetails/AppDetails.tsx
@@ -20,7 +20,6 @@ import {
     Progressing,
     noop,
     stopPropagation,
-    multiSelectStyles,
     DeploymentAppTypes,
     useSearchString,
     useAsync,
@@ -53,7 +52,6 @@ import {
     DEFAULT_STATUS_TEXT,
 } from '../../../../config'
 import { NavigationArrow, useAppContext, FragmentHOC } from '../../../common'
-import { groupHeaderStyle, Option } from '../../../v2/common/ReactSelect.utils'
 import { getAppConfigStatus, getAppOtherEnvironmentMin, stopStartApp } from '../../../../services/service'
 import AppNotDeployedIcon from '@Images/app-not-deployed.svg'
 import AppNotConfiguredIcon from '@Images/app-not-configured.png'
@@ -377,6 +375,7 @@ export const Details: React.FC<DetailsType> = ({
     useEffect(
         () => () => {
             clearPollingInterval()
+            clearDeploymentStatusTimer()
             IndexStore.clearAppDetails()
         },
         [],

--- a/src/components/v2/values/chartValuesDiff/ChartValuesView.component.tsx
+++ b/src/components/v2/values/chartValuesDiff/ChartValuesView.component.tsx
@@ -434,7 +434,6 @@ export const GitOpsDrawer = ({
                         renderValidationErrorLabel()}
                 </div>
             ) : null}
-            <hr />
         </>
     )
 }

--- a/src/components/v2/values/chartValuesDiff/ChartValuesView.reducer.ts
+++ b/src/components/v2/values/chartValuesDiff/ChartValuesView.reducer.ts
@@ -80,7 +80,7 @@ export const initState = (
         invalidProject: false,
         formValidationError: {},
         showNoGitOpsWarning: false,
-        deploymentAppType: deploymentAppType ?? DeploymentAppTypes.HELM,
+        deploymentAppType: deploymentAppType ?? window._env_.HIDE_GITOPS_OR_HELM_OPTION ? '' : DeploymentAppTypes.HELM,
         gitRepoURL: '',
         authMode: null,
         initialChartVersionValues: {


### PR DESCRIPTION
default deployment app type for helm chart should be "" if hide helm or gitops is enabled

Fixes https://github.com/devtron-labs/sprint-tasks/issues/1855

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


