### PR TITLE
chore: gitops configure warning rendering on every mount

### DIFF
--- a/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
+++ b/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
@@ -238,7 +238,7 @@ const ChartValuesView = ({
             dispatch({
                 type: ChartValuesViewActionTypes.updateGitOpsConfiguration,
                 payload: {
-                    showNoGitOpsWarning: result.isInstalled && !result.isConfigured,
+                    showNoGitOpsWarning: result.isInstalled && !result.isConfigured && !isUpdateAppView,
                     authMode: result.authMode,
                 },
             })
@@ -1723,6 +1723,7 @@ const ChartValuesView = ({
                                     isVirtualEnvironment={appDetails?.isVirtualEnvironment}
                                 />
                             )}
+                           { console.log('allowedDeploymentTypes', allowedDeploymentTypes) }
                             {!window._env_.HIDE_GITOPS_OR_HELM_OPTION && showDeploymentTools && (
                                 <DeploymentAppSelector
                                     commonState={commonState}

--- a/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
+++ b/src/components/v2/values/chartValuesDiff/ChartValuesView.tsx
@@ -1723,7 +1723,6 @@ const ChartValuesView = ({
                                     isVirtualEnvironment={appDetails?.isVirtualEnvironment}
                                 />
                             )}
-                           { console.log('allowedDeploymentTypes', allowedDeploymentTypes) }
                             {!window._env_.HIDE_GITOPS_OR_HELM_OPTION && showDeploymentTools && (
                                 <DeploymentAppSelector
                                     commonState={commonState}


### PR DESCRIPTION
# Description

- Gitops configure warning rendering on every mount
- Manifest link is missing from the left bar of Configure 

Fixes https://github.com/devtron-labs/sprint-tasks/issues/2039

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


