### PR TITLE
chore: add overflow hidden in expanded status to cater absence of overflow-clip-margin: content-box in safari

### DIFF
--- a/src/components/app/list/expandedRow/ExpandedRow.tsx
+++ b/src/components/app/list/expandedRow/ExpandedRow.tsx
@@ -36,10 +36,10 @@ export class ExpandedRow extends Component<ExpandedRowProps> {
                 <Link
                     key={env.id}
                     to={`${this.props.redirect(this.props.app, env.id)}`}
-                    className="app-list__row app-list__row--expanded"
+                    className={`app-list__row app-list__row--expanded ${!this.props.isArgoInstalled ? 'app-list__row--argo-not-installed' : ''}`}
                 >
                     <div className="app-list__cell--icon" />
-                    <div className="app-list__cell app-list__cell--name">
+                    <div className="app-list__cell app-list__cell--name dc__overflow-hidden">
                         <svg className="app-status app-status--pseudo" preserveAspectRatio="none" viewBox="0 0 200 40">
                             <line x1="0" y1="20" x2="100%" y2="20" stroke={color} strokeWidth="1" />
                             <line x1="0" y1="15" x2="0" y2="25" stroke={color} strokeWidth="1" />
@@ -52,15 +52,15 @@ export class ExpandedRow extends Component<ExpandedRowProps> {
                     )}
                     <div className="app-list__cell app-list__cell--env">{env.name}</div>
                     <div className="app-list__cell app-list__cell--cluster">
-                        <p className="dc__truncate-text">{env.clusterName}</p>
+                        <p className="dc__truncate-text m-0">{env.clusterName}</p>
                     </div>
                     <div className="app-list__cell app-list__cell--namespace">
-                        <p className="dc__truncate-text">{env.namespace}</p>
+                        <p className="dc__truncate-text m-0">{env.namespace}</p>
                     </div>
                     <div className="app-list__cell app-list__cell--time">
                         {env.lastDeployedTime && (
                             <Tippy className="default-tt" arrow placement="top" content={env.lastDeployedTime}>
-                                <p className="dc__truncate-text  m-0">{handleUTCTime(env.lastDeployedTime, true)}</p>
+                                <p className="dc__truncate-text m-0">{handleUTCTime(env.lastDeployedTime, true)}</p>
                             </Tippy>
                         )}
                     </div>


### PR DESCRIPTION
# Description
fix: add overflow hidden in expanded status to cater absence of overflow-clip-margin: content-box in safari. Plus have added some alignment fixes as well.
Reference: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-clip-margin

<img width="385" alt="Screenshot 2025-04-17 at 12 46 08 AM" src="https://github.com/user-attachments/assets/fd2e6010-81fa-4651-a801-68fd5adb5aeb" />

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


