### PR TITLE
fix: flow to fetch plugin details in case of template view

### DIFF
--- a/src/components/cdPipeline/CDPipeline.tsx
+++ b/src/components/cdPipeline/CDPipeline.tsx
@@ -279,6 +279,8 @@ export default function CDPipeline({
 
     const isGitOpsRepoNotConfigured = isExternalArgoPipeline ? false : isGitOpsRepoNotConfiguredProp
 
+    const areMandatoryPluginPossible = !!processPluginData && !isTemplateView
+
     const handleHideScopedVariableWidgetUpdate: PipelineContext['handleHideScopedVariableWidgetUpdate'] = (
         hideScopedVariableWidgetValue: boolean,
     ) => {
@@ -312,7 +314,7 @@ export default function CDPipeline({
         const postBuildPluginIds = getPluginIdsFromBuildStage(form.postBuildStage)
         const uniquePluginIds = Array.from(new Set([...preBuildPluginIds, ...postBuildPluginIds]))
 
-        if (processPluginData) {
+        if (areMandatoryPluginPossible) {
             await getMandatoryPluginData(form, uniquePluginIds)
             return
         }
@@ -448,7 +450,7 @@ export default function CDPipeline({
     }
 
     const getMandatoryPluginData: BuildCDProps['getMandatoryPluginData'] = async (form, requiredPluginIds = []) => {
-        if (!processPluginData || isTemplateView) {
+        if (!areMandatoryPluginPossible) {
             return
         }
 


### PR DESCRIPTION
# Description
This PR includes fix for flow to fetch plugin details in template view when a plugin is present in pre/post CD. Currently we are not fetching the details due to wrong early return

Fixes https://github.com/devtron-labs/sprint-tasks/issues/2137

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Dev tested


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


