### PR TITLE
fix: Hide default Cluster deletion dots from resource browser

### DIFF
--- a/src/components/ResourceBrowser/ResourceList/ClusterSelector.tsx
+++ b/src/components/ResourceBrowser/ResourceList/ClusterSelector.tsx
@@ -116,7 +116,7 @@ const ClusterSelector: React.FC<ClusterSelectorType> = ({
 
             {defaultOption?.isProd && <span className="px-6 py-2 br-4 bcb-1 cb-7 fs-12 lh-16 fw-5">Production</span>}
 
-            {defaultOption?.value !== String(DEFAULT_CLUSTER_ID) ? (
+            {defaultOption?.value !== String(DEFAULT_CLUSTER_ID) && (
                 <PopupMenu autoClose>
                     <PopupMenu.Button rootClassName="flex ml-auto p-4 border__secondary" isKebab>
                         <MenuDots className="icon-dim-16 fcn-7" data-testid="popup-menu-button" />
@@ -136,7 +136,7 @@ const ClusterSelector: React.FC<ClusterSelectorType> = ({
                         </div>
                     </PopupMenu.Body>
                 </PopupMenu>
-            ) : null}
+            )}
 
             {openDeleteClusterModal && (
                 <DeleteClusterConfirmationModal


### PR DESCRIPTION
# Description


Fixes https://github.com/devtron-labs/sprint-tasks/issues/2381

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


