### PR TITLE
fix: update getGrafanaModuleStatus to handle errors and return null on failure

### DIFF
--- a/src/components/common/navigation/NavigationRoutes.tsx
+++ b/src/components/common/navigation/NavigationRoutes.tsx
@@ -389,7 +389,14 @@ const NavigationRoutes = ({ reloadVersionConfig }: Readonly<NavigationRoutesType
         }
     }
 
-    const getGrafanaModuleStatus = () => getModuleInfo(ModuleNameMap.GRAFANA)
+    const getGrafanaModuleStatus = async () => {
+        try {
+            const response = await getModuleInfo(ModuleNameMap.GRAFANA)
+            return response
+        } catch {
+            return null
+        }
+    }
 
     const handleFetchInitialData = async () => {
         try {

--- a/src/components/common/navigation/NavigationRoutes.tsx
+++ b/src/components/common/navigation/NavigationRoutes.tsx
@@ -389,14 +389,7 @@ const NavigationRoutes = ({ reloadVersionConfig }: Readonly<NavigationRoutesType
         }
     }
 
-    const getGrafanaModuleStatus = async () => {
-        try {
-            const response = await getModuleInfo(ModuleNameMap.GRAFANA)
-            return response
-        } catch {
-            return null
-        }
-    }
+    const getGrafanaModuleStatus = () => getModuleInfo(ModuleNameMap.GRAFANA)
 
     const handleFetchInitialData = async () => {
         try {


### PR DESCRIPTION
# Description
fix: update getGrafanaModuleStatus to handle errors and return null on failure

Fixes https://github.com/devtron-labs/sprint-tasks/issues/2485

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


