### PR TITLE
fix: kubeconfig modal loading state

### DIFF
--- a/src/components/ClusterNodes/ClusterList/ClusterListView.tsx
+++ b/src/components/ClusterNodes/ClusterList/ClusterListView.tsx
@@ -92,7 +92,8 @@ const ClusterListView = (props: ClusterViewType) => {
                 }
                 acc[cluster.name] = cluster
                 return acc
-            }, {} as ClusterDetail) ?? {},
+            }, {} as BulkSelectionIdentifiersType<ClusterDetail>) ??
+            ({} as BulkSelectionIdentifiersType<ClusterDetail>),
         [filteredList],
     )
 
@@ -149,7 +150,7 @@ const ClusterListView = (props: ClusterViewType) => {
                 )}
             </div>
 
-            <ClusterSelectionBody {...props} filteredList={filteredList} />
+            <ClusterSelectionBody {...props} filteredList={filteredList} identifierMap={allOnThisPageIdentifiers} />
         </BulkSelectionProvider>
     )
 }

--- a/src/components/ClusterNodes/ClusterList/ClusterSelectionBody.tsx
+++ b/src/components/ClusterNodes/ClusterList/ClusterSelectionBody.tsx
@@ -52,6 +52,8 @@ const ClusterSelectionBody: React.FC<ClusterSelectionBodyTypes> = ({
     filteredList,
     refreshData,
     parentRef,
+    isClusterDetailListLoading,
+    identifierMap,
 }) => {
     const [showKubeConfigModal, setShowKubeConfigModal] = useState(false)
     const [selectedClusterName, setSelectedClusterName] = useState('')
@@ -136,6 +138,8 @@ const ClusterSelectionBody: React.FC<ClusterSelectionBodyTypes> = ({
                         clusterName={selectedClusterName || identifierCount === 0}
                         handleModalClose={onChangeCloseKubeConfigModal}
                         isSingleClusterButton={!!selectedClusterName}
+                        isClusterDetailListLoading={isClusterDetailListLoading}
+                        identifierMap={identifierMap}
                     />
                 )}
             </div>

--- a/src/components/ClusterNodes/ClusterList/types.ts
+++ b/src/components/ClusterNodes/ClusterList/types.ts
@@ -16,7 +16,7 @@
 
 import { MutableRefObject } from 'react'
 
-import { ClusterDetail } from '@devtron-labs/devtron-fe-common-lib'
+import { BulkSelectionIdentifiersType, ClusterDetail } from '@devtron-labs/devtron-fe-common-lib'
 
 export interface ClusterViewType {
     clusterOptions: ClusterDetail[]
@@ -24,6 +24,7 @@ export interface ClusterViewType {
     initialLoading: boolean
     refreshData: () => void
     parentRef: MutableRefObject<HTMLDivElement>
+    isClusterDetailListLoading: boolean
 }
 
 export interface ClusterListTypes {
@@ -39,4 +40,5 @@ export interface ClusterListRowTypes extends Omit<ClusterListTypes, 'filteredLis
 
 export interface ClusterSelectionBodyTypes extends ClusterViewType {
     filteredList: ClusterDetail[]
+    identifierMap: BulkSelectionIdentifiersType<ClusterDetail>
 }

--- a/src/components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/components/ResourceBrowser/ResourceBrowser.tsx
@@ -39,7 +39,9 @@ const ResourceBrowser: React.FC = () => {
     const [detailClusterListLoading, detailClusterList, , reloadDetailClusterList] = useAsync(() =>
         getClusterListing(false, abortControllerRef),
     )
-    const [initialLoading, clusterListMinData, error] = useAsync(() => getClusterListing(true, abortControllerRef))
+    const [initialLoading, clusterListMinData, error, reloadMinClusterListing] = useAsync(() =>
+        getClusterListing(true, abortControllerRef),
+    )
 
     useEffect(
         () => () => {
@@ -53,7 +55,7 @@ const ResourceBrowser: React.FC = () => {
         [detailClusterList, clusterListMinData],
     )
 
-    const filteredSortedCluserList = useMemo(
+    const filteredSortedClusterList = useMemo(
         () =>
             sortedClusterList.filter(
                 (option) =>
@@ -65,16 +67,17 @@ const ResourceBrowser: React.FC = () => {
 
     const renderContent = () => {
         if (error) {
-            return <ErrorScreenManager code={error.code} />
+            return <ErrorScreenManager code={error.code} reload={reloadMinClusterListing} />
         }
 
         return (
             <ClusterListView
                 parentRef={parentRef}
-                clusterOptions={filteredSortedCluserList}
+                clusterOptions={filteredSortedClusterList}
                 clusterListLoader={detailClusterListLoading}
                 initialLoading={initialLoading}
                 refreshData={reloadDetailClusterList}
+                isClusterDetailListLoading={detailClusterListLoading}
             />
         )
     }


### PR DESCRIPTION
# Description

This pull request enhances the cluster selection workflow in the resource browser by introducing bulk selection identifier support and improving error handling. The changes ensure that cluster selection and bulk actions are more robust and that error screens provide a reload option for a better user experience.

### Bulk Selection and Cluster List Enhancements

* Updated the `ClusterListView` and `ClusterSelectionBody` components to support and pass a new `identifierMap` prop for bulk selection, utilizing the `BulkSelectionIdentifiersType` type. This enables more efficient handling of bulk cluster selection actions. [[1]](diffhunk://#diff-9802e0de00fe57ae3a6dce6a4ceecada8a5ebbf178637939376351603db04770L95-R96) [[2]](diffhunk://#diff-9802e0de00fe57ae3a6dce6a4ceecada8a5ebbf178637939376351603db04770L152-R153) [[3]](diffhunk://#diff-095fe21cb658a7e73dcd26413d82d01abde0f50cecbdf060778a08a0d02bbe46R55-R56) [[4]](diffhunk://#diff-095fe21cb658a7e73dcd26413d82d01abde0f50cecbdf060778a08a0d02bbe46R141-R142) [[5]](diffhunk://#diff-f994d6ef70584620238ceb38fe3e4d0f6c2d769b8a4c8e0d33ae7a1427003b60R43)
* Extended the cluster view and selection types in `types.ts` to include `BulkSelectionIdentifiersType` and the new `isClusterDetailListLoading` flag, improving type safety and supporting new features. [[1]](diffhunk://#diff-f994d6ef70584620238ceb38fe3e4d0f6c2d769b8a4c8e0d33ae7a1427003b60L19-R27) [[2]](diffhunk://#diff-f994d6ef70584620238ceb38fe3e4d0f6c2d769b8a4c8e0d33ae7a1427003b60R43)

### Error Handling and UI Improvements

* Improved error handling in the resource browser by adding a `reload` function to the `ErrorScreenManager` component, allowing users to retry loading cluster data directly from the error screen.
* Fixed a typo in the variable name from `filteredSortedCluserList` to `filteredSortedClusterList` for clarity and correctness.

### Data Loading and Propagation

* Updated the cluster list loading logic to propagate the `isClusterDetailListLoading` flag throughout the cluster list components, ensuring accurate loading state representation in the UI. [[1]](diffhunk://#diff-81e28b5c4c5a4c69e55592411ff7b60bf59669457e1ec05a1db26c241c1ec48fL42-R44) [[2]](diffhunk://#diff-81e28b5c4c5a4c69e55592411ff7b60bf59669457e1ec05a1db26c241c1ec48fL68-R80)

Fixes https://github.com/devtron-labs/sprint-tasks/issues/2591

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


