### PR TITLE
feat: add loading state to deletion dialogs and set global API timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "homepage": "/dashboard",
     "dependencies": {
-        "@devtron-labs/devtron-fe-common-lib": "1.20.1",
+        "@devtron-labs/devtron-fe-common-lib": "1.20.3",
         "@esbuild-plugins/node-globals-polyfill": "0.2.3",
         "@rjsf/core": "^5.13.3",
         "@rjsf/utils": "^5.13.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import {
     BreadcrumbStore,
     DevtronProgressing,
     ErrorScreenManager,
+    setGlobalAPITimeout,
     showError,
     URLS as CommonURLS,
     useUserEmail,
@@ -147,6 +148,8 @@ const App = () => {
             setValidating(false)
             defaultRedirection()
         }
+
+        setGlobalAPITimeout(window._env_.GLOBAL_API_TIMEOUT)
     }, [])
 
     const renderRoutesWithErrorBoundary = () =>

--- a/src/components/common/ClusterNotReachableDialog/ClusterNotReachableDialog.tsx
+++ b/src/components/common/ClusterNotReachableDialog/ClusterNotReachableDialog.tsx
@@ -19,7 +19,12 @@ import { ForceDeleteConfirmationModal } from '@devtron-labs/devtron-fe-common-li
 import { NON_CASCADE_DELETE_DIALOG_INTERNAL_MESSAGE } from '../../../config/constantMessaging'
 import { ClusterNotReachableDialogType } from './ClusterNotReachableDialog.type'
 
-const ClusterNotReachableDialog = ({ clusterName, onClickCancel, onClickDelete }: ClusterNotReachableDialogType) => {
+const ClusterNotReachableDialog = ({
+    clusterName,
+    onClickCancel,
+    onClickDelete,
+    isDeleting,
+}: ClusterNotReachableDialogType) => {
     if (!clusterName) {
         return null
     }
@@ -34,6 +39,7 @@ const ClusterNotReachableDialog = ({ clusterName, onClickCancel, onClickDelete }
                 </p>
             }
             onDelete={onClickDelete}
+            isDeleting={isDeleting}
             closeConfirmationModal={onClickCancel}
         />
     )

--- a/src/components/common/ClusterNotReachableDialog/ClusterNotReachableDialog.type.ts
+++ b/src/components/common/ClusterNotReachableDialog/ClusterNotReachableDialog.type.ts
@@ -18,4 +18,5 @@ export interface ClusterNotReachableDialogType {
     clusterName: string
     onClickCancel: () => void
     onClickDelete: () => void
+    isDeleting?: boolean
 }

--- a/src/components/externalArgoApps/ExternalArgoAppDetail.tsx
+++ b/src/components/externalArgoApps/ExternalArgoAppDetail.tsx
@@ -24,6 +24,7 @@ import {
     DeploymentAppTypes,
     getIsRequestAborted,
     abortPreviousRequests,
+    API_STATUS_CODES,
 } from '@devtron-labs/devtron-fe-common-lib'
 import { getArgoAppDetail } from '../external-apps/ExternalAppService'
 import { checkIfToRefetchData, deleteRefetchDataFromUrl } from '../util/URLUtil'
@@ -40,6 +41,8 @@ const ExternalArgoAppDetail = ({ appName, clusterId, isExternalApp, namespace }:
     const [isLoading, setIsLoading] = useState(true)
     const [isReloadResourceTreeInProgress, setIsReloadResourceTreeInProgress] = useState(false)
     const [errorResponseCode, setErrorResponseCode] = useState(undefined)
+
+    const handledFirstCall = useRef(false)
 
     let isAPICallInProgress = false
 
@@ -114,7 +117,11 @@ const ExternalArgoAppDetail = ({ appName, clusterId, isExternalApp, namespace }:
             .catch((errors: ServerErrors) => {
                 if (!getIsRequestAborted(errors)) {
                     showError(errors)
-                    setErrorResponseCode(errors.code)
+
+                    if (!handledFirstCall.current || errors.code === API_STATUS_CODES.NOT_FOUND) {
+                        setErrorResponseCode(errors.code)
+                    }
+
                     isAPICallInProgress = false
                     handleInitiatePolling()
                 }
@@ -123,6 +130,7 @@ const ExternalArgoAppDetail = ({ appName, clusterId, isExternalApp, namespace }:
                 setIsLoading(false)
                 isAPICallInProgress = false
                 setIsReloadResourceTreeInProgress(false)
+                handledFirstCall.current = true
             })
     }
 

--- a/src/components/v2/appDetails/ea/EAAppDetail.component.tsx
+++ b/src/components/v2/appDetails/ea/EAAppDetail.component.tsx
@@ -24,6 +24,7 @@ import {
     DeploymentAppTypes,
     getIsRequestAborted,
     abortPreviousRequests,
+    API_STATUS_CODES,
 } from '@devtron-labs/devtron-fe-common-lib'
 import moment from 'moment'
 import { sortOptionsByValue } from '../../../common'
@@ -54,6 +55,7 @@ const ExternalAppDetail = ({ appId, appName, isExternalApp }) => {
     const [isReloadResourceTreeInProgress, setIsReloadResourceTreeInProgress] = useState(false)
 
     const abortControllerRef = useRef<AbortController>(new AbortController())
+    const handledFirstCall = useRef(false)
 
     let isAPICallInProgress = false
 
@@ -189,12 +191,15 @@ const ExternalAppDetail = ({ appId, appName, isExternalApp }) => {
 
                 if (!getIsRequestAborted(errors)) {
                     showError(errors)
-                    setErrorResponseCode(errors.code)
+                    if (!handledFirstCall.current || errors.code === API_STATUS_CODES.NOT_FOUND) {
+                        setErrorResponseCode(errors.code)
+                    }
                     handleInitiatePolling()
                 }
             })
             .finally(() => {
                 setIsReloadResourceTreeInProgress(false)
+                handledFirstCall.current = true
             })
     }
 

--- a/src/components/v2/appDetails/sourceInfo/EnvironmentSelector.component.tsx
+++ b/src/components/v2/appDetails/sourceInfo/EnvironmentSelector.component.tsx
@@ -76,6 +76,8 @@ const EnvironmentSelectorComponent = ({
     const [forceDeleteDialogMessage, setForceDeleteDialogMessage] = useState<string>('')
     const [nonCascadeDeleteDialog, showNonCascadeDeleteDialog] = useState<boolean>(false)
     const [clusterName, setClusterName] = useState<string>('')
+    const [isDeleteLoading, setIsDeleteLoading] = useState<boolean>(false)
+
     const isGitops = appDetails?.deploymentAppType === DeploymentAppTypes.ARGO
     const isExternalArgo = appDetails.appType === AppType.EXTERNAL_ARGO_APP
     const isExternalFlux = appDetails.appType === AppType.EXTERNAL_FLUX_APP
@@ -150,6 +152,7 @@ const EnvironmentSelectorComponent = ({
 
     async function deleteResourceAction(deleteAction: DELETE_ACTION) {
         try {
+            setIsDeleteLoading(true)
             const response = await getDeleteApplicationApi(deleteAction)
             if (response.result.deleteResponse?.deleteInitiated || (isExternalApp && response.result?.success)) {
                 setShowDeleteConfirmation(false)
@@ -179,6 +182,8 @@ const EnvironmentSelectorComponent = ({
                 showForceDeleteDialog(true)
             }
             showError(error)
+        } finally {
+            setIsDeleteLoading(false)
         }
     }
 
@@ -376,6 +381,7 @@ const EnvironmentSelectorComponent = ({
                                     handleDelete={handleDelete}
                                     toggleConfirmation={setShowDeleteConfirmation}
                                     isCreateValueView={false}
+                                    disableButton={isDeleteLoading}
                                 />
                             )}
                         </div>
@@ -387,6 +393,7 @@ const EnvironmentSelectorComponent = ({
                             subtitle={forceDeleteDialogMessage}
                             onDelete={handleForceDelete}
                             closeConfirmationModal={closeForceConfirmationModal}
+                            isDeleting={isDeleteLoading}
                         />
                     )}
 
@@ -395,6 +402,7 @@ const EnvironmentSelectorComponent = ({
                             clusterName={clusterName}
                             onClickCancel={onClickHideNonCascadeDeletePopup}
                             onClickDelete={onClickNonCascadeDelete}
+                            isDeleting={isDeleteLoading}
                         />
                     )}
                 </div>

--- a/src/components/v2/index.tsx
+++ b/src/components/v2/index.tsx
@@ -19,6 +19,7 @@ import { Redirect, Route, Switch, useHistory, useLocation, useParams, useRouteMa
 
 import {
     abortPreviousRequests,
+    API_STATUS_CODES,
     DetailsProgressing,
     ErrorScreenManager,
     getIsRequestAborted,
@@ -64,6 +65,7 @@ const RouterComponent = () => {
     const [isReloadResourceTreeInProgress, setIsReloadResourceTreeInProgress] = useState(false)
     const appDetailsRef = useRef({} as AppDetails)
     const isVirtualRef = useRef(false)
+    const handledFirstCall = useRef(false)
 
     useEffect(() => {
         IndexStore.setEnvDetails(EnvType.CHART, +params.appId, +params.envId)
@@ -126,8 +128,11 @@ const RouterComponent = () => {
             return
         }
 
-        setErrorResponseCode(e.code)
-        if (e.code === 404 && initTimer) {
+        if (!handledFirstCall.current || e.code === API_STATUS_CODES.NOT_FOUND) {
+            setErrorResponseCode(e.code)
+        }
+
+        if (e.code === API_STATUS_CODES.NOT_FOUND && initTimer) {
             clearTimeout(initTimer)
         }
     }
@@ -204,6 +209,8 @@ const RouterComponent = () => {
             if (!isAborted) {
                 handleInitiatePolling()
             }
+        }).finally(() => {
+            handledFirstCall.current = true
         })
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1722,9 +1722,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@devtron-labs/devtron-fe-common-lib@npm:1.20.1":
-  version: 1.20.1
-  resolution: "@devtron-labs/devtron-fe-common-lib@npm:1.20.1"
+"@devtron-labs/devtron-fe-common-lib@npm:1.20.3":
+  version: 1.20.3
+  resolution: "@devtron-labs/devtron-fe-common-lib@npm:1.20.3"
   dependencies:
     "@codemirror/autocomplete": "npm:6.18.6"
     "@codemirror/lang-json": "npm:6.0.1"
@@ -1774,7 +1774,7 @@ __metadata:
     react-select: 5.8.0
     rxjs: ^7.8.1
     yaml: ^2.4.1
-  checksum: 10c0/7e44289b93231e98c446d963b2064985c8a1e73ef46376f510721f2b3064b3e0d5311e8fcf29f8250f62c10ff064e52e4cead58c0ca78ceac389a07bd0a3ae69
+  checksum: 10c0/1178d511e77f615ab2f41fc685917f74cec9b29b5bc9826de31dfa51c3cf4866a629f456220c31f99c0b297b09b9779104678e76143c84e02765247cf3c14c2b
   languageName: node
   linkType: hard
 
@@ -5721,7 +5721,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "dashboard@workspace:."
   dependencies:
-    "@devtron-labs/devtron-fe-common-lib": "npm:1.20.1"
+    "@devtron-labs/devtron-fe-common-lib": "npm:1.20.3"
     "@esbuild-plugins/node-globals-polyfill": "npm:0.2.3"
     "@playwright/test": "npm:^1.32.1"
     "@rjsf/core": "npm:^5.13.3"


### PR DESCRIPTION
# Description

This pull request introduces improvements to error handling, API timeout configuration, and user feedback during resource deletion actions across several components. The main changes focus on better tracking of API error codes, especially on first load and 404 errors, propagating loading states to dialogs and buttons during delete actions, and setting a global API timeout from environment variables.

### Error handling and API response management

* Added `handledFirstCall` tracking and improved error code handling for initial API calls and 404 errors in `ExternalArgoAppDetail`, `EAAppDetail.component`, and `index.tsx`, ensuring error codes are set correctly on first load and when resources are not found. [[1]](diffhunk://#diff-daa3f12867fe5f3ee17dd221e7e8b63b02b262dca1d5082c0c048190446b09b7R45-R46) [[2]](diffhunk://#diff-daa3f12867fe5f3ee17dd221e7e8b63b02b262dca1d5082c0c048190446b09b7R120-R124) [[3]](diffhunk://#diff-daa3f12867fe5f3ee17dd221e7e8b63b02b262dca1d5082c0c048190446b09b7R133) [[4]](diffhunk://#diff-75aa792d4bfcf61b875a5cd732b2d9b12f47bea3e9893b32c992f1bb5a2da833R58) [[5]](diffhunk://#diff-75aa792d4bfcf61b875a5cd732b2d9b12f47bea3e9893b32c992f1bb5a2da833R194-R202) [[6]](diffhunk://#diff-b091f0de78b939cb8971b4989948a3a71e2ea96635a83333f56fe12d6f2ea415R68) [[7]](diffhunk://#diff-b091f0de78b939cb8971b4989948a3a71e2ea96635a83333f56fe12d6f2ea415R131-R135) [[8]](diffhunk://#diff-b091f0de78b939cb8971b4989948a3a71e2ea96635a83333f56fe12d6f2ea415R212-R213)
* Imported `API_STATUS_CODES` where needed to standardize error code comparisons. [[1]](diffhunk://#diff-daa3f12867fe5f3ee17dd221e7e8b63b02b262dca1d5082c0c048190446b09b7R27) [[2]](diffhunk://#diff-75aa792d4bfcf61b875a5cd732b2d9b12f47bea3e9893b32c992f1bb5a2da833R27) [[3]](diffhunk://#diff-b091f0de78b939cb8971b4989948a3a71e2ea96635a83333f56fe12d6f2ea415R22)

### Global API timeout configuration

* Added `setGlobalAPITimeout` import and invocation in `App.tsx` to set the API timeout globally using the environment variable `GLOBAL_API_TIMEOUT` during app initialization. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R26) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R151-R152)

### Resource deletion loading state and UI feedback

* Added `isDeleteLoading` state in `EnvironmentSelector.component.tsx` to manage loading state during resource deletion actions, with state changes before and after the API call. [[1]](diffhunk://#diff-01ff795c91d4e8401aa3d3074c78a70d73ee7f3f025dc0430d04258c1b456279R79-R80) [[2]](diffhunk://#diff-01ff795c91d4e8401aa3d3074c78a70d73ee7f3f025dc0430d04258c1b456279R155) [[3]](diffhunk://#diff-01ff795c91d4e8401aa3d3074c78a70d73ee7f3f025dc0430d04258c1b456279R185-R186)
* Passed `isDeleting` and `disableButton` props to deletion dialogs and buttons (`ForceDeleteConfirmationModal`, `ClusterNotReachableDialog`, and related components), ensuring users see appropriate feedback during ongoing delete operations. [[1]](diffhunk://#diff-14440d66103b133959f54debecbedb29b11abe38c026bd112f2791f09477f0d3L22-R27) [[2]](diffhunk://#diff-14440d66103b133959f54debecbedb29b11abe38c026bd112f2791f09477f0d3R42) [[3]](diffhunk://#diff-94cdbe33abc8b7d181283d642b7a2e57658a2f35617bae6055496c3fa5827fbbR21) [[4]](diffhunk://#diff-01ff795c91d4e8401aa3d3074c78a70d73ee7f3f025dc0430d04258c1b456279R384) [[5]](diffhunk://#diff-01ff795c91d4e8401aa3d3074c78a70d73ee7f3f025dc0430d04258c1b456279R396) [[6]](diffhunk://#diff-01ff795c91d4e8401aa3d3074c78a70d73ee7f3f025dc0430d04258c1b456279R405)

### Dialog and type updates

* Updated `ClusterNotReachableDialogType` and `ClusterNotReachableDialog` to include the optional `isDeleting` prop, allowing the dialog to reflect the loading state during deletion. [[1]](diffhunk://#diff-94cdbe33abc8b7d181283d642b7a2e57658a2f35617bae6055496c3fa5827fbbR21) [[2]](diffhunk://#diff-14440d66103b133959f54debecbedb29b11abe38c026bd112f2791f09477f0d3L22-R27) [[3]](diffhunk://#diff-14440d66103b133959f54debecbedb29b11abe38c026bd112f2791f09477f0d3R42)

Fixes https://github.com/devtron-labs/sprint-tasks/issues/2597

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas


