### PR TITLE
feat: add custom key event handler for Enter key in LogViewer

### DIFF
--- a/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/LogViewer.component.tsx
+++ b/src/components/v2/appDetails/k8Resource/nodeDetail/NodeDetailTabs/LogViewer.component.tsx
@@ -73,6 +73,14 @@ const LogViewerComponent: React.FunctionComponent<logViewerInterface> = ({ subje
 
         handleSelectionChange(terminal.current, setPopupText)
 
+        terminal.current.attachCustomKeyEventHandler((event: KeyboardEvent) => {
+            if (event.type === 'keydown' && event.key === 'Enter') {
+                terminal.current.writeln('')
+                return false
+            }
+            return true
+        })
+
         fitAddon.current = new FitAddon()
         terminal.current.loadAddon(fitAddon.current)
 


### PR DESCRIPTION
# Description
This pull request introduces a small but important enhancement to the `LogViewerComponent`, enabling enter in read-only logs in app details would help users to demarcate a suspicious block of logs.

**Terminal input handling improvements:**

* Added a custom key event handler to the terminal instance in `LogViewerComponent` that writes a new line when the Enter key is pressed, ensuring better handling of Enter key events in the log viewer.

Fixes https://github.com/devtron-labs/sprint-tasks/issues/2888

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


